### PR TITLE
Append return pid from executeNoWait

### DIFF
--- a/sdk/os/Process.ooc
+++ b/sdk/os/Process.ooc
@@ -101,7 +101,7 @@ Process: abstract class {
      * You have to call `wait` manually
      * @return child pid process.
      */
-    executeNoWait: abstract func -> Int
+    executeNoWait: abstract func -> Long
 
     /**
      * Execute the process, and return all the output to stdout

--- a/sdk/os/native/ProcessUnix.ooc
+++ b/sdk/os/native/ProcessUnix.ooc
@@ -45,7 +45,7 @@ ProcessUnix: class extends Process {
        Execute the process without waiting for it to end.
        You have to call `wait` manually.
     */
-    executeNoWait: func ->Int {
+    executeNoWait: func -> Long {
 
         pid := fork()
         if (pid == 0) {

--- a/sdk/os/native/ProcessWin32.ooc
+++ b/sdk/os/native/ProcessWin32.ooc
@@ -52,7 +52,7 @@ ProcessWin32: class extends Process {
        Execute the process without waiting for it to end.
        You have to call `wait` manually.
     */
-    executeNoWait: func {
+    executeNoWait: func -> Long {
         if (stdIn != null || stdOut != null || stdErr != null) {
             if(stdIn) {
                 si stdInput  = stdIn as PipeWin32 readFD
@@ -84,8 +84,10 @@ ProcessWin32: class extends Process {
             pi&          // Pointer to PROCESS_INFORMATION structure
         )) {
             Exception new(This, "CreateProcess failed (error %d).\n" format(GetLastError())) throw()
-            return
+            return -1
         }
+
+        return pi pid
     }
 
 }
@@ -141,6 +143,7 @@ StartFlags: cover {
 ProcessInformation: cover from PROCESS_INFORMATION {
     process: extern(hProcess) Handle
     thread:  extern(hThread)  Handle
+    pid: extern(dwProcessId)  Long
 }
 INFINITE: extern Long
 WAIT_OBJECT_0: extern Long


### PR DESCRIPTION
I'm developping Benchmark system with OOC. While i'm running a subprocess, I need to know child pid I'm running.

fork() return 0 on child... execvp replace process so no return is made
in parent, fork() has return child pid, so I can return this pid

pid is Int on Unix, Long for windows, so executeNoWait returns Long by default

PS: Thanks for your help
