### PR TITLE
Fixed `make rescue`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ backup:
 rescue:
 	git pull
 	rm -rf build/
-	wget http://commondatastorage.googleapis.com/rock-linux/rock-bootstrap-only.tar.bz2 -O - | tar xjvmp
+	#wget http://commondatastorage.googleapis.com/rock-linux/rock-bootstrap-only.tar.bz2 -O - | tar xjvmp
+	wget http://www.fileville.net/ooc/bootstrap.tar.bz2 -O - | tar xjvmp
 	$(MAKE) clean bootstrap
 
 # Compile rock with the backup'd version of itself


### PR DESCRIPTION
Since I set up the site previously, I decided to get `make rescue` working, using fileville.net/ooc/bootstrap.tar.bz2 :)
