### PR TITLE
Fixed main entrypoint ArrayList to use CString* instead of String*

### DIFF
--- a/sdk/text/Shlex.ooc
+++ b/sdk/text/Shlex.ooc
@@ -1,4 +1,4 @@
-import text/[EscapeSequence, Buffer]
+import text/[EscapeSequence]
 import structs/ArrayList
 
 WAIT := 0


### PR DESCRIPTION
There was code to handle the conversion from CString to String anyway, but the implicit typecasting was causing gcc warnings, and clang erorrs.
