### PR TITLE
Fix the lack of strtold on cygwin

### DIFF
--- a/sdk/lang/Character.ooc
+++ b/sdk/lang/Character.ooc
@@ -14,7 +14,15 @@ strtoll: extern func (Char*, Pointer, Int) -> LLong
 strtoul: extern func (Char*, Pointer, Int) -> ULong
 strtof:  extern func (Char*, Pointer)      -> Float
 strtod:  extern func (Char*, Pointer)      -> Double
-strtold: extern func (Char*, Pointer)      -> LDouble
+// Cygwin doesn't handle long doubles (and doesn't have strtold defined)
+version(!__CYGWIN__) {
+    strtold: extern func (Char*, Pointer)      -> LDouble
+}
+version(__CYGWIN__) {
+    strtold: func (str: Char*, p: Pointer) -> LDouble {
+        strtod(str, p) as LDouble
+    }
+}
 
 /**
  * Character type


### PR DESCRIPTION
I added a version block for `__CYGWIN__` which makes `strtold(a,b)` do `strtod(a,b) as LDouble`. Should fix #357.
