### PR TITLE
Added namespace types, regenerated latest nagaqueen

### DIFF
--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -567,6 +567,10 @@ AstBuilder: class {
         list types add(element)
     }
 
+    onTypeNamespace: unmangled(nq_onTypeNamespace) func (type: Type, ident: CString) -> Type {
+        NamespaceType new(type, VariableAccess new(ident toString(), token()), token())
+    }
+
     /*
      * Function types
      */

--- a/source/rock/frontend/NagaQueen.c
+++ b/source/rock/frontend/NagaQueen.c
@@ -204,6 +204,7 @@ void nq_onTypeGenericArgument(void *this, void *type, void *genType);
 void nq_onFuncTypeGenericArgument(void *this, void *type, char *name);
 void *nq_onTypeList(void *this);
 void *nq_onTypeListElement(void *this, void *list, void *elem);
+void *nq_onTypeNamespace(void *this, void *type, void *ident);
 
 void *nq_onFuncTypeNew(void *this);
 void nq_onFuncTypeArgument(void *this, void *funcType, void *argType);
@@ -723,10 +724,10 @@ YY_RULE(int) yy_Conditional(GREG *G); /* 98 */
 YY_RULE(int) yy_CommentLine(GREG *G); /* 97 */
 YY_RULE(int) yy_EoledStatement(GREG *G); /* 96 */
 YY_RULE(int) yy_StmtCore(GREG *G); /* 95 */
-YY_RULE(int) yy_Old(GREG *G); /* 94 */
-YY_RULE(int) yy_FuncTypeCore(GREG *G); /* 93 */
-YY_RULE(int) yy_TypeListCore(GREG *G); /* 92 */
-YY_RULE(int) yy_TypeList(GREG *G); /* 91 */
+YY_RULE(int) yy_FuncTypeCore(GREG *G); /* 94 */
+YY_RULE(int) yy_TypeListCore(GREG *G); /* 93 */
+YY_RULE(int) yy_TypeList(GREG *G); /* 92 */
+YY_RULE(int) yy_Old(GREG *G); /* 91 */
 YY_RULE(int) yy_GenericType(GREG *G); /* 90 */
 YY_RULE(int) yy_FuncType(GREG *G); /* 89 */
 YY_RULE(int) yy_TypeBase(GREG *G); /* 88 */
@@ -2924,14 +2925,171 @@ YY_ACTION(void) yy_1_TypeListCore(GREG *G, char *yytext, int yyleng, yythunk *th
   yyprintf((stderr, "do yy_1_TypeListCore\n"));
    yy=nq_onTypeList(core->this); ;
 }
+YY_ACTION(void) yy_17_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_17_Type\n"));
+   yy=t; ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_16_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_16_Type\n"));
+   t=yy=nq_onTypeBrackets(core->this, t, inner); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_15_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_15_Type\n"));
+   inner=NULL; ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_14_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_14_Type\n"));
+   t=yy=nq_onTypeReference(core->this, t); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_13_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_13_Type\n"));
+   t=yy=nq_onTypePointer  (core->this, t); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_12_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_12_Type\n"));
+   nq_onTypeGenericArgument(core->this, t, genType); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_11_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_11_Type\n"));
+   nq_onTypeGenericArgument(core->this, t, genType); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_10_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_10_Type\n"));
+   t=yy=nq_onTypeNamespace(core->this, t, temp); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
+YY_ACTION(void) yy_9_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
+  yyprintf((stderr, "do yy_9_Type\n"));
+   temp=nq_StringClone(i); ;
+#undef i
+#undef temp
+#undef inner
+#undef genType
+#undef t
+#undef list
+}
 YY_ACTION(void) yy_8_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_8_Type\n"));
    yy=t; ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -2939,12 +3097,16 @@ YY_ACTION(void) yy_8_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_7_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_7_Type\n"));
    t=yy=nq_onTypeBrackets(core->this, t, inner); ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -2952,12 +3114,16 @@ YY_ACTION(void) yy_7_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_6_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_6_Type\n"));
    inner=NULL; ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -2965,12 +3131,16 @@ YY_ACTION(void) yy_6_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_5_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_5_Type\n"));
    t=yy=nq_onTypeReference(core->this, t); ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -2978,12 +3148,16 @@ YY_ACTION(void) yy_5_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_4_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_4_Type\n"));
    t=yy=nq_onTypePointer  (core->this, t); ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -2991,12 +3165,16 @@ YY_ACTION(void) yy_4_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_3_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_3_Type\n"));
    nq_onTypeGenericArgument(core->this, t, genType); ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -3004,12 +3182,16 @@ YY_ACTION(void) yy_3_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_2_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_2_Type\n"));
    nq_onTypeGenericArgument(core->this, t, genType); ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
@@ -3017,93 +3199,260 @@ YY_ACTION(void) yy_2_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_
 }
 YY_ACTION(void) yy_1_Type(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
-#define inner G->val[-1]
-#define genType G->val[-2]
-#define t G->val[-3]
-#define list G->val[-4]
+#define i G->val[-1]
+#define temp G->val[-2]
+#define inner G->val[-3]
+#define genType G->val[-4]
+#define t G->val[-5]
+#define list G->val[-6]
   yyprintf((stderr, "do yy_1_Type\n"));
    yy=list; ;
+#undef i
+#undef temp
 #undef inner
 #undef genType
 #undef t
 #undef list
+}
+YY_ACTION(void) yy_16_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_16_GenericType\n"));
+   yy=t; ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_15_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_15_GenericType\n"));
+   t=yy=nq_onTypeBrackets(core->this, t, inner); ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_14_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_14_GenericType\n"));
+   inner=NULL; ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_13_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_13_GenericType\n"));
+   t=yy=nq_onTypeReference(core->this, t); ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_12_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_12_GenericType\n"));
+   t=yy=nq_onTypePointer  (core->this, t); ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_11_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_11_GenericType\n"));
+   nq_onTypeGenericArgument(core->this, t, t2); ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_10_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_10_GenericType\n"));
+   nq_onTypeGenericArgument(core->this, t, t2); ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_9_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_9_GenericType\n"));
+   yy=t; ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
+}
+YY_ACTION(void) yy_8_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define inner G->val[-1]
+#define t2 G->val[-2]
+#define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
+  yyprintf((stderr, "do yy_8_GenericType\n"));
+   t=yy=nq_onTypeBrackets(core->this, t, inner); ;
+#undef inner
+#undef t2
+#undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_7_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_7_GenericType\n"));
-   yy=t; ;
+   inner=NULL; ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_6_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_6_GenericType\n"));
-   t=yy=nq_onTypeBrackets(core->this, t, inner); ;
+   t=yy=nq_onTypeReference(core->this, t); ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_5_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_5_GenericType\n"));
-   inner=NULL; ;
+   t=yy=nq_onTypePointer  (core->this, t); ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_4_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_4_GenericType\n"));
-   t=yy=nq_onTypeReference(core->this, t); ;
+   nq_onTypeGenericArgument(core->this, t, t2); ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_3_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_3_GenericType\n"));
-   t=yy=nq_onTypePointer  (core->this, t); ;
+   nq_onTypeGenericArgument(core->this, t, t2); ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_2_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_2_GenericType\n"));
-   nq_onTypeGenericArgument(core->this, t, t2); ;
+   t=yy=nq_onTypeNamespace(core->this, t, temp); ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_1_GenericType(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define inner G->val[-1]
 #define t2 G->val[-2]
 #define t G->val[-3]
+#define i G->val[-4]
+#define temp G->val[-5]
   yyprintf((stderr, "do yy_1_GenericType\n"));
-   nq_onTypeGenericArgument(core->this, t, t2); ;
+   temp=nq_StringClone(i); ;
 #undef inner
 #undef t2
 #undef t
+#undef i
+#undef temp
 }
 YY_ACTION(void) yy_8_TypeBase(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
@@ -6558,23 +6907,14 @@ YY_RULE(int) yy_StmtCore(GREG *G)
   yyprintf((stderr, "  fail %s @ %s\n", "StmtCore", G->buf+G->pos));
   return 0;
 }
-YY_RULE(int) yy_Old(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "Old"));  yyDo(G, yy_1_Old, G->begin, G->end);
-  yyprintf((stderr, "  ok   %s @ %s\n", "Old", G->buf+G->pos));
-  return 1;
-  l412:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
-  yyprintf((stderr, "  fail %s @ %s\n", "Old", G->buf+G->pos));
-  return 0;
-}
 YY_RULE(int) yy_FuncTypeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "FuncTypeCore"));  if (!yymatchString(G, "Func")) goto l413;
-  {  int yypos414= G->pos, yythunkpos414= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l413;  G->pos= yypos414; G->thunkpos= yythunkpos414;
+  yyprintf((stderr, "%s\n", "FuncTypeCore"));  if (!yymatchString(G, "Func")) goto l412;
+  {  int yypos413= G->pos, yythunkpos413= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l412;  G->pos= yypos413; G->thunkpos= yythunkpos413;
   }  yyDo(G, yy_1_FuncTypeCore, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "FuncTypeCore", G->buf+G->pos));
   return 1;
-  l413:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l412:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FuncTypeCore", G->buf+G->pos));
   return 0;
 }
@@ -6583,44 +6923,74 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
   yyprintf((stderr, "%s\n", "TypeListCore"));  yyDo(G, yy_1_TypeListCore, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "TypeListCore", G->buf+G->pos));
   return 1;
-  l415:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l414:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "TypeListCore", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_TypeList(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "TypeList"));  if (!yymatchChar(G, '(')) goto l416;  if (!yy_WS(G)) { goto l416; }  if (!yy_TypeListCore(G)) { goto l416; }  yyDo(G, yySet, -2, 0);  if (!yy_Type(G)) { goto l416; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_TypeList, G->begin, G->end);
-  l417:;	
-  {  int yypos418= G->pos, yythunkpos418= G->thunkpos;  if (!yy_WS(G)) { goto l418; }  if (!yymatchChar(G, ',')) goto l418;  if (!yy_WS(G)) { goto l418; }  if (!yy_Type(G)) { goto l418; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_TypeList, G->begin, G->end);  goto l417;
-  l418:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;
-  }  if (!yymatchChar(G, ')')) goto l416;  if (!yy__(G)) { goto l416; }  yyDo(G, yy_3_TypeList, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "TypeList"));  if (!yymatchChar(G, '(')) goto l415;  if (!yy_WS(G)) { goto l415; }  if (!yy_TypeListCore(G)) { goto l415; }  yyDo(G, yySet, -2, 0);  if (!yy_Type(G)) { goto l415; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_TypeList, G->begin, G->end);
+  l416:;	
+  {  int yypos417= G->pos, yythunkpos417= G->thunkpos;  if (!yy_WS(G)) { goto l417; }  if (!yymatchChar(G, ',')) goto l417;  if (!yy_WS(G)) { goto l417; }  if (!yy_Type(G)) { goto l417; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_TypeList, G->begin, G->end);  goto l416;
+  l417:;	  G->pos= yypos417; G->thunkpos= yythunkpos417;
+  }  if (!yymatchChar(G, ')')) goto l415;  if (!yy__(G)) { goto l415; }  yyDo(G, yy_3_TypeList, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "TypeList", G->buf+G->pos));  yyDo(G, yyPop, 2, 0);
   return 1;
-  l416:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l415:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "TypeList", G->buf+G->pos));
   return 0;
 }
+YY_RULE(int) yy_Old(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;
+  yyprintf((stderr, "%s\n", "Old"));  yyDo(G, yy_1_Old, G->begin, G->end);
+  yyprintf((stderr, "  ok   %s @ %s\n", "Old", G->buf+G->pos));
+  return 1;
+  l418:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "Old", G->buf+G->pos));
+  return 0;
+}
 YY_RULE(int) yy_GenericType(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "GenericType"));  if (!yy_TypeBase(G)) { goto l419; }  yyDo(G, yySet, -3, 0);  if (!yy__(G)) { goto l419; }  if (!yymatchChar(G, '<')) goto l419;  if (!yy__(G)) { goto l419; }  if (!yy_Type(G)) { goto l419; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_1_GenericType, G->begin, G->end);
-  l420:;	
-  {  int yypos421= G->pos, yythunkpos421= G->thunkpos;  if (!yy__(G)) { goto l421; }  if (!yymatchChar(G, ',')) goto l421;  if (!yy__(G)) { goto l421; }  if (!yy_Type(G)) { goto l421; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_GenericType, G->begin, G->end);  goto l420;
-  l421:;	  G->pos= yypos421; G->thunkpos= yythunkpos421;
-  }  if (!yy__(G)) { goto l419; }  if (!yymatchChar(G, '>')) goto l419;  if (!yy__(G)) { goto l419; }
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0);
+  yyprintf((stderr, "%s\n", "GenericType"));
+  {  int yypos420= G->pos, yythunkpos420= G->thunkpos;  if (!yy_Old(G)) { goto l421; }  yyDo(G, yySet, -5, 0);  if (!yy__(G)) { goto l421; }  if (!yy_IDENT(G)) { goto l421; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_1_GenericType, G->begin, G->end);  if (!yy__(G)) { goto l421; }  if (!yy_TypeBase(G)) { goto l421; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_2_GenericType, G->begin, G->end);  if (!yy__(G)) { goto l421; }  if (!yymatchChar(G, '<')) goto l421;  if (!yy__(G)) { goto l421; }  if (!yy_Type(G)) { goto l421; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_GenericType, G->begin, G->end);
   l422:;	
-  {  int yypos423= G->pos, yythunkpos423= G->thunkpos;
-  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;  if (!yymatchChar(G, '*')) goto l425;  yyDo(G, yy_3_GenericType, G->begin, G->end);  goto l424;
-  l425:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;  if (!yymatchChar(G, '@')) goto l426;  yyDo(G, yy_4_GenericType, G->begin, G->end);  goto l424;
-  l426:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;  if (!yymatchChar(G, '[')) goto l423;  if (!yy_WS(G)) { goto l423; }  yyDo(G, yy_5_GenericType, G->begin, G->end);  if (!yy__(G)) { goto l423; }
-  {  int yypos427= G->pos, yythunkpos427= G->thunkpos;  if (!yy_Expr(G)) { goto l427; }  yyDo(G, yySet, -1, 0);  goto l428;
-  l427:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;
-  }
-  l428:;	  if (!yymatchChar(G, ']')) goto l423;  yyDo(G, yy_6_GenericType, G->begin, G->end);
-  }
-  l424:;	  goto l422;
+  {  int yypos423= G->pos, yythunkpos423= G->thunkpos;  if (!yy__(G)) { goto l423; }  if (!yymatchChar(G, ',')) goto l423;  if (!yy__(G)) { goto l423; }  if (!yy_Type(G)) { goto l423; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_GenericType, G->begin, G->end);  goto l422;
   l423:;	  G->pos= yypos423; G->thunkpos= yythunkpos423;
-  }  if (!yy__(G)) { goto l419; }  yyDo(G, yy_7_GenericType, G->begin, G->end);
-  yyprintf((stderr, "  ok   %s @ %s\n", "GenericType", G->buf+G->pos));  yyDo(G, yyPop, 3, 0);
+  }  if (!yy__(G)) { goto l421; }  if (!yymatchChar(G, '>')) goto l421;  if (!yy__(G)) { goto l421; }
+  l424:;	
+  {  int yypos425= G->pos, yythunkpos425= G->thunkpos;
+  {  int yypos426= G->pos, yythunkpos426= G->thunkpos;  if (!yymatchChar(G, '*')) goto l427;  yyDo(G, yy_5_GenericType, G->begin, G->end);  goto l426;
+  l427:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yymatchChar(G, '@')) goto l428;  yyDo(G, yy_6_GenericType, G->begin, G->end);  goto l426;
+  l428:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yymatchChar(G, '[')) goto l425;  if (!yy_WS(G)) { goto l425; }  yyDo(G, yy_7_GenericType, G->begin, G->end);  if (!yy__(G)) { goto l425; }
+  {  int yypos429= G->pos, yythunkpos429= G->thunkpos;  if (!yy_Expr(G)) { goto l429; }  yyDo(G, yySet, -1, 0);  goto l430;
+  l429:;	  G->pos= yypos429; G->thunkpos= yythunkpos429;
+  }
+  l430:;	  if (!yymatchChar(G, ']')) goto l425;  yyDo(G, yy_8_GenericType, G->begin, G->end);
+  }
+  l426:;	  goto l424;
+  l425:;	  G->pos= yypos425; G->thunkpos= yythunkpos425;
+  }  if (!yy__(G)) { goto l421; }  yyDo(G, yy_9_GenericType, G->begin, G->end);  goto l420;
+  l421:;	  G->pos= yypos420; G->thunkpos= yythunkpos420;  if (!yy_TypeBase(G)) { goto l419; }  yyDo(G, yySet, -3, 0);  if (!yy__(G)) { goto l419; }  if (!yymatchChar(G, '<')) goto l419;  if (!yy__(G)) { goto l419; }  if (!yy_Type(G)) { goto l419; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_10_GenericType, G->begin, G->end);
+  l431:;	
+  {  int yypos432= G->pos, yythunkpos432= G->thunkpos;  if (!yy__(G)) { goto l432; }  if (!yymatchChar(G, ',')) goto l432;  if (!yy__(G)) { goto l432; }  if (!yy_Type(G)) { goto l432; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_11_GenericType, G->begin, G->end);  goto l431;
+  l432:;	  G->pos= yypos432; G->thunkpos= yythunkpos432;
+  }  if (!yy__(G)) { goto l419; }  if (!yymatchChar(G, '>')) goto l419;  if (!yy__(G)) { goto l419; }
+  l433:;	
+  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;
+  {  int yypos435= G->pos, yythunkpos435= G->thunkpos;  if (!yymatchChar(G, '*')) goto l436;  yyDo(G, yy_12_GenericType, G->begin, G->end);  goto l435;
+  l436:;	  G->pos= yypos435; G->thunkpos= yythunkpos435;  if (!yymatchChar(G, '@')) goto l437;  yyDo(G, yy_13_GenericType, G->begin, G->end);  goto l435;
+  l437:;	  G->pos= yypos435; G->thunkpos= yythunkpos435;  if (!yymatchChar(G, '[')) goto l434;  if (!yy_WS(G)) { goto l434; }  yyDo(G, yy_14_GenericType, G->begin, G->end);  if (!yy__(G)) { goto l434; }
+  {  int yypos438= G->pos, yythunkpos438= G->thunkpos;  if (!yy_Expr(G)) { goto l438; }  yyDo(G, yySet, -1, 0);  goto l439;
+  l438:;	  G->pos= yypos438; G->thunkpos= yythunkpos438;
+  }
+  l439:;	  if (!yymatchChar(G, ']')) goto l434;  yyDo(G, yy_15_GenericType, G->begin, G->end);
+  }
+  l435:;	  goto l433;
+  l434:;	  G->pos= yypos434; G->thunkpos= yythunkpos434;
+  }  if (!yy__(G)) { goto l419; }  yyDo(G, yy_16_GenericType, G->begin, G->end);
+  }
+  l420:;	
+  yyprintf((stderr, "  ok   %s @ %s\n", "GenericType", G->buf+G->pos));  yyDo(G, yyPop, 5, 0);
   return 1;
   l419:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GenericType", G->buf+G->pos));
@@ -6628,1485 +6998,1507 @@ YY_RULE(int) yy_GenericType(GREG *G)
 }
 YY_RULE(int) yy_FuncType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "FuncType"));  if (!yy_FuncTypeCore(G)) { goto l429; }  yyDo(G, yySet, -4, 0);
-  {  int yypos430= G->pos, yythunkpos430= G->thunkpos;  if (!yy__(G)) { goto l430; }  if (!yymatchChar(G, '<')) goto l430;  if (!yy__(G)) { goto l430; }  if (!yy_IDENT(G)) { goto l430; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_FuncType, G->begin, G->end);
-  l432:;	
-  {  int yypos433= G->pos, yythunkpos433= G->thunkpos;  if (!yy__(G)) { goto l433; }  if (!yymatchChar(G, ',')) goto l433;  if (!yy__(G)) { goto l433; }  if (!yy_IDENT(G)) { goto l433; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_2_FuncType, G->begin, G->end);  goto l432;
-  l433:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;
-  }  if (!yy__(G)) { goto l430; }  if (!yymatchChar(G, '>')) goto l430;  goto l431;
-  l430:;	  G->pos= yypos430; G->thunkpos= yythunkpos430;
+  yyprintf((stderr, "%s\n", "FuncType"));  if (!yy_FuncTypeCore(G)) { goto l440; }  yyDo(G, yySet, -4, 0);
+  {  int yypos441= G->pos, yythunkpos441= G->thunkpos;  if (!yy__(G)) { goto l441; }  if (!yymatchChar(G, '<')) goto l441;  if (!yy__(G)) { goto l441; }  if (!yy_IDENT(G)) { goto l441; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_FuncType, G->begin, G->end);
+  l443:;	
+  {  int yypos444= G->pos, yythunkpos444= G->thunkpos;  if (!yy__(G)) { goto l444; }  if (!yymatchChar(G, ',')) goto l444;  if (!yy__(G)) { goto l444; }  if (!yy_IDENT(G)) { goto l444; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_2_FuncType, G->begin, G->end);  goto l443;
+  l444:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;
+  }  if (!yy__(G)) { goto l441; }  if (!yymatchChar(G, '>')) goto l441;  goto l442;
+  l441:;	  G->pos= yypos441; G->thunkpos= yythunkpos441;
   }
-  l431:;	
-  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;  if (!yy__(G)) { goto l434; }  if (!yymatchChar(G, '(')) goto l434;
-  {  int yypos436= G->pos, yythunkpos436= G->thunkpos;  if (!yy__(G)) { goto l436; }  if (!yy_Type(G)) { goto l436; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_FuncType, G->begin, G->end);
-  l438:;	
-  {  int yypos439= G->pos, yythunkpos439= G->thunkpos;  if (!yymatchChar(G, ',')) goto l439;  if (!yy__(G)) { goto l439; }  if (!yy_Type(G)) { goto l439; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_FuncType, G->begin, G->end);  goto l438;
-  l439:;	  G->pos= yypos439; G->thunkpos= yythunkpos439;
-  }  goto l437;
-  l436:;	  G->pos= yypos436; G->thunkpos= yythunkpos436;
+  l442:;	
+  {  int yypos445= G->pos, yythunkpos445= G->thunkpos;  if (!yy__(G)) { goto l445; }  if (!yymatchChar(G, '(')) goto l445;
+  {  int yypos447= G->pos, yythunkpos447= G->thunkpos;  if (!yy__(G)) { goto l447; }  if (!yy_Type(G)) { goto l447; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_FuncType, G->begin, G->end);
+  l449:;	
+  {  int yypos450= G->pos, yythunkpos450= G->thunkpos;  if (!yymatchChar(G, ',')) goto l450;  if (!yy__(G)) { goto l450; }  if (!yy_Type(G)) { goto l450; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_FuncType, G->begin, G->end);  goto l449;
+  l450:;	  G->pos= yypos450; G->thunkpos= yythunkpos450;
+  }  goto l448;
+  l447:;	  G->pos= yypos447; G->thunkpos= yythunkpos447;
   }
-  l437:;	
-  {  int yypos440= G->pos, yythunkpos440= G->thunkpos;  if (!yymatchString(G, "...")) goto l440;  if (!yy__(G)) { goto l440; }  yyDo(G, yy_5_FuncType, G->begin, G->end);  goto l441;
-  l440:;	  G->pos= yypos440; G->thunkpos= yythunkpos440;
+  l448:;	
+  {  int yypos451= G->pos, yythunkpos451= G->thunkpos;  if (!yymatchString(G, "...")) goto l451;  if (!yy__(G)) { goto l451; }  yyDo(G, yy_5_FuncType, G->begin, G->end);  goto l452;
+  l451:;	  G->pos= yypos451; G->thunkpos= yythunkpos451;
   }
-  l441:;	  if (!yy__(G)) { goto l434; }  if (!yymatchChar(G, ')')) goto l434;  goto l435;
-  l434:;	  G->pos= yypos434; G->thunkpos= yythunkpos434;
+  l452:;	  if (!yy__(G)) { goto l445; }  if (!yymatchChar(G, ')')) goto l445;  goto l446;
+  l445:;	  G->pos= yypos445; G->thunkpos= yythunkpos445;
   }
-  l435:;	
-  {  int yypos442= G->pos, yythunkpos442= G->thunkpos;  if (!yy__(G)) { goto l442; }  if (!yymatchString(G, "->")) goto l442;  if (!yy__(G)) { goto l442; }  if (!yy_Type(G)) { goto l442; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_6_FuncType, G->begin, G->end);  goto l443;
-  l442:;	  G->pos= yypos442; G->thunkpos= yythunkpos442;
+  l446:;	
+  {  int yypos453= G->pos, yythunkpos453= G->thunkpos;  if (!yy__(G)) { goto l453; }  if (!yymatchString(G, "->")) goto l453;  if (!yy__(G)) { goto l453; }  if (!yy_Type(G)) { goto l453; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_6_FuncType, G->begin, G->end);  goto l454;
+  l453:;	  G->pos= yypos453; G->thunkpos= yythunkpos453;
   }
-  l443:;	  yyDo(G, yy_7_FuncType, G->begin, G->end);
+  l454:;	  yyDo(G, yy_7_FuncType, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "FuncType", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l429:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l440:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FuncType", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_TypeBase(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "TypeBase"));
-  {  int yypos445= G->pos, yythunkpos445= G->thunkpos;  if (!yy_FuncType(G)) { goto l446; }  goto l445;
-  l446:;	  G->pos= yypos445; G->thunkpos= yythunkpos445;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l444;  yyDo(G, yy_1_TypeBase, G->begin, G->end);
-  {  int yypos447= G->pos, yythunkpos447= G->thunkpos;  if (!yy_CONST_KW(G)) { goto l447; }  if (!yy__(G)) { goto l447; }  goto l448;
-  l447:;	  G->pos= yypos447; G->thunkpos= yythunkpos447;
+  {  int yypos456= G->pos, yythunkpos456= G->thunkpos;  if (!yy_FuncType(G)) { goto l457; }  goto l456;
+  l457:;	  G->pos= yypos456; G->thunkpos= yythunkpos456;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l455;  yyDo(G, yy_1_TypeBase, G->begin, G->end);
+  {  int yypos458= G->pos, yythunkpos458= G->thunkpos;  if (!yy_CONST_KW(G)) { goto l458; }  if (!yy__(G)) { goto l458; }  goto l459;
+  l458:;	  G->pos= yypos458; G->thunkpos= yythunkpos458;
   }
-  l448:;	
-  l449:;	
-  {  int yypos450= G->pos, yythunkpos450= G->thunkpos;
-  {  int yypos451= G->pos, yythunkpos451= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l452;  yyDo(G, yy_2_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l452; }  goto l451;
-  l452:;	  G->pos= yypos451; G->thunkpos= yythunkpos451;  if (!yymatchString(G, "signed")) goto l453;  yyDo(G, yy_3_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l453; }  goto l451;
-  l453:;	  G->pos= yypos451; G->thunkpos= yythunkpos451;  if (!yymatchString(G, "long")) goto l454;
-  {  int yypos455= G->pos, yythunkpos455= G->thunkpos;  if (!yy__(G)) { goto l454; }
-  {  int yypos456= G->pos, yythunkpos456= G->thunkpos;  if (!yymatchString(G, "long")) goto l457;  goto l456;
-  l457:;	  G->pos= yypos456; G->thunkpos= yythunkpos456;  if (!yymatchString(G, "double")) goto l458;  goto l456;
-  l458:;	  G->pos= yypos456; G->thunkpos= yythunkpos456;  if (!yymatchString(G, "int")) goto l454;
+  l459:;	
+  l460:;	
+  {  int yypos461= G->pos, yythunkpos461= G->thunkpos;
+  {  int yypos462= G->pos, yythunkpos462= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l463;  yyDo(G, yy_2_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l463; }  goto l462;
+  l463:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yymatchString(G, "signed")) goto l464;  yyDo(G, yy_3_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l464; }  goto l462;
+  l464:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yymatchString(G, "long")) goto l465;
+  {  int yypos466= G->pos, yythunkpos466= G->thunkpos;  if (!yy__(G)) { goto l465; }
+  {  int yypos467= G->pos, yythunkpos467= G->thunkpos;  if (!yymatchString(G, "long")) goto l468;  goto l467;
+  l468:;	  G->pos= yypos467; G->thunkpos= yythunkpos467;  if (!yymatchString(G, "double")) goto l469;  goto l467;
+  l469:;	  G->pos= yypos467; G->thunkpos= yythunkpos467;  if (!yymatchString(G, "int")) goto l465;
   }
-  l456:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;
-  }  yyDo(G, yy_4_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l454; }  goto l451;
-  l454:;	  G->pos= yypos451; G->thunkpos= yythunkpos451;  if (!yymatchString(G, "struct")) goto l459;  yyDo(G, yy_5_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l459; }  goto l451;
-  l459:;	  G->pos= yypos451; G->thunkpos= yythunkpos451;  if (!yymatchString(G, "union")) goto l450;  yyDo(G, yy_6_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l450; }
+  l467:;	  G->pos= yypos466; G->thunkpos= yythunkpos466;
+  }  yyDo(G, yy_4_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l465; }  goto l462;
+  l465:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yymatchString(G, "struct")) goto l470;  yyDo(G, yy_5_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l470; }  goto l462;
+  l470:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yymatchString(G, "union")) goto l461;  yyDo(G, yy_6_TypeBase, G->begin, G->end);  if (!yy__(G)) { goto l461; }
   }
-  l451:;	  if (!yy__(G)) { goto l450; }  goto l449;
-  l450:;	  G->pos= yypos450; G->thunkpos= yythunkpos450;
-  }  if (!yy_IDENT(G)) { goto l444; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_7_TypeBase, G->begin, G->end);  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l444;  yyDo(G, yy_8_TypeBase, G->begin, G->end);
+  l462:;	  if (!yy__(G)) { goto l461; }  goto l460;
+  l461:;	  G->pos= yypos461; G->thunkpos= yythunkpos461;
+  }  if (!yy_IDENT(G)) { goto l455; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_7_TypeBase, G->begin, G->end);  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l455;  yyDo(G, yy_8_TypeBase, G->begin, G->end);
   }
-  l445:;	
+  l456:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "TypeBase", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l444:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l455:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "TypeBase", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_SET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "SET_KW"));  if (!yymatchString(G, "set")) goto l460;
+  yyprintf((stderr, "%s\n", "SET_KW"));  if (!yymatchString(G, "set")) goto l471;
   yyprintf((stderr, "  ok   %s @ %s\n", "SET_KW", G->buf+G->pos));
   return 1;
-  l460:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l471:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SET_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_GET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "GET_KW"));  if (!yymatchString(G, "get")) goto l461;
+  yyprintf((stderr, "%s\n", "GET_KW"));  if (!yymatchString(G, "get")) goto l472;
   yyprintf((stderr, "  ok   %s @ %s\n", "GET_KW", G->buf+G->pos));
   return 1;
-  l461:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l472:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GET_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0);
-  yyprintf((stderr, "%s\n", "PropertyDeclSetter"));  if (!yy_OocDoc(G)) { goto l462; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_1_PropertyDeclSetter, G->begin, G->end);  if (!yy_WS(G)) { goto l462; }  if (!yy_SET_KW(G)) { goto l462; }  if (!yy_WS(G)) { goto l462; }
-  {  int yypos463= G->pos, yythunkpos463= G->thunkpos;  if (!yy_COLON(G)) { goto l463; }  if (!yy_WS(G)) { goto l463; }  if (!yy_ExternName(G)) { goto l463; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_PropertyDeclSetter, G->begin, G->end);  goto l464;
-  l463:;	  G->pos= yypos463; G->thunkpos= yythunkpos463;
+  yyprintf((stderr, "%s\n", "PropertyDeclSetter"));  if (!yy_OocDoc(G)) { goto l473; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_1_PropertyDeclSetter, G->begin, G->end);  if (!yy_WS(G)) { goto l473; }  if (!yy_SET_KW(G)) { goto l473; }  if (!yy_WS(G)) { goto l473; }
+  {  int yypos474= G->pos, yythunkpos474= G->thunkpos;  if (!yy_COLON(G)) { goto l474; }  if (!yy_WS(G)) { goto l474; }  if (!yy_ExternName(G)) { goto l474; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_PropertyDeclSetter, G->begin, G->end);  goto l475;
+  l474:;	  G->pos= yypos474; G->thunkpos= yythunkpos474;
   }
-  l464:;	
-  {  int yypos465= G->pos, yythunkpos465= G->thunkpos;  if (!yymatchChar(G, '(')) goto l465;  if (!yy_WS(G)) { goto l465; }
-  {  int yypos467= G->pos, yythunkpos467= G->thunkpos;  if (!yy_IDENT(G)) { goto l468; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_PropertyDeclSetter, G->begin, G->end);  goto l467;
-  l468:;	  G->pos= yypos467; G->thunkpos= yythunkpos467;  if (!yy_ASS(G)) { goto l465; }  if (!yy_IDENT(G)) { goto l465; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l465; }  yyDo(G, yy_4_PropertyDeclSetter, G->begin, G->end);
+  l475:;	
+  {  int yypos476= G->pos, yythunkpos476= G->thunkpos;  if (!yymatchChar(G, '(')) goto l476;  if (!yy_WS(G)) { goto l476; }
+  {  int yypos478= G->pos, yythunkpos478= G->thunkpos;  if (!yy_IDENT(G)) { goto l479; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_PropertyDeclSetter, G->begin, G->end);  goto l478;
+  l479:;	  G->pos= yypos478; G->thunkpos= yythunkpos478;  if (!yy_ASS(G)) { goto l476; }  if (!yy_IDENT(G)) { goto l476; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l476; }  yyDo(G, yy_4_PropertyDeclSetter, G->begin, G->end);
   }
-  l467:;	  if (!yymatchChar(G, ')')) goto l465;  if (!yy_WS(G)) { goto l465; }  if (!yymatchChar(G, '{')) goto l465;
-  l469:;	
-  {  int yypos470= G->pos, yythunkpos470= G->thunkpos;  if (!yy_WS(G)) { goto l470; }  if (!yy_Stmt(G)) { goto l470; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_5_PropertyDeclSetter, G->begin, G->end);  if (!yy_WS(G)) { goto l470; }  goto l469;
-  l470:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;
-  }  if (!yymatchChar(G, '}')) goto l465;  goto l466;
-  l465:;	  G->pos= yypos465; G->thunkpos= yythunkpos465;
+  l478:;	  if (!yymatchChar(G, ')')) goto l476;  if (!yy_WS(G)) { goto l476; }  if (!yymatchChar(G, '{')) goto l476;
+  l480:;	
+  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy_WS(G)) { goto l481; }  if (!yy_Stmt(G)) { goto l481; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_5_PropertyDeclSetter, G->begin, G->end);  if (!yy_WS(G)) { goto l481; }  goto l480;
+  l481:;	  G->pos= yypos481; G->thunkpos= yythunkpos481;
+  }  if (!yymatchChar(G, '}')) goto l476;  goto l477;
+  l476:;	  G->pos= yypos476; G->thunkpos= yythunkpos476;
   }
-  l466:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end);
+  l477:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "PropertyDeclSetter", G->buf+G->pos));  yyDo(G, yyPop, 5, 0);
   return 1;
-  l462:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l473:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "PropertyDeclSetter", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "PropertyDeclGetter"));  if (!yy_OocDoc(G)) { goto l471; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_PropertyDeclGetter, G->begin, G->end);  if (!yy_WS(G)) { goto l471; }  if (!yy_GET_KW(G)) { goto l471; }  if (!yy_WS(G)) { goto l471; }
-  {  int yypos472= G->pos, yythunkpos472= G->thunkpos;  if (!yy_COLON(G)) { goto l472; }  if (!yy_WS(G)) { goto l472; }  if (!yy_ExternName(G)) { goto l472; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_PropertyDeclGetter, G->begin, G->end);  goto l473;
-  l472:;	  G->pos= yypos472; G->thunkpos= yythunkpos472;
+  yyprintf((stderr, "%s\n", "PropertyDeclGetter"));  if (!yy_OocDoc(G)) { goto l482; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_PropertyDeclGetter, G->begin, G->end);  if (!yy_WS(G)) { goto l482; }  if (!yy_GET_KW(G)) { goto l482; }  if (!yy_WS(G)) { goto l482; }
+  {  int yypos483= G->pos, yythunkpos483= G->thunkpos;  if (!yy_COLON(G)) { goto l483; }  if (!yy_WS(G)) { goto l483; }  if (!yy_ExternName(G)) { goto l483; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_PropertyDeclGetter, G->begin, G->end);  goto l484;
+  l483:;	  G->pos= yypos483; G->thunkpos= yythunkpos483;
   }
-  l473:;	
-  {  int yypos474= G->pos, yythunkpos474= G->thunkpos;  if (!yymatchChar(G, '{')) goto l474;
-  l476:;	
-  {  int yypos477= G->pos, yythunkpos477= G->thunkpos;  if (!yy_WS(G)) { goto l477; }  if (!yy_Stmt(G)) { goto l477; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_PropertyDeclGetter, G->begin, G->end);  if (!yy_WS(G)) { goto l477; }  goto l476;
-  l477:;	  G->pos= yypos477; G->thunkpos= yythunkpos477;
-  }  if (!yymatchChar(G, '}')) goto l474;  goto l475;
-  l474:;	  G->pos= yypos474; G->thunkpos= yythunkpos474;
+  l484:;	
+  {  int yypos485= G->pos, yythunkpos485= G->thunkpos;  if (!yymatchChar(G, '{')) goto l485;
+  l487:;	
+  {  int yypos488= G->pos, yythunkpos488= G->thunkpos;  if (!yy_WS(G)) { goto l488; }  if (!yy_Stmt(G)) { goto l488; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_PropertyDeclGetter, G->begin, G->end);  if (!yy_WS(G)) { goto l488; }  goto l487;
+  l488:;	  G->pos= yypos488; G->thunkpos= yythunkpos488;
+  }  if (!yymatchChar(G, '}')) goto l485;  goto l486;
+  l485:;	  G->pos= yypos485; G->thunkpos= yythunkpos485;
   }
-  l475:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end);
+  l486:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "PropertyDeclGetter", G->buf+G->pos));  yyDo(G, yyPop, 3, 0);
   return 1;
-  l471:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l482:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "PropertyDeclGetter", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 {
   yyprintf((stderr, "%s\n", "PropertyDeclCore"));
-  l479:;	
-  {  int yypos480= G->pos, yythunkpos480= G->thunkpos;
-  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy_PropertyDeclGetter(G)) { goto l482; }  goto l481;
-  l482:;	  G->pos= yypos481; G->thunkpos= yythunkpos481;  if (!yy_PropertyDeclSetter(G)) { goto l480; }
+  l490:;	
+  {  int yypos491= G->pos, yythunkpos491= G->thunkpos;
+  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;  if (!yy_PropertyDeclGetter(G)) { goto l493; }  goto l492;
+  l493:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yy_PropertyDeclSetter(G)) { goto l491; }
   }
-  l481:;	  goto l479;
-  l480:;	  G->pos= yypos480; G->thunkpos= yythunkpos480;
+  l492:;	  goto l490;
+  l491:;	  G->pos= yypos491; G->thunkpos= yythunkpos491;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "PropertyDeclCore", G->buf+G->pos));
   return 1;
 }
 YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0);
-  yyprintf((stderr, "%s\n", "ConventionalVarDecl"));  yyDo(G, yy_1_ConventionalVarDecl, G->begin, G->end);  if (!yy_OocDoc(G)) { goto l483; }  yyDo(G, yySet, -5, 0);  if (!yy_IDENT(G)) { goto l483; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end);
-  {  int yypos484= G->pos, yythunkpos484= G->thunkpos;  if (!yy__(G)) { goto l484; }  if (!yy_ASS(G)) { goto l484; }  if (!yy__(G)) { goto l484; }  if (!yy_Expr(G)) { goto l484; }  yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end);  goto l485;
-  l484:;	  G->pos= yypos484; G->thunkpos= yythunkpos484;
+  yyprintf((stderr, "%s\n", "ConventionalVarDecl"));  yyDo(G, yy_1_ConventionalVarDecl, G->begin, G->end);  if (!yy_OocDoc(G)) { goto l494; }  yyDo(G, yySet, -5, 0);  if (!yy_IDENT(G)) { goto l494; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end);
+  {  int yypos495= G->pos, yythunkpos495= G->thunkpos;  if (!yy__(G)) { goto l495; }  if (!yy_ASS(G)) { goto l495; }  if (!yy__(G)) { goto l495; }  if (!yy_Expr(G)) { goto l495; }  yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end);  goto l496;
+  l495:;	  G->pos= yypos495; G->thunkpos= yythunkpos495;
   }
-  l485:;	
-  l486:;	
-  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yy__(G)) { goto l487; }  if (!yymatchChar(G, ',')) goto l487;  if (!yy_OocDoc(G)) { goto l487; }  yyDo(G, yySet, -5, 0);  if (!yy_WS(G)) { goto l487; }  if (!yy_IDENT(G)) { goto l487; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end);
-  {  int yypos488= G->pos, yythunkpos488= G->thunkpos;  if (!yy__(G)) { goto l488; }  if (!yy_ASS(G)) { goto l488; }  if (!yy__(G)) { goto l488; }  if (!yy_Expr(G)) { goto l488; }  yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end);  goto l489;
-  l488:;	  G->pos= yypos488; G->thunkpos= yythunkpos488;
+  l496:;	
+  l497:;	
+  {  int yypos498= G->pos, yythunkpos498= G->thunkpos;  if (!yy__(G)) { goto l498; }  if (!yymatchChar(G, ',')) goto l498;  if (!yy_OocDoc(G)) { goto l498; }  yyDo(G, yySet, -5, 0);  if (!yy_WS(G)) { goto l498; }  if (!yy_IDENT(G)) { goto l498; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end);
+  {  int yypos499= G->pos, yythunkpos499= G->thunkpos;  if (!yy__(G)) { goto l499; }  if (!yy_ASS(G)) { goto l499; }  if (!yy__(G)) { goto l499; }  if (!yy_Expr(G)) { goto l499; }  yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end);  goto l500;
+  l499:;	  G->pos= yypos499; G->thunkpos= yythunkpos499;
   }
-  l489:;	  if (!yy__(G)) { goto l487; }  goto l486;
-  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
-  }  if (!yy_WS(G)) { goto l483; }  if (!yy_COLON(G)) { goto l483; }  if (!yy_WS(G)) { goto l483; }
-  l490:;	
-  {  int yypos491= G->pos, yythunkpos491= G->thunkpos;  if (!yy__(G)) { goto l491; }
-  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;  if (!yy_STATIC_KW(G)) { goto l493; }  yyDo(G, yy_6_ConventionalVarDecl, G->begin, G->end);  goto l492;
-  l493:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yy_CONST_KW(G)) { goto l494; }  yyDo(G, yy_7_ConventionalVarDecl, G->begin, G->end);  goto l492;
-  l494:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yy_PROTO_KW(G)) { goto l495; }  yyDo(G, yy_8_ConventionalVarDecl, G->begin, G->end);  goto l492;
-  l495:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yy_ExternName(G)) { goto l496; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_9_ConventionalVarDecl, G->begin, G->end);  goto l492;
-  l496:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yy_UnmangledName(G)) { goto l491; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_10_ConventionalVarDecl, G->begin, G->end);
+  l500:;	  if (!yy__(G)) { goto l498; }  goto l497;
+  l498:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;
+  }  if (!yy_WS(G)) { goto l494; }  if (!yy_COLON(G)) { goto l494; }  if (!yy_WS(G)) { goto l494; }
+  l501:;	
+  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yy__(G)) { goto l502; }
+  {  int yypos503= G->pos, yythunkpos503= G->thunkpos;  if (!yy_STATIC_KW(G)) { goto l504; }  yyDo(G, yy_6_ConventionalVarDecl, G->begin, G->end);  goto l503;
+  l504:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;  if (!yy_CONST_KW(G)) { goto l505; }  yyDo(G, yy_7_ConventionalVarDecl, G->begin, G->end);  goto l503;
+  l505:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;  if (!yy_PROTO_KW(G)) { goto l506; }  yyDo(G, yy_8_ConventionalVarDecl, G->begin, G->end);  goto l503;
+  l506:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;  if (!yy_ExternName(G)) { goto l507; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_9_ConventionalVarDecl, G->begin, G->end);  goto l503;
+  l507:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;  if (!yy_UnmangledName(G)) { goto l502; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_10_ConventionalVarDecl, G->begin, G->end);
   }
-  l492:;	  goto l490;
-  l491:;	  G->pos= yypos491; G->thunkpos= yythunkpos491;
-  }  if (!yy_WS(G)) { goto l483; }  if (!yy_Type(G)) { goto l483; }  yyDo(G, yy_11_ConventionalVarDecl, G->begin, G->end);
-  {  int yypos497= G->pos, yythunkpos497= G->thunkpos;  if (!yy__(G)) { goto l497; }  if (!yy_ASS(G)) { goto l497; }  if (!yy__(G)) { goto l497; }  if (!yy_Expr(G)) { goto l497; }  yyDo(G, yy_12_ConventionalVarDecl, G->begin, G->end);  goto l498;
-  l497:;	  G->pos= yypos497; G->thunkpos= yythunkpos497;
+  l503:;	  goto l501;
+  l502:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;
+  }  if (!yy_WS(G)) { goto l494; }  if (!yy_Type(G)) { goto l494; }  yyDo(G, yy_11_ConventionalVarDecl, G->begin, G->end);
+  {  int yypos508= G->pos, yythunkpos508= G->thunkpos;  if (!yy__(G)) { goto l508; }  if (!yy_ASS(G)) { goto l508; }  if (!yy__(G)) { goto l508; }  if (!yy_Expr(G)) { goto l508; }  yyDo(G, yy_12_ConventionalVarDecl, G->begin, G->end);  goto l509;
+  l508:;	  G->pos= yypos508; G->thunkpos= yythunkpos508;
   }
-  l498:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end);
+  l509:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ConventionalVarDecl", G->buf+G->pos));  yyDo(G, yyPop, 5, 0);
   return 1;
-  l483:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l494:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ConventionalVarDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_CONST_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "CONST_KW"));  if (!yymatchString(G, "const")) goto l499;
+  yyprintf((stderr, "%s\n", "CONST_KW"));  if (!yymatchString(G, "const")) goto l510;
   yyprintf((stderr, "  ok   %s @ %s\n", "CONST_KW", G->buf+G->pos));
   return 1;
-  l499:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l510:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CONST_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "ASS_DECL"));  if (!yymatchString(G, ":=")) goto l500;  if (!yy__(G)) { goto l500; }
+  yyprintf((stderr, "%s\n", "ASS_DECL"));  if (!yymatchString(G, ":=")) goto l511;  if (!yy__(G)) { goto l511; }
   yyprintf((stderr, "  ok   %s @ %s\n", "ASS_DECL", G->buf+G->pos));
   return 1;
-  l500:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l511:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASS_DECL", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Tuple(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "Tuple"));  if (!yymatchChar(G, '(')) goto l501;  yyDo(G, yy_1_Tuple, G->begin, G->end);  if (!yy_WS(G)) { goto l501; }  yyDo(G, yy_2_Tuple, G->begin, G->end);
-  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yy_Expr(G)) { goto l502; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_Tuple, G->begin, G->end);
-  l504:;	
-  {  int yypos505= G->pos, yythunkpos505= G->thunkpos;
-  {  int yypos506= G->pos, yythunkpos506= G->thunkpos;  if (!yy_WS(G)) { goto l507; }  if (!yymatchChar(G, ',')) goto l507;  goto l506;
-  l507:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;  if (!yy_EOL(G)) { goto l505; }
+  yyprintf((stderr, "%s\n", "Tuple"));  if (!yymatchChar(G, '(')) goto l512;  yyDo(G, yy_1_Tuple, G->begin, G->end);  if (!yy_WS(G)) { goto l512; }  yyDo(G, yy_2_Tuple, G->begin, G->end);
+  {  int yypos513= G->pos, yythunkpos513= G->thunkpos;  if (!yy_Expr(G)) { goto l513; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_Tuple, G->begin, G->end);
+  l515:;	
+  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;
+  {  int yypos517= G->pos, yythunkpos517= G->thunkpos;  if (!yy_WS(G)) { goto l518; }  if (!yymatchChar(G, ',')) goto l518;  goto l517;
+  l518:;	  G->pos= yypos517; G->thunkpos= yythunkpos517;  if (!yy_EOL(G)) { goto l516; }
   }
-  l506:;	  if (!yy_WS(G)) { goto l505; }  if (!yy_Expr(G)) { goto l505; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_4_Tuple, G->begin, G->end);  goto l504;
-  l505:;	  G->pos= yypos505; G->thunkpos= yythunkpos505;
-  }  goto l503;
-  l502:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;
+  l517:;	  if (!yy_WS(G)) { goto l516; }  if (!yy_Expr(G)) { goto l516; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_4_Tuple, G->begin, G->end);  goto l515;
+  l516:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;
+  }  goto l514;
+  l513:;	  G->pos= yypos513; G->thunkpos= yythunkpos513;
   }
-  l503:;	  if (!yy_WS(G)) { goto l501; }  if (!yy_CLOS_PAREN(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_CLOSING_SQUAR, "Malformed tuple!\n", G->pos + G->offset); ; } goto l501; }  yyDo(G, yy_5_Tuple, G->begin, G->end);
+  l514:;	  if (!yy_WS(G)) { goto l512; }  if (!yy_CLOS_PAREN(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_CLOSING_SQUAR, "Malformed tuple!\n", G->pos + G->offset); ; } goto l512; }  yyDo(G, yy_5_Tuple, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "Tuple", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l501:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l512:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Tuple", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "VarDeclFromExpr"));  if (!yy_OocDoc(G)) { goto l508; }  yyDo(G, yySet, -4, 0);
-  {  int yypos509= G->pos, yythunkpos509= G->thunkpos;  if (!yy_IDENT(G)) { goto l510; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_VarDeclFromExpr, G->begin, G->end);  goto l509;
-  l510:;	  G->pos= yypos509; G->thunkpos= yythunkpos509;  if (!yy_Tuple(G)) { goto l508; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_VarDeclFromExpr, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "VarDeclFromExpr"));  if (!yy_OocDoc(G)) { goto l519; }  yyDo(G, yySet, -4, 0);
+  {  int yypos520= G->pos, yythunkpos520= G->thunkpos;  if (!yy_IDENT(G)) { goto l521; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_VarDeclFromExpr, G->begin, G->end);  goto l520;
+  l521:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;  if (!yy_Tuple(G)) { goto l519; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_VarDeclFromExpr, G->begin, G->end);
   }
-  l509:;	  if (!yy__(G)) { goto l508; }  if (!yy_ASS_DECL(G)) { goto l508; }
-  l511:;	
-  {  int yypos512= G->pos, yythunkpos512= G->thunkpos;  if (!yy__(G)) { goto l512; }
-  {  int yypos513= G->pos, yythunkpos513= G->thunkpos;  if (!yy_STATIC_KW(G)) { goto l514; }  yyDo(G, yy_3_VarDeclFromExpr, G->begin, G->end);  goto l513;
-  l514:;	  G->pos= yypos513; G->thunkpos= yythunkpos513;  if (!yy_CONST_KW(G)) { goto l515; }  yyDo(G, yy_4_VarDeclFromExpr, G->begin, G->end);  goto l513;
-  l515:;	  G->pos= yypos513; G->thunkpos= yythunkpos513;  if (!yy_PROTO_KW(G)) { goto l512; }  yyDo(G, yy_5_VarDeclFromExpr, G->begin, G->end);
+  l520:;	  if (!yy__(G)) { goto l519; }  if (!yy_ASS_DECL(G)) { goto l519; }
+  l522:;	
+  {  int yypos523= G->pos, yythunkpos523= G->thunkpos;  if (!yy__(G)) { goto l523; }
+  {  int yypos524= G->pos, yythunkpos524= G->thunkpos;  if (!yy_STATIC_KW(G)) { goto l525; }  yyDo(G, yy_3_VarDeclFromExpr, G->begin, G->end);  goto l524;
+  l525:;	  G->pos= yypos524; G->thunkpos= yythunkpos524;  if (!yy_CONST_KW(G)) { goto l526; }  yyDo(G, yy_4_VarDeclFromExpr, G->begin, G->end);  goto l524;
+  l526:;	  G->pos= yypos524; G->thunkpos= yythunkpos524;  if (!yy_PROTO_KW(G)) { goto l523; }  yyDo(G, yy_5_VarDeclFromExpr, G->begin, G->end);
   }
-  l513:;	
-  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l512;  G->pos= yypos516; G->thunkpos= yythunkpos516;
-  }  goto l511;
-  l512:;	  G->pos= yypos512; G->thunkpos= yythunkpos512;
-  }  if (!yy__(G)) { goto l508; }  if (!yy_Expr(G)) { goto l508; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end);  if (!yy__(G)) { goto l508; }  yyDo(G, yy_7_VarDeclFromExpr, G->begin, G->end);
+  l524:;	
+  {  int yypos527= G->pos, yythunkpos527= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l523;  G->pos= yypos527; G->thunkpos= yythunkpos527;
+  }  goto l522;
+  l523:;	  G->pos= yypos523; G->thunkpos= yythunkpos523;
+  }  if (!yy__(G)) { goto l519; }  if (!yy_Expr(G)) { goto l519; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end);  if (!yy__(G)) { goto l519; }  yyDo(G, yy_7_VarDeclFromExpr, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "VarDeclFromExpr", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l508:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l519:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VarDeclFromExpr", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "UNMANGLED_KW"));  if (!yymatchString(G, "unmangled")) goto l517;
+  yyprintf((stderr, "%s\n", "UNMANGLED_KW"));  if (!yymatchString(G, "unmangled")) goto l528;
   yyprintf((stderr, "  ok   %s @ %s\n", "UNMANGLED_KW", G->buf+G->pos));
   return 1;
-  l517:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l528:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "UNMANGLED_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_EXTERN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "EXTERN_KW"));  if (!yymatchString(G, "extern")) goto l518;
+  yyprintf((stderr, "%s\n", "EXTERN_KW"));  if (!yymatchString(G, "extern")) goto l529;
   yyprintf((stderr, "  ok   %s @ %s\n", "EXTERN_KW", G->buf+G->pos));
   return 1;
-  l518:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l529:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EXTERN_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "INTERFACE_KW"));  if (!yymatchString(G, "interface")) goto l519;
+  yyprintf((stderr, "%s\n", "INTERFACE_KW"));  if (!yymatchString(G, "interface")) goto l530;
   yyprintf((stderr, "  ok   %s @ %s\n", "INTERFACE_KW", G->buf+G->pos));
   return 1;
-  l519:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l530:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INTERFACE_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_COVER_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "COVER_KW"));  if (!yymatchString(G, "cover")) goto l520;
+  yyprintf((stderr, "%s\n", "COVER_KW"));  if (!yymatchString(G, "cover")) goto l531;
   yyprintf((stderr, "  ok   %s @ %s\n", "COVER_KW", G->buf+G->pos));
   return 1;
-  l520:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l531:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "COVER_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_PLUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "PLUS"));  if (!yymatchChar(G, '+')) goto l521;
-  {  int yypos522= G->pos, yythunkpos522= G->thunkpos;  if (!yymatchChar(G, '=')) goto l522;  goto l521;
-  l522:;	  G->pos= yypos522; G->thunkpos= yythunkpos522;
-  }  if (!yy__(G)) { goto l521; }
+  yyprintf((stderr, "%s\n", "PLUS"));  if (!yymatchChar(G, '+')) goto l532;
+  {  int yypos533= G->pos, yythunkpos533= G->thunkpos;  if (!yymatchChar(G, '=')) goto l533;  goto l532;
+  l533:;	  G->pos= yypos533; G->thunkpos= yythunkpos533;
+  }  if (!yy__(G)) { goto l532; }
   yyprintf((stderr, "  ok   %s @ %s\n", "PLUS", G->buf+G->pos));
   return 1;
-  l521:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l532:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "PLUS", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_STAR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "STAR"));  if (!yymatchChar(G, '*')) goto l523;
-  {  int yypos524= G->pos, yythunkpos524= G->thunkpos;  if (!yymatchChar(G, '=')) goto l524;  goto l523;
-  l524:;	  G->pos= yypos524; G->thunkpos= yythunkpos524;
-  }  if (!yy__(G)) { goto l523; }
+  yyprintf((stderr, "%s\n", "STAR"));  if (!yymatchChar(G, '*')) goto l534;
+  {  int yypos535= G->pos, yythunkpos535= G->thunkpos;  if (!yymatchChar(G, '=')) goto l535;  goto l534;
+  l535:;	  G->pos= yypos535; G->thunkpos= yythunkpos535;
+  }  if (!yy__(G)) { goto l534; }
   yyprintf((stderr, "  ok   %s @ %s\n", "STAR", G->buf+G->pos));
   return 1;
-  l523:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l534:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "STAR", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Expr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
   yyprintf((stderr, "%s\n", "Expr"));
-  {  int yypos526= G->pos, yythunkpos526= G->thunkpos;  if (!yy_VariableDecl(G)) { goto l527; }  yyDo(G, yySet, -4, 0);  if (!yy__(G)) { goto l527; }  goto l526;
-  l527:;	  G->pos= yypos526; G->thunkpos= yythunkpos526;  if (!yy_DoubleArrow(G)) { goto l528; }  yyDo(G, yySet, -3, 0);  if (!yy__(G)) { goto l528; }  goto l526;
-  l528:;	  G->pos= yypos526; G->thunkpos= yythunkpos526;  if (!yy_BinaryOperation(G)) { goto l529; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l529; }
-  l530:;	
-  {  int yypos531= G->pos, yythunkpos531= G->thunkpos;  if (!yy__(G)) { goto l531; }  if (!yymatchChar(G, '.')) goto l531;  yyDo(G, yy_1_Expr, G->begin, G->end);  if (!yy_WS(G)) { goto l531; }  if (!yy_FunctionCall(G)) { goto l531; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_Expr, G->begin, G->end);  goto l530;
-  l531:;	  G->pos= yypos531; G->thunkpos= yythunkpos531;
-  }  goto l526;
-  l529:;	  G->pos= yypos526; G->thunkpos= yythunkpos526;  if (!yy_AnonymousFunctionDecl(G)) { goto l525; }
+  {  int yypos537= G->pos, yythunkpos537= G->thunkpos;  if (!yy_VariableDecl(G)) { goto l538; }  yyDo(G, yySet, -4, 0);  if (!yy__(G)) { goto l538; }  goto l537;
+  l538:;	  G->pos= yypos537; G->thunkpos= yythunkpos537;  if (!yy_DoubleArrow(G)) { goto l539; }  yyDo(G, yySet, -3, 0);  if (!yy__(G)) { goto l539; }  goto l537;
+  l539:;	  G->pos= yypos537; G->thunkpos= yythunkpos537;  if (!yy_BinaryOperation(G)) { goto l540; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l540; }
+  l541:;	
+  {  int yypos542= G->pos, yythunkpos542= G->thunkpos;  if (!yy__(G)) { goto l542; }  if (!yymatchChar(G, '.')) goto l542;  yyDo(G, yy_1_Expr, G->begin, G->end);  if (!yy_WS(G)) { goto l542; }  if (!yy_FunctionCall(G)) { goto l542; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_Expr, G->begin, G->end);  goto l541;
+  l542:;	  G->pos= yypos542; G->thunkpos= yythunkpos542;
+  }  goto l537;
+  l540:;	  G->pos= yypos537; G->thunkpos= yythunkpos537;  if (!yy_AnonymousFunctionDecl(G)) { goto l536; }
   }
-  l526:;	
+  l537:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Expr", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l525:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l536:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Expr", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_EnumElement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "EnumElement"));  if (!yy_OocDoc(G)) { goto l532; }  yyDo(G, yySet, -4, 0);  if (!yy_IDENT(G)) { goto l532; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_EnumElement, G->begin, G->end);  if (!yy__(G)) { goto l532; }
-  {  int yypos533= G->pos, yythunkpos533= G->thunkpos;
-  {  int yypos535= G->pos, yythunkpos535= G->thunkpos;  if (!yy_ASS(G)) { goto l536; }  if (!yy_Expr(G)) { goto l536; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_EnumElement, G->begin, G->end);  goto l535;
-  l536:;	  G->pos= yypos535; G->thunkpos= yythunkpos535;  if (!yy_COLON(G)) { goto l533; }  if (!yy__(G)) { goto l533; }  if (!yy_ExternName(G)) { goto l533; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_EnumElement, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "EnumElement"));  if (!yy_OocDoc(G)) { goto l543; }  yyDo(G, yySet, -4, 0);  if (!yy_IDENT(G)) { goto l543; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_EnumElement, G->begin, G->end);  if (!yy__(G)) { goto l543; }
+  {  int yypos544= G->pos, yythunkpos544= G->thunkpos;
+  {  int yypos546= G->pos, yythunkpos546= G->thunkpos;  if (!yy_ASS(G)) { goto l547; }  if (!yy_Expr(G)) { goto l547; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_EnumElement, G->begin, G->end);  goto l546;
+  l547:;	  G->pos= yypos546; G->thunkpos= yythunkpos546;  if (!yy_COLON(G)) { goto l544; }  if (!yy__(G)) { goto l544; }  if (!yy_ExternName(G)) { goto l544; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_EnumElement, G->begin, G->end);
   }
-  l535:;	  goto l534;
-  l533:;	  G->pos= yypos533; G->thunkpos= yythunkpos533;
+  l546:;	  goto l545;
+  l544:;	  G->pos= yypos544; G->thunkpos= yythunkpos544;
   }
-  l534:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end);
+  l545:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "EnumElement", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l532:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l543:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EnumElement", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_IntLiteral(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "IntLiteral"));
-  {  int yypos538= G->pos, yythunkpos538= G->thunkpos;  if (!yy_OCT_LIT(G)) { goto l539; }  yyDo(G, yySet, -3, 0);  if (!yy__(G)) { goto l539; }  yyDo(G, yy_1_IntLiteral, G->begin, G->end);  goto l538;
-  l539:;	  G->pos= yypos538; G->thunkpos= yythunkpos538;  if (!yy_HEX_LIT(G)) { goto l540; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l540; }  yyDo(G, yy_2_IntLiteral, G->begin, G->end);  goto l538;
-  l540:;	  G->pos= yypos538; G->thunkpos= yythunkpos538;  if (!yy_DEC_LIT(G)) { goto l537; }  yyDo(G, yySet, -1, 0);  if (!yy__(G)) { goto l537; }  yyDo(G, yy_3_IntLiteral, G->begin, G->end);
+  {  int yypos549= G->pos, yythunkpos549= G->thunkpos;  if (!yy_OCT_LIT(G)) { goto l550; }  yyDo(G, yySet, -3, 0);  if (!yy__(G)) { goto l550; }  yyDo(G, yy_1_IntLiteral, G->begin, G->end);  goto l549;
+  l550:;	  G->pos= yypos549; G->thunkpos= yythunkpos549;  if (!yy_HEX_LIT(G)) { goto l551; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l551; }  yyDo(G, yy_2_IntLiteral, G->begin, G->end);  goto l549;
+  l551:;	  G->pos= yypos549; G->thunkpos= yythunkpos549;  if (!yy_DEC_LIT(G)) { goto l548; }  yyDo(G, yySet, -1, 0);  if (!yy__(G)) { goto l548; }  yyDo(G, yy_3_IntLiteral, G->begin, G->end);
   }
-  l538:;	
+  l549:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IntLiteral", G->buf+G->pos));  yyDo(G, yyPop, 3, 0);
   return 1;
-  l537:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l548:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IntLiteral", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "EnumIncrementOper"));
-  {  int yypos542= G->pos, yythunkpos542= G->thunkpos;  if (!yy_STAR(G)) { goto l543; }  yyDo(G, yy_1_EnumIncrementOper, G->begin, G->end);  goto l542;
-  l543:;	  G->pos= yypos542; G->thunkpos= yythunkpos542;  if (!yy_PLUS(G)) { goto l541; }  yyDo(G, yy_2_EnumIncrementOper, G->begin, G->end);
+  {  int yypos553= G->pos, yythunkpos553= G->thunkpos;  if (!yy_STAR(G)) { goto l554; }  yyDo(G, yy_1_EnumIncrementOper, G->begin, G->end);  goto l553;
+  l554:;	  G->pos= yypos553; G->thunkpos= yythunkpos553;  if (!yy_PLUS(G)) { goto l552; }  yyDo(G, yy_2_EnumIncrementOper, G->begin, G->end);
   }
-  l542:;	
+  l553:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "EnumIncrementOper", G->buf+G->pos));
   return 1;
-  l541:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l552:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EnumIncrementOper", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_FROM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "FROM_KW"));  if (!yymatchString(G, "from")) goto l544;
+  yyprintf((stderr, "%s\n", "FROM_KW"));  if (!yymatchString(G, "from")) goto l555;
   yyprintf((stderr, "  ok   %s @ %s\n", "FROM_KW", G->buf+G->pos));
   return 1;
-  l544:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l555:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FROM_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ENUM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "ENUM_KW"));  if (!yymatchString(G, "enum")) goto l545;
+  yyprintf((stderr, "%s\n", "ENUM_KW"));  if (!yymatchString(G, "enum")) goto l556;
   yyprintf((stderr, "  ok   %s @ %s\n", "ENUM_KW", G->buf+G->pos));
   return 1;
-  l545:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l556:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ENUM_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "IMPLEMENTS_KW"));  if (!yymatchString(G, "implements")) goto l546;
+  yyprintf((stderr, "%s\n", "IMPLEMENTS_KW"));  if (!yymatchString(G, "implements")) goto l557;
   yyprintf((stderr, "  ok   %s @ %s\n", "IMPLEMENTS_KW", G->buf+G->pos));
   return 1;
-  l546:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l557:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IMPLEMENTS_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "EXTENDS_KW"));  if (!yymatchString(G, "extends")) goto l547;
+  yyprintf((stderr, "%s\n", "EXTENDS_KW"));  if (!yymatchString(G, "extends")) goto l558;
   yyprintf((stderr, "  ok   %s @ %s\n", "EXTENDS_KW", G->buf+G->pos));
   return 1;
-  l547:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l558:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EXTENDS_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_CLASS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "CLASS_KW"));  if (!yymatchString(G, "class")) goto l548;
+  yyprintf((stderr, "%s\n", "CLASS_KW"));  if (!yymatchString(G, "class")) goto l559;
   yyprintf((stderr, "  ok   %s @ %s\n", "CLASS_KW", G->buf+G->pos));
   return 1;
-  l548:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l559:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CLASS_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ASS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "ASS"));
-  {  int yypos550= G->pos, yythunkpos550= G->thunkpos;  if (!yy_DOUBLE_ARROW(G)) { goto l550; }  goto l549;
-  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
-  }  if (!yymatchChar(G, '=')) goto l549;  if (!yy__(G)) { goto l549; }
+  {  int yypos561= G->pos, yythunkpos561= G->thunkpos;  if (!yy_DOUBLE_ARROW(G)) { goto l561; }  goto l560;
+  l561:;	  G->pos= yypos561; G->thunkpos= yythunkpos561;
+  }  if (!yymatchChar(G, '=')) goto l560;  if (!yy__(G)) { goto l560; }
   yyprintf((stderr, "  ok   %s @ %s\n", "ASS", G->buf+G->pos));
   return 1;
-  l549:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l560:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASS", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "DOT"));
-  {  int yypos552= G->pos, yythunkpos552= G->thunkpos;  if (!yy_DOUBLE_DOT(G)) { goto l552; }  goto l551;
-  l552:;	  G->pos= yypos552; G->thunkpos= yythunkpos552;
-  }  if (!yymatchChar(G, '.')) goto l551;
+  {  int yypos563= G->pos, yythunkpos563= G->thunkpos;  if (!yy_DOUBLE_DOT(G)) { goto l563; }  goto l562;
+  l563:;	  G->pos= yypos563; G->thunkpos= yythunkpos563;
+  }  if (!yymatchChar(G, '.')) goto l562;
   yyprintf((stderr, "  ok   %s @ %s\n", "DOT", G->buf+G->pos));
   return 1;
-  l551:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l562:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DOT", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "CLOS_BRACK"));  if (!yymatchChar(G, '}')) goto l553;
+  yyprintf((stderr, "%s\n", "CLOS_BRACK"));  if (!yymatchChar(G, '}')) goto l564;
   yyprintf((stderr, "  ok   %s @ %s\n", "CLOS_BRACK", G->buf+G->pos));
   return 1;
-  l553:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l564:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CLOS_BRACK", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Type(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0);
   yyprintf((stderr, "%s\n", "Type"));
-  {  int yypos555= G->pos, yythunkpos555= G->thunkpos;  if (!yy_TypeList(G)) { goto l556; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_1_Type, G->begin, G->end);  goto l555;
-  l556:;	  G->pos= yypos555; G->thunkpos= yythunkpos555;  if (!yy_TypeBase(G)) { goto l554; }  yyDo(G, yySet, -3, 0);
-  {  int yypos557= G->pos, yythunkpos557= G->thunkpos;  if (!yy__(G)) { goto l557; }  if (!yymatchChar(G, '<')) goto l557;  if (!yy__(G)) { goto l557; }  if (!yy_Type(G)) { goto l557; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_Type, G->begin, G->end);
-  l559:;	
-  {  int yypos560= G->pos, yythunkpos560= G->thunkpos;  if (!yy__(G)) { goto l560; }  if (!yymatchChar(G, ',')) goto l560;  if (!yy__(G)) { goto l560; }  if (!yy_Type(G)) { goto l560; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_Type, G->begin, G->end);  goto l559;
-  l560:;	  G->pos= yypos560; G->thunkpos= yythunkpos560;
-  }  if (!yy__(G)) { goto l557; }  if (!yymatchChar(G, '>')) goto l557;  goto l558;
-  l557:;	  G->pos= yypos557; G->thunkpos= yythunkpos557;
+  {  int yypos566= G->pos, yythunkpos566= G->thunkpos;  if (!yy_TypeList(G)) { goto l567; }  yyDo(G, yySet, -6, 0);  yyDo(G, yy_1_Type, G->begin, G->end);  goto l566;
+  l567:;	  G->pos= yypos566; G->thunkpos= yythunkpos566;  if (!yy_TypeBase(G)) { goto l568; }  yyDo(G, yySet, -5, 0);
+  {  int yypos569= G->pos, yythunkpos569= G->thunkpos;  if (!yy__(G)) { goto l569; }  if (!yymatchChar(G, '<')) goto l569;  if (!yy__(G)) { goto l569; }  if (!yy_Type(G)) { goto l569; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_Type, G->begin, G->end);
+  l571:;	
+  {  int yypos572= G->pos, yythunkpos572= G->thunkpos;  if (!yy__(G)) { goto l572; }  if (!yymatchChar(G, ',')) goto l572;  if (!yy__(G)) { goto l572; }  if (!yy_Type(G)) { goto l572; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_3_Type, G->begin, G->end);  goto l571;
+  l572:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;
+  }  if (!yy__(G)) { goto l569; }  if (!yymatchChar(G, '>')) goto l569;  goto l570;
+  l569:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;
   }
-  l558:;	  if (!yy__(G)) { goto l554; }
-  l561:;	
-  {  int yypos562= G->pos, yythunkpos562= G->thunkpos;
-  {  int yypos563= G->pos, yythunkpos563= G->thunkpos;  if (!yy_STAR(G)) { goto l564; }  yyDo(G, yy_4_Type, G->begin, G->end);  goto l563;
-  l564:;	  G->pos= yypos563; G->thunkpos= yythunkpos563;  if (!yymatchChar(G, '@')) goto l565;  yyDo(G, yy_5_Type, G->begin, G->end);  goto l563;
-  l565:;	  G->pos= yypos563; G->thunkpos= yythunkpos563;  if (!yymatchChar(G, '[')) goto l562;  if (!yy_WS(G)) { goto l562; }  yyDo(G, yy_6_Type, G->begin, G->end);  if (!yy__(G)) { goto l562; }
-  {  int yypos566= G->pos, yythunkpos566= G->thunkpos;  if (!yy_Expr(G)) { goto l566; }  yyDo(G, yySet, -1, 0);  goto l567;
-  l566:;	  G->pos= yypos566; G->thunkpos= yythunkpos566;
+  l570:;	  if (!yy__(G)) { goto l568; }
+  l573:;	
+  {  int yypos574= G->pos, yythunkpos574= G->thunkpos;
+  {  int yypos575= G->pos, yythunkpos575= G->thunkpos;  if (!yy_STAR(G)) { goto l576; }  yyDo(G, yy_4_Type, G->begin, G->end);  goto l575;
+  l576:;	  G->pos= yypos575; G->thunkpos= yythunkpos575;  if (!yymatchChar(G, '@')) goto l577;  yyDo(G, yy_5_Type, G->begin, G->end);  goto l575;
+  l577:;	  G->pos= yypos575; G->thunkpos= yythunkpos575;  if (!yymatchChar(G, '[')) goto l574;  if (!yy_WS(G)) { goto l574; }  yyDo(G, yy_6_Type, G->begin, G->end);  if (!yy__(G)) { goto l574; }
+  {  int yypos578= G->pos, yythunkpos578= G->thunkpos;  if (!yy_Expr(G)) { goto l578; }  yyDo(G, yySet, -3, 0);  goto l579;
+  l578:;	  G->pos= yypos578; G->thunkpos= yythunkpos578;
   }
-  l567:;	  if (!yymatchChar(G, ']')) goto l562;  yyDo(G, yy_7_Type, G->begin, G->end);
+  l579:;	  if (!yymatchChar(G, ']')) goto l574;  yyDo(G, yy_7_Type, G->begin, G->end);
   }
-  l563:;	  goto l561;
-  l562:;	  G->pos= yypos562; G->thunkpos= yythunkpos562;
-  }  if (!yy__(G)) { goto l554; }  yyDo(G, yy_8_Type, G->begin, G->end);
+  l575:;	  goto l573;
+  l574:;	  G->pos= yypos574; G->thunkpos= yythunkpos574;
+  }  if (!yy__(G)) { goto l568; }  yyDo(G, yy_8_Type, G->begin, G->end);  goto l566;
+  l568:;	  G->pos= yypos566; G->thunkpos= yythunkpos566;  if (!yymatchChar(G, '(')) goto l565;  if (!yy_Old(G)) { goto l565; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l565; }  if (!yy_IDENT(G)) { goto l565; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_9_Type, G->begin, G->end);  if (!yy__(G)) { goto l565; }  if (!yy_TypeBase(G)) { goto l565; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_10_Type, G->begin, G->end);
+  {  int yypos580= G->pos, yythunkpos580= G->thunkpos;  if (!yy__(G)) { goto l580; }  if (!yymatchChar(G, '<')) goto l580;  if (!yy__(G)) { goto l580; }  if (!yy_Type(G)) { goto l580; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_11_Type, G->begin, G->end);
+  l582:;	
+  {  int yypos583= G->pos, yythunkpos583= G->thunkpos;  if (!yy__(G)) { goto l583; }  if (!yymatchChar(G, ',')) goto l583;  if (!yy__(G)) { goto l583; }  if (!yy_Type(G)) { goto l583; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_12_Type, G->begin, G->end);  goto l582;
+  l583:;	  G->pos= yypos583; G->thunkpos= yythunkpos583;
+  }  if (!yy__(G)) { goto l580; }  if (!yymatchChar(G, '>')) goto l580;  goto l581;
+  l580:;	  G->pos= yypos580; G->thunkpos= yythunkpos580;
   }
-  l555:;	
-  yyprintf((stderr, "  ok   %s @ %s\n", "Type", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
+  l581:;	  if (!yy__(G)) { goto l565; }
+  l584:;	
+  {  int yypos585= G->pos, yythunkpos585= G->thunkpos;
+  {  int yypos586= G->pos, yythunkpos586= G->thunkpos;  if (!yy_STAR(G)) { goto l587; }  yyDo(G, yy_13_Type, G->begin, G->end);  goto l586;
+  l587:;	  G->pos= yypos586; G->thunkpos= yythunkpos586;  if (!yymatchChar(G, '@')) goto l588;  yyDo(G, yy_14_Type, G->begin, G->end);  goto l586;
+  l588:;	  G->pos= yypos586; G->thunkpos= yythunkpos586;  if (!yymatchChar(G, '[')) goto l585;  if (!yy_WS(G)) { goto l585; }  yyDo(G, yy_15_Type, G->begin, G->end);  if (!yy__(G)) { goto l585; }
+  {  int yypos589= G->pos, yythunkpos589= G->thunkpos;  if (!yy_Expr(G)) { goto l589; }  yyDo(G, yySet, -3, 0);  goto l590;
+  l589:;	  G->pos= yypos589; G->thunkpos= yythunkpos589;
+  }
+  l590:;	  if (!yymatchChar(G, ']')) goto l585;  yyDo(G, yy_16_Type, G->begin, G->end);
+  }
+  l586:;	  goto l584;
+  l585:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;
+  }  if (!yy__(G)) { goto l565; }  yyDo(G, yy_17_Type, G->begin, G->end);  if (!yymatchChar(G, ')')) goto l565;
+  }
+  l566:;	
+  yyprintf((stderr, "  ok   %s @ %s\n", "Type", G->buf+G->pos));  yyDo(G, yyPop, 6, 0);
   return 1;
-  l554:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l565:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Type", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_R_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "R_ARROW"));  if (!yymatchString(G, "->")) goto l568;
+  yyprintf((stderr, "%s\n", "R_ARROW"));  if (!yymatchString(G, "->")) goto l591;
   yyprintf((stderr, "  ok   %s @ %s\n", "R_ARROW", G->buf+G->pos));
   return 1;
-  l568:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l591:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "R_ARROW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_CLOS_PAREN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "CLOS_PAREN"));  if (!yymatchChar(G, ')')) goto l569;
+  yyprintf((stderr, "%s\n", "CLOS_PAREN"));  if (!yymatchChar(G, ')')) goto l592;
   yyprintf((stderr, "  ok   %s @ %s\n", "CLOS_PAREN", G->buf+G->pos));
   return 1;
-  l569:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l592:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CLOS_PAREN", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Argument(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0);
   yyprintf((stderr, "%s\n", "Argument"));
-  {  int yypos571= G->pos, yythunkpos571= G->thunkpos;  if (!yy_DOT(G)) { goto l572; }  if (!yy_IDENT(G)) { goto l572; }  yyDo(G, yySet, -5, 0);  if (!yy__(G)) { goto l572; }  yyDo(G, yy_1_Argument, G->begin, G->end);  goto l571;
-  l572:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;  if (!yy_ASS(G)) { goto l573; }  if (!yy_IDENT(G)) { goto l573; }  yyDo(G, yySet, -4, 0);  if (!yy__(G)) { goto l573; }  yyDo(G, yy_2_Argument, G->begin, G->end);  goto l571;
-  l573:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;  if (!yy_VariableDecl(G)) { goto l574; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_Argument, G->begin, G->end);  goto l571;
-  l574:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;  if (!yy_IDENT(G)) { goto l575; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l575; }  if (!yymatchChar(G, ':')) goto l575;  if (!yy__(G)) { goto l575; }  if (!yymatchString(G, "...")) goto l575;  if (!yy__(G)) { goto l575; }  yyDo(G, yy_4_Argument, G->begin, G->end);  goto l571;
-  l575:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;  if (!yy_Type(G)) { goto l576; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_5_Argument, G->begin, G->end);  goto l571;
-  l576:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;  if (!yymatchString(G, "...")) goto l570;  yyDo(G, yy_6_Argument, G->begin, G->end);
+  {  int yypos594= G->pos, yythunkpos594= G->thunkpos;  if (!yy_DOT(G)) { goto l595; }  if (!yy_IDENT(G)) { goto l595; }  yyDo(G, yySet, -5, 0);  if (!yy__(G)) { goto l595; }  yyDo(G, yy_1_Argument, G->begin, G->end);  goto l594;
+  l595:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yy_ASS(G)) { goto l596; }  if (!yy_IDENT(G)) { goto l596; }  yyDo(G, yySet, -4, 0);  if (!yy__(G)) { goto l596; }  yyDo(G, yy_2_Argument, G->begin, G->end);  goto l594;
+  l596:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yy_VariableDecl(G)) { goto l597; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_Argument, G->begin, G->end);  goto l594;
+  l597:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yy_IDENT(G)) { goto l598; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l598; }  if (!yymatchChar(G, ':')) goto l598;  if (!yy__(G)) { goto l598; }  if (!yymatchString(G, "...")) goto l598;  if (!yy__(G)) { goto l598; }  yyDo(G, yy_4_Argument, G->begin, G->end);  goto l594;
+  l598:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yy_Type(G)) { goto l599; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_5_Argument, G->begin, G->end);  goto l594;
+  l599:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yymatchString(G, "...")) goto l593;  yyDo(G, yy_6_Argument, G->begin, G->end);
   }
-  l571:;	
+  l594:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Argument", G->buf+G->pos));  yyDo(G, yyPop, 5, 0);
   return 1;
-  l570:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l593:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Argument", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "AnonymousFunctionDecl"));  yyDo(G, yy_1_AnonymousFunctionDecl, G->begin, G->end);  if (!yy_FunctionDeclCore(G)) { goto l577; }
+  yyprintf((stderr, "%s\n", "AnonymousFunctionDecl"));  yyDo(G, yy_1_AnonymousFunctionDecl, G->begin, G->end);  if (!yy_FunctionDeclCore(G)) { goto l600; }
   yyprintf((stderr, "  ok   %s @ %s\n", "AnonymousFunctionDecl", G->buf+G->pos));
   return 1;
-  l577:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AnonymousFunctionDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "FunctionDeclCore"));  if (!yy__(G)) { goto l578; }  if (!yy_FUNC_KW(G)) { goto l578; }
-  {  int yypos579= G->pos, yythunkpos579= G->thunkpos;  if (!yymatchChar(G, '@')) goto l579;  yyDo(G, yy_1_FunctionDeclCore, G->begin, G->end);  goto l580;
-  l579:;	  G->pos= yypos579; G->thunkpos= yythunkpos579;
+  yyprintf((stderr, "%s\n", "FunctionDeclCore"));  if (!yy__(G)) { goto l601; }  if (!yy_FUNC_KW(G)) { goto l601; }
+  {  int yypos602= G->pos, yythunkpos602= G->thunkpos;  if (!yymatchChar(G, '@')) goto l602;  yyDo(G, yy_1_FunctionDeclCore, G->begin, G->end);  goto l603;
+  l602:;	  G->pos= yypos602; G->thunkpos= yythunkpos602;
   }
-  l580:;	
-  {  int yypos581= G->pos, yythunkpos581= G->thunkpos;  if (!yy__(G)) { goto l581; }  if (!yymatchChar(G, '~')) goto l581;  if (!yy_IDENT(G)) { goto l581; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_FunctionDeclCore, G->begin, G->end);  goto l582;
-  l581:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;
+  l603:;	
+  {  int yypos604= G->pos, yythunkpos604= G->thunkpos;  if (!yy__(G)) { goto l604; }  if (!yymatchChar(G, '~')) goto l604;  if (!yy_IDENT(G)) { goto l604; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_FunctionDeclCore, G->begin, G->end);  goto l605;
+  l604:;	  G->pos= yypos604; G->thunkpos= yythunkpos604;
   }
-  l582:;	  if (!yy_FunctionDeclBody(G)) { goto l578; }
+  l605:;	  if (!yy_FunctionDeclBody(G)) { goto l601; }
   yyprintf((stderr, "  ok   %s @ %s\n", "FunctionDeclCore", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l578:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l601:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FunctionDeclCore", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_PROTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "PROTO_KW"));  if (!yymatchString(G, "proto")) goto l583;
+  yyprintf((stderr, "%s\n", "PROTO_KW"));  if (!yymatchString(G, "proto")) goto l606;
   yyprintf((stderr, "  ok   %s @ %s\n", "PROTO_KW", G->buf+G->pos));
   return 1;
-  l583:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l606:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "PROTO_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_FINAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "FINAL_KW"));  if (!yymatchString(G, "final")) goto l584;
+  yyprintf((stderr, "%s\n", "FINAL_KW"));  if (!yymatchString(G, "final")) goto l607;
   yyprintf((stderr, "  ok   %s @ %s\n", "FINAL_KW", G->buf+G->pos));
   return 1;
-  l584:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l607:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FINAL_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_INLINE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "INLINE_KW"));  if (!yymatchString(G, "inline")) goto l585;
+  yyprintf((stderr, "%s\n", "INLINE_KW"));  if (!yymatchString(G, "inline")) goto l608;
   yyprintf((stderr, "  ok   %s @ %s\n", "INLINE_KW", G->buf+G->pos));
   return 1;
-  l585:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INLINE_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_STATIC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "STATIC_KW"));  if (!yymatchString(G, "static")) goto l586;
+  yyprintf((stderr, "%s\n", "STATIC_KW"));  if (!yymatchString(G, "static")) goto l609;
   yyprintf((stderr, "  ok   %s @ %s\n", "STATIC_KW", G->buf+G->pos));
   return 1;
-  l586:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l609:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "STATIC_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "ABSTRACT_KW"));  if (!yymatchString(G, "abstract")) goto l587;
+  yyprintf((stderr, "%s\n", "ABSTRACT_KW"));  if (!yymatchString(G, "abstract")) goto l610;
   yyprintf((stderr, "  ok   %s @ %s\n", "ABSTRACT_KW", G->buf+G->pos));
   return 1;
-  l587:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l610:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ABSTRACT_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_UnmangledName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "UnmangledName"));  if (!yy_UNMANGLED_KW(G)) { goto l588; }  yyDo(G, yy_1_UnmangledName, G->begin, G->end);
-  {  int yypos589= G->pos, yythunkpos589= G->thunkpos;  if (!yy__(G)) { goto l589; }  if (!yymatchChar(G, '(')) goto l589;  if (!yy__(G)) { goto l589; }  if (!yy_IDENT(G)) { goto l589; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_UnmangledName, G->begin, G->end);  if (!yy__(G)) { goto l589; }  if (!yymatchChar(G, ')')) goto l589;  goto l590;
-  l589:;	  G->pos= yypos589; G->thunkpos= yythunkpos589;
+  yyprintf((stderr, "%s\n", "UnmangledName"));  if (!yy_UNMANGLED_KW(G)) { goto l611; }  yyDo(G, yy_1_UnmangledName, G->begin, G->end);
+  {  int yypos612= G->pos, yythunkpos612= G->thunkpos;  if (!yy__(G)) { goto l612; }  if (!yymatchChar(G, '(')) goto l612;  if (!yy__(G)) { goto l612; }  if (!yy_IDENT(G)) { goto l612; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_UnmangledName, G->begin, G->end);  if (!yy__(G)) { goto l612; }  if (!yymatchChar(G, ')')) goto l612;  goto l613;
+  l612:;	  G->pos= yypos612; G->thunkpos= yythunkpos612;
   }
-  l590:;	
+  l613:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "UnmangledName", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l588:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l611:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "UnmangledName", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ExternName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "ExternName"));  if (!yy_EXTERN_KW(G)) { goto l591; }  yyDo(G, yy_1_ExternName, G->begin, G->end);
-  {  int yypos592= G->pos, yythunkpos592= G->thunkpos;  if (!yy__(G)) { goto l592; }  if (!yymatchChar(G, '(')) goto l592;  if (!yy__(G)) { goto l592; }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l592;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l592;
-  l594:;	
-  {  int yypos595= G->pos, yythunkpos595= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l595;  goto l594;
-  l595:;	  G->pos= yypos595; G->thunkpos= yythunkpos595;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l592;  yyDo(G, yy_2_ExternName, G->begin, G->end);  if (!yy__(G)) { goto l592; }  if (!yymatchChar(G, ')')) goto l592;  goto l593;
-  l592:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;
+  yyprintf((stderr, "%s\n", "ExternName"));  if (!yy_EXTERN_KW(G)) { goto l614; }  yyDo(G, yy_1_ExternName, G->begin, G->end);
+  {  int yypos615= G->pos, yythunkpos615= G->thunkpos;  if (!yy__(G)) { goto l615; }  if (!yymatchChar(G, '(')) goto l615;  if (!yy__(G)) { goto l615; }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l615;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l615;
+  l617:;	
+  {  int yypos618= G->pos, yythunkpos618= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l618;  goto l617;
+  l618:;	  G->pos= yypos618; G->thunkpos= yythunkpos618;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l615;  yyDo(G, yy_2_ExternName, G->begin, G->end);  if (!yy__(G)) { goto l615; }  if (!yymatchChar(G, ')')) goto l615;  goto l616;
+  l615:;	  G->pos= yypos615; G->thunkpos= yythunkpos615;
   }
-  l593:;	
+  l616:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "ExternName", G->buf+G->pos));
   return 1;
-  l591:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l614:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ExternName", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_OocDoc(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "OocDoc"));
-  {  int yypos597= G->pos, yythunkpos597= G->thunkpos;  if (!yymatchString(G, "/**")) goto l598;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l598;
-  l599:;	
-  {  int yypos600= G->pos, yythunkpos600= G->thunkpos;
-  {  int yypos601= G->pos, yythunkpos601= G->thunkpos;  if (!yymatchString(G, "*/")) goto l601;  goto l600;
-  l601:;	  G->pos= yypos601; G->thunkpos= yythunkpos601;
+  {  int yypos620= G->pos, yythunkpos620= G->thunkpos;  if (!yymatchString(G, "/**")) goto l621;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l621;
+  l622:;	
+  {  int yypos623= G->pos, yythunkpos623= G->thunkpos;
+  {  int yypos624= G->pos, yythunkpos624= G->thunkpos;  if (!yymatchString(G, "*/")) goto l624;  goto l623;
+  l624:;	  G->pos= yypos624; G->thunkpos= yythunkpos624;
   }
-  {  int yypos602= G->pos, yythunkpos602= G->thunkpos;  if (!yy_EOL(G)) { goto l603; }  goto l602;
-  l603:;	  G->pos= yypos602; G->thunkpos= yythunkpos602;  if (!yymatchDot(G)) goto l600;
+  {  int yypos625= G->pos, yythunkpos625= G->thunkpos;  if (!yy_EOL(G)) { goto l626; }  goto l625;
+  l626:;	  G->pos= yypos625; G->thunkpos= yythunkpos625;  if (!yymatchDot(G)) goto l623;
   }
-  l602:;	  goto l599;
-  l600:;	  G->pos= yypos600; G->thunkpos= yythunkpos600;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l598;  if (!yymatchString(G, "*/")) goto l598;  yyDo(G, yy_1_OocDoc, G->begin, G->end);  if (!yy_WS(G)) { goto l598; }  goto l597;
-  l598:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  if (!yymatchString(G, "///")) goto l604;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l604;
-  l605:;	
-  {  int yypos606= G->pos, yythunkpos606= G->thunkpos;
-  {  int yypos607= G->pos, yythunkpos607= G->thunkpos;  if (!yy_EOL(G)) { goto l607; }  goto l606;
-  l607:;	  G->pos= yypos607; G->thunkpos= yythunkpos607;
-  }  if (!yymatchDot(G)) goto l606;  goto l605;
-  l606:;	  G->pos= yypos606; G->thunkpos= yythunkpos606;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l604;  if (!yy_EOL(G)) { goto l604; }  yyDo(G, yy_2_OocDoc, G->begin, G->end);  if (!yy_WS(G)) { goto l604; }  goto l597;
-  l604:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  yyDo(G, yy_3_OocDoc, G->begin, G->end);
+  l625:;	  goto l622;
+  l623:;	  G->pos= yypos623; G->thunkpos= yythunkpos623;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l621;  if (!yymatchString(G, "*/")) goto l621;  yyDo(G, yy_1_OocDoc, G->begin, G->end);  if (!yy_WS(G)) { goto l621; }  goto l620;
+  l621:;	  G->pos= yypos620; G->thunkpos= yythunkpos620;  if (!yymatchString(G, "///")) goto l627;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l627;
+  l628:;	
+  {  int yypos629= G->pos, yythunkpos629= G->thunkpos;
+  {  int yypos630= G->pos, yythunkpos630= G->thunkpos;  if (!yy_EOL(G)) { goto l630; }  goto l629;
+  l630:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;
+  }  if (!yymatchDot(G)) goto l629;  goto l628;
+  l629:;	  G->pos= yypos629; G->thunkpos= yythunkpos629;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l627;  if (!yy_EOL(G)) { goto l627; }  yyDo(G, yy_2_OocDoc, G->begin, G->end);  if (!yy_WS(G)) { goto l627; }  goto l620;
+  l627:;	  G->pos= yypos620; G->thunkpos= yythunkpos620;  yyDo(G, yy_3_OocDoc, G->begin, G->end);
   }
-  l597:;	
+  l620:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "OocDoc", G->buf+G->pos));
   return 1;
-  l596:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l619:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OocDoc", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_FUNC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "FUNC_KW"));  if (!yymatchString(G, "func")) goto l608;
+  yyprintf((stderr, "%s\n", "FUNC_KW"));  if (!yymatchString(G, "func")) goto l631;
   yyprintf((stderr, "  ok   %s @ %s\n", "FUNC_KW", G->buf+G->pos));
   return 1;
-  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l631:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FUNC_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_COLON(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "COLON"));
-  {  int yypos610= G->pos, yythunkpos610= G->thunkpos;  if (!yy_ASS_DECL(G)) { goto l610; }  goto l609;
-  l610:;	  G->pos= yypos610; G->thunkpos= yythunkpos610;
-  }  if (!yymatchChar(G, ':')) goto l609;
+  {  int yypos633= G->pos, yythunkpos633= G->thunkpos;  if (!yy_ASS_DECL(G)) { goto l633; }  goto l632;
+  l633:;	  G->pos= yypos633; G->thunkpos= yythunkpos633;
+  }  if (!yymatchChar(G, ':')) goto l632;
   yyprintf((stderr, "  ok   %s @ %s\n", "COLON", G->buf+G->pos));
   return 1;
-  l609:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l632:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "COLON", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "RegularFunctionDecl"));  if (!yy_OocDoc(G)) { goto l611; }  yyDo(G, yySet, -4, 0);  if (!yy_IDENT(G)) { goto l611; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_RegularFunctionDecl, G->begin, G->end);  if (!yy__(G)) { goto l611; }  if (!yy_COLON(G)) { goto l611; }
-  l612:;	
-  {  int yypos613= G->pos, yythunkpos613= G->thunkpos;  if (!yy__(G)) { goto l613; }
-  {  int yypos614= G->pos, yythunkpos614= G->thunkpos;  if (!yy_ExternName(G)) { goto l615; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_RegularFunctionDecl, G->begin, G->end);  goto l614;
-  l615:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_UnmangledName(G)) { goto l616; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_RegularFunctionDecl, G->begin, G->end);  goto l614;
-  l616:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_ABSTRACT_KW(G)) { goto l617; }  yyDo(G, yy_4_RegularFunctionDecl, G->begin, G->end);  goto l614;
-  l617:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_STATIC_KW(G)) { goto l618; }  yyDo(G, yy_5_RegularFunctionDecl, G->begin, G->end);  goto l614;
-  l618:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_INLINE_KW(G)) { goto l619; }  yyDo(G, yy_6_RegularFunctionDecl, G->begin, G->end);  goto l614;
-  l619:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_FINAL_KW(G)) { goto l620; }  yyDo(G, yy_7_RegularFunctionDecl, G->begin, G->end);  goto l614;
-  l620:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_PROTO_KW(G)) { goto l613; }  yyDo(G, yy_8_RegularFunctionDecl, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "RegularFunctionDecl"));  if (!yy_OocDoc(G)) { goto l634; }  yyDo(G, yySet, -4, 0);  if (!yy_IDENT(G)) { goto l634; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_RegularFunctionDecl, G->begin, G->end);  if (!yy__(G)) { goto l634; }  if (!yy_COLON(G)) { goto l634; }
+  l635:;	
+  {  int yypos636= G->pos, yythunkpos636= G->thunkpos;  if (!yy__(G)) { goto l636; }
+  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;  if (!yy_ExternName(G)) { goto l638; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_RegularFunctionDecl, G->begin, G->end);  goto l637;
+  l638:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_UnmangledName(G)) { goto l639; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_RegularFunctionDecl, G->begin, G->end);  goto l637;
+  l639:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_ABSTRACT_KW(G)) { goto l640; }  yyDo(G, yy_4_RegularFunctionDecl, G->begin, G->end);  goto l637;
+  l640:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_STATIC_KW(G)) { goto l641; }  yyDo(G, yy_5_RegularFunctionDecl, G->begin, G->end);  goto l637;
+  l641:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_INLINE_KW(G)) { goto l642; }  yyDo(G, yy_6_RegularFunctionDecl, G->begin, G->end);  goto l637;
+  l642:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_FINAL_KW(G)) { goto l643; }  yyDo(G, yy_7_RegularFunctionDecl, G->begin, G->end);  goto l637;
+  l643:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_PROTO_KW(G)) { goto l636; }  yyDo(G, yy_8_RegularFunctionDecl, G->begin, G->end);
   }
-  l614:;	  goto l612;
-  l613:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;
-  }  if (!yy_FunctionDeclCore(G)) { goto l611; }
+  l637:;	  goto l635;
+  l636:;	  G->pos= yypos636; G->thunkpos= yythunkpos636;
+  }  if (!yy_FunctionDeclCore(G)) { goto l634; }
   yyprintf((stderr, "  ok   %s @ %s\n", "RegularFunctionDecl", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l611:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l634:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "RegularFunctionDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_SuperFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "SuperFunctionDecl"));  if (!yy_IDENT(G)) { goto l621; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l621; }  if (!yy_COLON(G)) { goto l621; }  if (!yy__(G)) { goto l621; }  if (!yymatchString(G, "super")) goto l621;  if (!yy__(G)) { goto l621; }  if (!yy_FUNC_KW(G)) { goto l621; }  if (!yy__(G)) { goto l621; }  yyDo(G, yy_1_SuperFunctionDecl, G->begin, G->end);
-  {  int yypos622= G->pos, yythunkpos622= G->thunkpos;  if (!yy__(G)) { goto l622; }  if (!yymatchChar(G, '~')) goto l622;  if (!yy_IDENT(G)) { goto l622; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_SuperFunctionDecl, G->begin, G->end);  goto l623;
-  l622:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;
+  yyprintf((stderr, "%s\n", "SuperFunctionDecl"));  if (!yy_IDENT(G)) { goto l644; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l644; }  if (!yy_COLON(G)) { goto l644; }  if (!yy__(G)) { goto l644; }  if (!yymatchString(G, "super")) goto l644;  if (!yy__(G)) { goto l644; }  if (!yy_FUNC_KW(G)) { goto l644; }  if (!yy__(G)) { goto l644; }  yyDo(G, yy_1_SuperFunctionDecl, G->begin, G->end);
+  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yy__(G)) { goto l645; }  if (!yymatchChar(G, '~')) goto l645;  if (!yy_IDENT(G)) { goto l645; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_SuperFunctionDecl, G->begin, G->end);  goto l646;
+  l645:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;
   }
-  l623:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end);
+  l646:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "SuperFunctionDecl", G->buf+G->pos));  yyDo(G, yyPop, 2, 0);
   return 1;
-  l621:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l644:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SuperFunctionDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "FunctionDeclBody"));
-  {  int yypos625= G->pos, yythunkpos625= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l625; }  goto l626;
-  l625:;	  G->pos= yypos625; G->thunkpos= yythunkpos625;
+  {  int yypos648= G->pos, yythunkpos648= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l648; }  goto l649;
+  l648:;	  G->pos= yypos648; G->thunkpos= yythunkpos648;
   }
-  l626:;	
-  {  int yypos627= G->pos, yythunkpos627= G->thunkpos;  if (!yy_WS(G)) { goto l627; }  if (!yymatchChar(G, '(')) goto l627;  yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end);
-  {  int yypos629= G->pos, yythunkpos629= G->thunkpos;  if (!yy_WS(G)) { goto l629; }  if (!yy_Argument(G)) { goto l629; }  if (!yy_WS(G)) { goto l629; }
-  l631:;	
-  {  int yypos632= G->pos, yythunkpos632= G->thunkpos;  if (!yymatchChar(G, ',')) goto l632;  if (!yy_WS(G)) { goto l632; }  if (!yy_Argument(G)) { goto l632; }  if (!yy_WS(G)) { goto l632; }  goto l631;
-  l632:;	  G->pos= yypos632; G->thunkpos= yythunkpos632;
-  }  goto l630;
-  l629:;	  G->pos= yypos629; G->thunkpos= yythunkpos629;
+  l649:;	
+  {  int yypos650= G->pos, yythunkpos650= G->thunkpos;  if (!yy_WS(G)) { goto l650; }  if (!yymatchChar(G, '(')) goto l650;  yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end);
+  {  int yypos652= G->pos, yythunkpos652= G->thunkpos;  if (!yy_WS(G)) { goto l652; }  if (!yy_Argument(G)) { goto l652; }  if (!yy_WS(G)) { goto l652; }
+  l654:;	
+  {  int yypos655= G->pos, yythunkpos655= G->thunkpos;  if (!yymatchChar(G, ',')) goto l655;  if (!yy_WS(G)) { goto l655; }  if (!yy_Argument(G)) { goto l655; }  if (!yy_WS(G)) { goto l655; }  goto l654;
+  l655:;	  G->pos= yypos655; G->thunkpos= yythunkpos655;
+  }  goto l653;
+  l652:;	  G->pos= yypos652; G->thunkpos= yythunkpos652;
   }
-  l630:;	  if (!yy_WS(G)) { goto l627; }  if (!yy_CLOS_PAREN(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n", G->pos + G->offset) ; } goto l627; }  yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end);  goto l628;
-  l627:;	  G->pos= yypos627; G->thunkpos= yythunkpos627;
+  l653:;	  if (!yy_WS(G)) { goto l650; }  if (!yy_CLOS_PAREN(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n", G->pos + G->offset) ; } goto l650; }  yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end);  goto l651;
+  l650:;	  G->pos= yypos650; G->thunkpos= yythunkpos650;
   }
-  l628:;	
-  {  int yypos633= G->pos, yythunkpos633= G->thunkpos;  if (!yy__(G)) { goto l633; }  if (!yymatchChar(G, '~')) goto l633;  if (!yy_IDENT(G)) { goto l633; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end);  goto l634;
-  l633:;	  G->pos= yypos633; G->thunkpos= yythunkpos633;
+  l651:;	
+  {  int yypos656= G->pos, yythunkpos656= G->thunkpos;  if (!yy__(G)) { goto l656; }  if (!yymatchChar(G, '~')) goto l656;  if (!yy_IDENT(G)) { goto l656; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end);  goto l657;
+  l656:;	  G->pos= yypos656; G->thunkpos= yythunkpos656;
   }
-  l634:;	
-  {  int yypos635= G->pos, yythunkpos635= G->thunkpos;  if (!yy__(G)) { goto l635; }  if (!yy_R_ARROW(G)) { goto l635; }  if (!yy__(G)) { goto l635; }  if (!yy_Type(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_RET_TYPE, "Missing return type.\n", G->pos + G->offset) ; } goto l635; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end);  goto l636;
-  l635:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;
+  l657:;	
+  {  int yypos658= G->pos, yythunkpos658= G->thunkpos;  if (!yy__(G)) { goto l658; }  if (!yy_R_ARROW(G)) { goto l658; }  if (!yy__(G)) { goto l658; }  if (!yy_Type(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_RET_TYPE, "Missing return type.\n", G->pos + G->offset) ; } goto l658; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end);  goto l659;
+  l658:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;
   }
-  l636:;	
-  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end);  if (!yy_WS(G)) { goto l637; }  if (!yymatchChar(G, '{')) goto l637;  if (!yy_WS(G)) { goto l637; }
-  l639:;	
-  {  int yypos640= G->pos, yythunkpos640= G->thunkpos;  if (!yy_WS(G)) { goto l640; }  if (!yy_Stmt(G)) { goto l640; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end);  if (!yy_WS(G)) { goto l640; }  goto l639;
-  l640:;	  G->pos= yypos640; G->thunkpos= yythunkpos640;
-  }  if (!yy_WS(G)) { goto l637; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; nq_error(core->this, NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n", G->pos + G->offset) ; } goto l637; }  goto l638;
-  l637:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;
+  l659:;	
+  {  int yypos660= G->pos, yythunkpos660= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end);  if (!yy_WS(G)) { goto l660; }  if (!yymatchChar(G, '{')) goto l660;  if (!yy_WS(G)) { goto l660; }
+  l662:;	
+  {  int yypos663= G->pos, yythunkpos663= G->thunkpos;  if (!yy_WS(G)) { goto l663; }  if (!yy_Stmt(G)) { goto l663; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end);  if (!yy_WS(G)) { goto l663; }  goto l662;
+  l663:;	  G->pos= yypos663; G->thunkpos= yythunkpos663;
+  }  if (!yy_WS(G)) { goto l660; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; nq_error(core->this, NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n", G->pos + G->offset) ; } goto l660; }  goto l661;
+  l660:;	  G->pos= yypos660; G->thunkpos= yythunkpos660;
   }
-  l638:;	  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end);
+  l661:;	  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "FunctionDeclBody", G->buf+G->pos));  yyDo(G, yyPop, 3, 0);
   return 1;
-  l624:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l647:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FunctionDeclBody", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "OPERATOR_KW"));  if (!yymatchString(G, "operator")) goto l641;
+  yyprintf((stderr, "%s\n", "OPERATOR_KW"));  if (!yymatchString(G, "operator")) goto l664;
   yyprintf((stderr, "  ok   %s @ %s\n", "OPERATOR_KW", G->buf+G->pos));
   return 1;
-  l641:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l664:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OPERATOR_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_MORETHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "MORETHAN"));  if (!yymatchChar(G, '>')) goto l642;
-  {  int yypos643= G->pos, yythunkpos643= G->thunkpos;  if (!yymatchChar(G, '=')) goto l643;  goto l642;
-  l643:;	  G->pos= yypos643; G->thunkpos= yythunkpos643;
-  }  if (!yy__(G)) { goto l642; }
+  yyprintf((stderr, "%s\n", "MORETHAN"));  if (!yymatchChar(G, '>')) goto l665;
+  {  int yypos666= G->pos, yythunkpos666= G->thunkpos;  if (!yymatchChar(G, '=')) goto l666;  goto l665;
+  l666:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;
+  }  if (!yy__(G)) { goto l665; }
   yyprintf((stderr, "  ok   %s @ %s\n", "MORETHAN", G->buf+G->pos));
   return 1;
-  l642:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l665:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MORETHAN", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_LESSTHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "LESSTHAN"));  if (!yymatchChar(G, '<')) goto l644;
-  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yymatchChar(G, '=')) goto l645;  goto l644;
-  l645:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;
-  }  if (!yy__(G)) { goto l644; }
+  yyprintf((stderr, "%s\n", "LESSTHAN"));  if (!yymatchChar(G, '<')) goto l667;
+  {  int yypos668= G->pos, yythunkpos668= G->thunkpos;  if (!yymatchChar(G, '=')) goto l668;  goto l667;
+  l668:;	  G->pos= yypos668; G->thunkpos= yythunkpos668;
+  }  if (!yy__(G)) { goto l667; }
   yyprintf((stderr, "  ok   %s @ %s\n", "LESSTHAN", G->buf+G->pos));
   return 1;
-  l644:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l667:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LESSTHAN", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_GenericArguments(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "GenericArguments"));  if (!yy__(G)) { goto l646; }  if (!yy_LESSTHAN(G)) { goto l646; }  if (!yy__(G)) { goto l646; }  if (!yy_IDENT(G)) { goto l646; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_GenericArguments, G->begin, G->end);
-  l647:;	
-  {  int yypos648= G->pos, yythunkpos648= G->thunkpos;  if (!yy__(G)) { goto l648; }  if (!yymatchChar(G, ',')) goto l648;  if (!yy__(G)) { goto l648; }  if (!yy_IDENT(G)) { goto l648; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_GenericArguments, G->begin, G->end);  goto l647;
-  l648:;	  G->pos= yypos648; G->thunkpos= yythunkpos648;
-  }  if (!yy_MORETHAN(G)) { goto l646; }  if (!yy__(G)) { goto l646; }
+  yyprintf((stderr, "%s\n", "GenericArguments"));  if (!yy__(G)) { goto l669; }  if (!yy_LESSTHAN(G)) { goto l669; }  if (!yy__(G)) { goto l669; }  if (!yy_IDENT(G)) { goto l669; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_GenericArguments, G->begin, G->end);
+  l670:;	
+  {  int yypos671= G->pos, yythunkpos671= G->thunkpos;  if (!yy__(G)) { goto l671; }  if (!yymatchChar(G, ',')) goto l671;  if (!yy__(G)) { goto l671; }  if (!yy_IDENT(G)) { goto l671; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_GenericArguments, G->begin, G->end);  goto l670;
+  l671:;	  G->pos= yypos671; G->thunkpos= yythunkpos671;
+  }  if (!yy_MORETHAN(G)) { goto l669; }  if (!yy__(G)) { goto l669; }
   yyprintf((stderr, "  ok   %s @ %s\n", "GenericArguments", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l646:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l669:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GenericArguments", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Terminator(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "Terminator"));
-  {  int yypos650= G->pos, yythunkpos650= G->thunkpos;  if (!yy_CommentLine(G)) { goto l651; }  goto l650;
-  l651:;	  G->pos= yypos650; G->thunkpos= yythunkpos650;
-  {  int yypos652= G->pos, yythunkpos652= G->thunkpos;  if (!yy_CommentMultiLine(G)) { goto l652; }  goto l653;
-  l652:;	  G->pos= yypos652; G->thunkpos= yythunkpos652;
+  {  int yypos673= G->pos, yythunkpos673= G->thunkpos;  if (!yy_CommentLine(G)) { goto l674; }  goto l673;
+  l674:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;
+  {  int yypos675= G->pos, yythunkpos675= G->thunkpos;  if (!yy_CommentMultiLine(G)) { goto l675; }  goto l676;
+  l675:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;
   }
-  l653:;	
-  {  int yypos654= G->pos, yythunkpos654= G->thunkpos;  if (!yy_EOL(G)) { goto l655; }  goto l654;
-  l655:;	  G->pos= yypos654; G->thunkpos= yythunkpos654;  if (!yymatchChar(G, ';')) goto l649;
+  l676:;	
+  {  int yypos677= G->pos, yythunkpos677= G->thunkpos;  if (!yy_EOL(G)) { goto l678; }  goto l677;
+  l678:;	  G->pos= yypos677; G->thunkpos= yythunkpos677;  if (!yymatchChar(G, ';')) goto l672;
   }
-  l654:;	
+  l677:;	
   }
-  l650:;	
+  l673:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Terminator", G->buf+G->pos));
   return 1;
-  l649:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l672:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Terminator", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_VariableDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "VariableDecl"));
-  {  int yypos657= G->pos, yythunkpos657= G->thunkpos;  if (!yy_VarDeclFromExpr(G)) { goto l658; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_VariableDecl, G->begin, G->end);  goto l657;
-  l658:;	  G->pos= yypos657; G->thunkpos= yythunkpos657;  if (!yy_ConventionalVarDecl(G)) { goto l656; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_VariableDecl, G->begin, G->end);
+  {  int yypos680= G->pos, yythunkpos680= G->thunkpos;  if (!yy_VarDeclFromExpr(G)) { goto l681; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_VariableDecl, G->begin, G->end);  goto l680;
+  l681:;	  G->pos= yypos680; G->thunkpos= yythunkpos680;  if (!yy_ConventionalVarDecl(G)) { goto l679; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_VariableDecl, G->begin, G->end);
   }
-  l657:;	
+  l680:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "VariableDecl", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l656:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l679:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VariableDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_PropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "PropertyDecl"));  if (!yy_OocDoc(G)) { goto l659; }  yyDo(G, yySet, -2, 0);  if (!yy_IDENT(G)) { goto l659; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_PropertyDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l659; }  if (!yy_COLON(G)) { goto l659; }  if (!yy_WS(G)) { goto l659; }
-  {  int yypos660= G->pos, yythunkpos660= G->thunkpos;  if (!yy_STATIC_KW(G)) { goto l660; }  yyDo(G, yy_2_PropertyDecl, G->begin, G->end);  goto l661;
-  l660:;	  G->pos= yypos660; G->thunkpos= yythunkpos660;
+  yyprintf((stderr, "%s\n", "PropertyDecl"));  if (!yy_OocDoc(G)) { goto l682; }  yyDo(G, yySet, -2, 0);  if (!yy_IDENT(G)) { goto l682; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_1_PropertyDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l682; }  if (!yy_COLON(G)) { goto l682; }  if (!yy_WS(G)) { goto l682; }
+  {  int yypos683= G->pos, yythunkpos683= G->thunkpos;  if (!yy_STATIC_KW(G)) { goto l683; }  yyDo(G, yy_2_PropertyDecl, G->begin, G->end);  goto l684;
+  l683:;	  G->pos= yypos683; G->thunkpos= yythunkpos683;
   }
-  l661:;	  if (!yy_WS(G)) { goto l659; }  if (!yy_Type(G)) { goto l659; }  yyDo(G, yy_3_PropertyDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l659; }  if (!yymatchChar(G, '{')) goto l659;  if (!yy_WS(G)) { goto l659; }  if (!yy_PropertyDeclCore(G)) { goto l659; }  if (!yy_WS(G)) { goto l659; }  if (!yymatchChar(G, '}')) goto l659;  if (!yy_WS(G)) { goto l659; }  yyDo(G, yy_4_PropertyDecl, G->begin, G->end);
+  l684:;	  if (!yy_WS(G)) { goto l682; }  if (!yy_Type(G)) { goto l682; }  yyDo(G, yy_3_PropertyDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l682; }  if (!yymatchChar(G, '{')) goto l682;  if (!yy_WS(G)) { goto l682; }  if (!yy_PropertyDeclCore(G)) { goto l682; }  if (!yy_WS(G)) { goto l682; }  if (!yymatchChar(G, '}')) goto l682;  if (!yy_WS(G)) { goto l682; }  yyDo(G, yy_4_PropertyDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "PropertyDecl", G->buf+G->pos));  yyDo(G, yyPop, 2, 0);
   return 1;
-  l659:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l682:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "PropertyDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_FunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "FunctionDecl"));
-  {  int yypos663= G->pos, yythunkpos663= G->thunkpos;  if (!yy_SuperFunctionDecl(G)) { goto l664; }  goto l663;
-  l664:;	  G->pos= yypos663; G->thunkpos= yythunkpos663;  if (!yy_RegularFunctionDecl(G)) { goto l662; }
+  {  int yypos686= G->pos, yythunkpos686= G->thunkpos;  if (!yy_SuperFunctionDecl(G)) { goto l687; }  goto l686;
+  l687:;	  G->pos= yypos686; G->thunkpos= yythunkpos686;  if (!yy_RegularFunctionDecl(G)) { goto l685; }
   }
-  l663:;	
+  l686:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "FunctionDecl", G->buf+G->pos));
   return 1;
-  l662:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l685:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FunctionDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_OperatorDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "OperatorDecl"));  if (!yy_OPERATOR_KW(G)) { goto l665; }  yyDo(G, yy_1_OperatorDecl, G->begin, G->end);  if (!yy__(G)) { goto l665; }  if (!yy__(G)) { goto l665; }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l665;
-  {  int yypos666= G->pos, yythunkpos666= G->thunkpos;  if (!yymatchString(G, "=>")) goto l667;  goto l666;
-  l667:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "<=>")) goto l668;  goto l666;
-  l668:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, ">>=")) goto l669;  goto l666;
-  l669:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "<<=")) goto l670;  goto l666;
-  l670:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, ">>")) goto l671;  goto l666;
-  l671:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "<<")) goto l672;  goto l666;
-  l672:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, ">=")) goto l673;  goto l666;
-  l673:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "<=")) goto l674;  goto l666;
-  l674:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "!=")) goto l675;  goto l666;
-  l675:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "==")) goto l676;  goto l666;
-  l676:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '>')) goto l677;  goto l666;
-  l677:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '<')) goto l678;  goto l666;
-  l678:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '!')) goto l679;  goto l666;
-  l679:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "+=")) goto l680;  goto l666;
-  l680:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "-=")) goto l681;  goto l666;
-  l681:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "*=")) goto l682;  goto l666;
-  l682:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "**=")) goto l683;  goto l666;
-  l683:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "/=")) goto l684;  goto l666;
-  l684:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '+')) goto l685;  goto l666;
-  l685:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '-')) goto l686;  goto l666;
-  l686:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "**")) goto l687;  goto l666;
-  l687:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '/')) goto l688;  goto l666;
-  l688:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '*')) goto l689;  goto l666;
-  l689:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '=')) goto l690;  goto l666;
-  l690:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "[]=")) goto l691;  goto l666;
-  l691:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "[]")) goto l692;  goto l666;
-  l692:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "&&")) goto l693;  goto l666;
-  l693:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "||")) goto l694;  goto l666;
-  l694:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '%')) goto l695;  goto l666;
-  l695:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "as")) goto l696;  goto l666;
-  l696:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "implicit as")) goto l697;  goto l666;
-  l697:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "&=")) goto l698;  goto l666;
-  l698:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "|=")) goto l699;  goto l666;
-  l699:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchString(G, "^=")) goto l700;  goto l666;
-  l700:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '&')) goto l701;  goto l666;
-  l701:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '|')) goto l702;  goto l666;
-  l702:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '^')) goto l703;  goto l666;
-  l703:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  if (!yymatchChar(G, '~')) goto l665;
+  yyprintf((stderr, "%s\n", "OperatorDecl"));  if (!yy_OPERATOR_KW(G)) { goto l688; }  yyDo(G, yy_1_OperatorDecl, G->begin, G->end);  if (!yy__(G)) { goto l688; }  if (!yy__(G)) { goto l688; }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l688;
+  {  int yypos689= G->pos, yythunkpos689= G->thunkpos;  if (!yymatchString(G, "=>")) goto l690;  goto l689;
+  l690:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "<=>")) goto l691;  goto l689;
+  l691:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, ">>=")) goto l692;  goto l689;
+  l692:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "<<=")) goto l693;  goto l689;
+  l693:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, ">>")) goto l694;  goto l689;
+  l694:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "<<")) goto l695;  goto l689;
+  l695:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, ">=")) goto l696;  goto l689;
+  l696:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "<=")) goto l697;  goto l689;
+  l697:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "!=")) goto l698;  goto l689;
+  l698:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "==")) goto l699;  goto l689;
+  l699:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '>')) goto l700;  goto l689;
+  l700:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '<')) goto l701;  goto l689;
+  l701:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '!')) goto l702;  goto l689;
+  l702:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "+=")) goto l703;  goto l689;
+  l703:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "-=")) goto l704;  goto l689;
+  l704:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "*=")) goto l705;  goto l689;
+  l705:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "**=")) goto l706;  goto l689;
+  l706:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "/=")) goto l707;  goto l689;
+  l707:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '+')) goto l708;  goto l689;
+  l708:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '-')) goto l709;  goto l689;
+  l709:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "**")) goto l710;  goto l689;
+  l710:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '/')) goto l711;  goto l689;
+  l711:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '*')) goto l712;  goto l689;
+  l712:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '=')) goto l713;  goto l689;
+  l713:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "[]=")) goto l714;  goto l689;
+  l714:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "[]")) goto l715;  goto l689;
+  l715:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "&&")) goto l716;  goto l689;
+  l716:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "||")) goto l717;  goto l689;
+  l717:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '%')) goto l718;  goto l689;
+  l718:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "as")) goto l719;  goto l689;
+  l719:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "implicit as")) goto l720;  goto l689;
+  l720:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "&=")) goto l721;  goto l689;
+  l721:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "|=")) goto l722;  goto l689;
+  l722:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchString(G, "^=")) goto l723;  goto l689;
+  l723:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '&')) goto l724;  goto l689;
+  l724:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '|')) goto l725;  goto l689;
+  l725:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '^')) goto l726;  goto l689;
+  l726:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  if (!yymatchChar(G, '~')) goto l688;
   }
-  l666:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l665;  yyDo(G, yy_2_OperatorDecl, G->begin, G->end);  if (!yy__(G)) { goto l665; }  if (!yy_FunctionDeclBody(G)) { goto l665; }  yyDo(G, yy_3_OperatorDecl, G->begin, G->end);
+  l689:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l688;  yyDo(G, yy_2_OperatorDecl, G->begin, G->end);  if (!yy__(G)) { goto l688; }  if (!yy_FunctionDeclBody(G)) { goto l688; }  yyDo(G, yy_3_OperatorDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OperatorDecl", G->buf+G->pos));
   return 1;
-  l665:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l688:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OperatorDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_InterfaceDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "InterfaceDecl"));  if (!yy_OocDoc(G)) { goto l704; }  yyDo(G, yySet, -4, 0);  if (!yy_IDENT(G)) { goto l704; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_InterfaceDecl, G->begin, G->end);  if (!yy__(G)) { goto l704; }  if (!yy_COLON(G)) { goto l704; }  if (!yy__(G)) { goto l704; }  if (!yy_INTERFACE_KW(G)) { goto l704; }
-  {  int yypos705= G->pos, yythunkpos705= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l705; }  goto l706;
-  l705:;	  G->pos= yypos705; G->thunkpos= yythunkpos705;
+  yyprintf((stderr, "%s\n", "InterfaceDecl"));  if (!yy_OocDoc(G)) { goto l727; }  yyDo(G, yySet, -4, 0);  if (!yy_IDENT(G)) { goto l727; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_1_InterfaceDecl, G->begin, G->end);  if (!yy__(G)) { goto l727; }  if (!yy_COLON(G)) { goto l727; }  if (!yy__(G)) { goto l727; }  if (!yy_INTERFACE_KW(G)) { goto l727; }
+  {  int yypos728= G->pos, yythunkpos728= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l728; }  goto l729;
+  l728:;	  G->pos= yypos728; G->thunkpos= yythunkpos728;
   }
-  l706:;	
-  {  int yypos707= G->pos, yythunkpos707= G->thunkpos;  if (!yy__(G)) { goto l707; }  if (!yy_EXTENDS_KW(G)) { goto l707; }  if (!yy__(G)) { goto l707; }  if (!yy_Type(G)) { goto l707; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_InterfaceDecl, G->begin, G->end);  goto l708;
-  l707:;	  G->pos= yypos707; G->thunkpos= yythunkpos707;
+  l729:;	
+  {  int yypos730= G->pos, yythunkpos730= G->thunkpos;  if (!yy__(G)) { goto l730; }  if (!yy_EXTENDS_KW(G)) { goto l730; }  if (!yy__(G)) { goto l730; }  if (!yy_Type(G)) { goto l730; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_2_InterfaceDecl, G->begin, G->end);  goto l731;
+  l730:;	  G->pos= yypos730; G->thunkpos= yythunkpos730;
   }
-  l708:;	
-  {  int yypos709= G->pos, yythunkpos709= G->thunkpos;  if (!yy__(G)) { goto l709; }  if (!yy_IMPLEMENTS_KW(G)) { goto l709; }  if (!yy__(G)) { goto l709; }  if (!yy_Type(G)) { goto l709; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_InterfaceDecl, G->begin, G->end);
-  l711:;	
-  {  int yypos712= G->pos, yythunkpos712= G->thunkpos;  if (!yy__(G)) { goto l712; }  if (!yymatchChar(G, ',')) goto l712;  if (!yy__(G)) { goto l712; }  if (!yy_Type(G)) { goto l712; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_InterfaceDecl, G->begin, G->end);  goto l711;
-  l712:;	  G->pos= yypos712; G->thunkpos= yythunkpos712;
-  }  goto l710;
-  l709:;	  G->pos= yypos709; G->thunkpos= yythunkpos709;
+  l731:;	
+  {  int yypos732= G->pos, yythunkpos732= G->thunkpos;  if (!yy__(G)) { goto l732; }  if (!yy_IMPLEMENTS_KW(G)) { goto l732; }  if (!yy__(G)) { goto l732; }  if (!yy_Type(G)) { goto l732; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_InterfaceDecl, G->begin, G->end);
+  l734:;	
+  {  int yypos735= G->pos, yythunkpos735= G->thunkpos;  if (!yy__(G)) { goto l735; }  if (!yymatchChar(G, ',')) goto l735;  if (!yy__(G)) { goto l735; }  if (!yy_Type(G)) { goto l735; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_4_InterfaceDecl, G->begin, G->end);  goto l734;
+  l735:;	  G->pos= yypos735; G->thunkpos= yythunkpos735;
+  }  goto l733;
+  l732:;	  G->pos= yypos732; G->thunkpos= yythunkpos732;
   }
-  l710:;	  if (!yy_WS(G)) { goto l704; }  if (!yymatchChar(G, '{')) goto l704;  if (!yy_WS(G)) { goto l704; }
-  l713:;	
-  {  int yypos714= G->pos, yythunkpos714= G->thunkpos;  if (!yy_WS(G)) { goto l714; }  if (!yy_FunctionDecl(G)) { goto l714; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l714; }  goto l713;
-  l714:;	  G->pos= yypos714; G->thunkpos= yythunkpos714;
-  }  if (!yy_WS(G)) { goto l704; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected function declaration\n", G->pos + G->offset); ; } goto l704; }  yyDo(G, yy_5_InterfaceDecl, G->begin, G->end);
+  l733:;	  if (!yy_WS(G)) { goto l727; }  if (!yymatchChar(G, '{')) goto l727;  if (!yy_WS(G)) { goto l727; }
+  l736:;	
+  {  int yypos737= G->pos, yythunkpos737= G->thunkpos;  if (!yy_WS(G)) { goto l737; }  if (!yy_FunctionDecl(G)) { goto l737; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l737; }  goto l736;
+  l737:;	  G->pos= yypos737; G->thunkpos= yythunkpos737;
+  }  if (!yy_WS(G)) { goto l727; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected function declaration\n", G->pos + G->offset); ; } goto l727; }  yyDo(G, yy_5_InterfaceDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "InterfaceDecl", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l704:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l727:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "InterfaceDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_EnumDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0);
-  yyprintf((stderr, "%s\n", "EnumDecl"));  if (!yy_OocDoc(G)) { goto l715; }  yyDo(G, yySet, -6, 0);  if (!yy_IDENT(G)) { goto l715; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_1_EnumDecl, G->begin, G->end);  if (!yy__(G)) { goto l715; }  if (!yy_COLON(G)) { goto l715; }
-  {  int yypos716= G->pos, yythunkpos716= G->thunkpos;  if (!yy__(G)) { goto l716; }  if (!yy_ExternName(G)) { goto l716; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_EnumDecl, G->begin, G->end);  goto l717;
-  l716:;	  G->pos= yypos716; G->thunkpos= yythunkpos716;
+  yyprintf((stderr, "%s\n", "EnumDecl"));  if (!yy_OocDoc(G)) { goto l738; }  yyDo(G, yySet, -6, 0);  if (!yy_IDENT(G)) { goto l738; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_1_EnumDecl, G->begin, G->end);  if (!yy__(G)) { goto l738; }  if (!yy_COLON(G)) { goto l738; }
+  {  int yypos739= G->pos, yythunkpos739= G->thunkpos;  if (!yy__(G)) { goto l739; }  if (!yy_ExternName(G)) { goto l739; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_2_EnumDecl, G->begin, G->end);  goto l740;
+  l739:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;
   }
-  l717:;	  if (!yy__(G)) { goto l715; }  if (!yy_ENUM_KW(G)) { goto l715; }
-  {  int yypos718= G->pos, yythunkpos718= G->thunkpos;  if (!yy__(G)) { goto l718; }  if (!yy_FROM_KW(G)) { goto l718; }  if (!yy__(G)) { goto l718; }  if (!yy_Type(G)) { goto l718; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_EnumDecl, G->begin, G->end);  goto l719;
-  l718:;	  G->pos= yypos718; G->thunkpos= yythunkpos718;
+  l740:;	  if (!yy__(G)) { goto l738; }  if (!yy_ENUM_KW(G)) { goto l738; }
+  {  int yypos741= G->pos, yythunkpos741= G->thunkpos;  if (!yy__(G)) { goto l741; }  if (!yy_FROM_KW(G)) { goto l741; }  if (!yy__(G)) { goto l741; }  if (!yy_Type(G)) { goto l741; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_3_EnumDecl, G->begin, G->end);  goto l742;
+  l741:;	  G->pos= yypos741; G->thunkpos= yythunkpos741;
   }
-  l719:;	
-  {  int yypos720= G->pos, yythunkpos720= G->thunkpos;  if (!yy__(G)) { goto l720; }  if (!yymatchChar(G, '(')) goto l720;  if (!yy__(G)) { goto l720; }  if (!yy_EnumIncrementOper(G)) { goto l720; }  yyDo(G, yySet, -2, 0);  if (!yy_WS(G)) { goto l720; }  if (!yy_IntLiteral(G)) { goto l720; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_4_EnumDecl, G->begin, G->end);  if (!yy__(G)) { goto l720; }  if (!yymatchChar(G, ')')) goto l720;  goto l721;
-  l720:;	  G->pos= yypos720; G->thunkpos= yythunkpos720;
+  l742:;	
+  {  int yypos743= G->pos, yythunkpos743= G->thunkpos;  if (!yy__(G)) { goto l743; }  if (!yymatchChar(G, '(')) goto l743;  if (!yy__(G)) { goto l743; }  if (!yy_EnumIncrementOper(G)) { goto l743; }  yyDo(G, yySet, -2, 0);  if (!yy_WS(G)) { goto l743; }  if (!yy_IntLiteral(G)) { goto l743; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_4_EnumDecl, G->begin, G->end);  if (!yy__(G)) { goto l743; }  if (!yymatchChar(G, ')')) goto l743;  goto l744;
+  l743:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;
   }
-  l721:;	  if (!yy_WS(G)) { goto l715; }  if (!yymatchChar(G, '{')) goto l715;  if (!yy_WS(G)) { goto l715; }
-  {  int yypos722= G->pos, yythunkpos722= G->thunkpos;  if (!yy_EnumElement(G)) { goto l722; }
-  l724:;	
-  {  int yypos725= G->pos, yythunkpos725= G->thunkpos;
-  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yy_Terminator(G)) { goto l727; }
-  l728:;	
-  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;  if (!yy_Terminator(G)) { goto l729; }  goto l728;
-  l729:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;
-  }  if (!yy_WS(G)) { goto l727; }  if (!yy_FunctionDecl(G)) { goto l727; }  goto l726;
-  l727:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;
-  {  int yypos730= G->pos, yythunkpos730= G->thunkpos;  if (!yymatchChar(G, ',')) goto l731;  goto l730;
-  l731:;	  G->pos= yypos730; G->thunkpos= yythunkpos730;  if (!yy_Terminator(G)) { goto l725; }
-  l732:;	
-  {  int yypos733= G->pos, yythunkpos733= G->thunkpos;  if (!yy_Terminator(G)) { goto l733; }  goto l732;
-  l733:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;
+  l744:;	  if (!yy_WS(G)) { goto l738; }  if (!yymatchChar(G, '{')) goto l738;  if (!yy_WS(G)) { goto l738; }
+  {  int yypos745= G->pos, yythunkpos745= G->thunkpos;  if (!yy_EnumElement(G)) { goto l745; }
+  l747:;	
+  {  int yypos748= G->pos, yythunkpos748= G->thunkpos;
+  {  int yypos749= G->pos, yythunkpos749= G->thunkpos;  if (!yy_Terminator(G)) { goto l750; }
+  l751:;	
+  {  int yypos752= G->pos, yythunkpos752= G->thunkpos;  if (!yy_Terminator(G)) { goto l752; }  goto l751;
+  l752:;	  G->pos= yypos752; G->thunkpos= yythunkpos752;
+  }  if (!yy_WS(G)) { goto l750; }  if (!yy_FunctionDecl(G)) { goto l750; }  goto l749;
+  l750:;	  G->pos= yypos749; G->thunkpos= yythunkpos749;
+  {  int yypos753= G->pos, yythunkpos753= G->thunkpos;  if (!yymatchChar(G, ',')) goto l754;  goto l753;
+  l754:;	  G->pos= yypos753; G->thunkpos= yythunkpos753;  if (!yy_Terminator(G)) { goto l748; }
+  l755:;	
+  {  int yypos756= G->pos, yythunkpos756= G->thunkpos;  if (!yy_Terminator(G)) { goto l756; }  goto l755;
+  l756:;	  G->pos= yypos756; G->thunkpos= yythunkpos756;
   }
   }
-  l730:;	  if (!yy_WS(G)) { goto l725; }  if (!yy_EnumElement(G)) { goto l725; }
+  l753:;	  if (!yy_WS(G)) { goto l748; }  if (!yy_EnumElement(G)) { goto l748; }
   }
-  l726:;	  goto l724;
-  l725:;	  G->pos= yypos725; G->thunkpos= yythunkpos725;
-  }  goto l723;
-  l722:;	  G->pos= yypos722; G->thunkpos= yythunkpos722;
+  l749:;	  goto l747;
+  l748:;	  G->pos= yypos748; G->thunkpos= yythunkpos748;
+  }  goto l746;
+  l745:;	  G->pos= yypos745; G->thunkpos= yythunkpos745;
   }
-  l723:;	  if (!yy_WS(G)) { goto l715; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected enum element!\n", G->pos + G->offset); ; } goto l715; }  yyDo(G, yy_5_EnumDecl, G->begin, G->end);
+  l746:;	  if (!yy_WS(G)) { goto l738; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected enum element!\n", G->pos + G->offset); ; } goto l738; }  yyDo(G, yy_5_EnumDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "EnumDecl", G->buf+G->pos));  yyDo(G, yyPop, 6, 0);
   return 1;
-  l715:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l738:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EnumDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ExtendDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "ExtendDecl"));  if (!yy_OocDoc(G)) { goto l734; }  yyDo(G, yySet, -3, 0);  if (!yymatchString(G, "extend")) goto l734;  if (!yy_WS(G)) { goto l734; }  if (!yy_Type(G)) { goto l734; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_1_ExtendDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l734; }  if (!yymatchChar(G, '{')) goto l734;  if (!yy_WS(G)) { goto l734; }
-  l735:;	
-  {  int yypos736= G->pos, yythunkpos736= G->thunkpos;  if (!yy_WS(G)) { goto l736; }  if (!yy_FunctionDecl(G)) { goto l736; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l736; }  goto l735;
-  l736:;	  G->pos= yypos736; G->thunkpos= yythunkpos736;
-  }  if (!yy_WS(G)) { goto l734; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n", G->pos + G->offset); ; } goto l734; }  yyDo(G, yy_2_ExtendDecl, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "ExtendDecl"));  if (!yy_OocDoc(G)) { goto l757; }  yyDo(G, yySet, -3, 0);  if (!yymatchString(G, "extend")) goto l757;  if (!yy_WS(G)) { goto l757; }  if (!yy_Type(G)) { goto l757; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_1_ExtendDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l757; }  if (!yymatchChar(G, '{')) goto l757;  if (!yy_WS(G)) { goto l757; }
+  l758:;	
+  {  int yypos759= G->pos, yythunkpos759= G->thunkpos;  if (!yy_WS(G)) { goto l759; }  if (!yy_FunctionDecl(G)) { goto l759; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l759; }  goto l758;
+  l759:;	  G->pos= yypos759; G->thunkpos= yythunkpos759;
+  }  if (!yy_WS(G)) { goto l757; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n", G->pos + G->offset); ; } goto l757; }  yyDo(G, yy_2_ExtendDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ExtendDecl", G->buf+G->pos));  yyDo(G, yyPop, 3, 0);
   return 1;
-  l734:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l757:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ExtendDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_CoverDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 7, 0);
-  yyprintf((stderr, "%s\n", "CoverDecl"));  if (!yy_OocDoc(G)) { goto l737; }  yyDo(G, yySet, -7, 0);  if (!yy_IDENT(G)) { goto l737; }  yyDo(G, yySet, -6, 0);  yyDo(G, yy_1_CoverDecl, G->begin, G->end);  if (!yy__(G)) { goto l737; }  if (!yy_COLON(G)) { goto l737; }
-  {  int yypos738= G->pos, yythunkpos738= G->thunkpos;  if (!yy__(G)) { goto l738; }  if (!yy_ExternName(G)) { goto l738; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_2_CoverDecl, G->begin, G->end);  goto l739;
-  l738:;	  G->pos= yypos738; G->thunkpos= yythunkpos738;
+  yyprintf((stderr, "%s\n", "CoverDecl"));  if (!yy_OocDoc(G)) { goto l760; }  yyDo(G, yySet, -7, 0);  if (!yy_IDENT(G)) { goto l760; }  yyDo(G, yySet, -6, 0);  yyDo(G, yy_1_CoverDecl, G->begin, G->end);  if (!yy__(G)) { goto l760; }  if (!yy_COLON(G)) { goto l760; }
+  {  int yypos761= G->pos, yythunkpos761= G->thunkpos;  if (!yy__(G)) { goto l761; }  if (!yy_ExternName(G)) { goto l761; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_2_CoverDecl, G->begin, G->end);  goto l762;
+  l761:;	  G->pos= yypos761; G->thunkpos= yythunkpos761;
   }
-  l739:;	  if (!yy__(G)) { goto l737; }  if (!yy_COVER_KW(G)) { goto l737; }
-  {  int yypos740= G->pos, yythunkpos740= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l740; }  goto l741;
-  l740:;	  G->pos= yypos740; G->thunkpos= yythunkpos740;
+  l762:;	  if (!yy__(G)) { goto l760; }  if (!yy_COVER_KW(G)) { goto l760; }
+  {  int yypos763= G->pos, yythunkpos763= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l763; }  goto l764;
+  l763:;	  G->pos= yypos763; G->thunkpos= yythunkpos763;
   }
-  l741:;	
-  {  int yypos742= G->pos, yythunkpos742= G->thunkpos;  if (!yy__(G)) { goto l742; }  if (!yy_FROM_KW(G)) { goto l742; }  if (!yy__(G)) { goto l742; }  if (!yy_Type(G)) { goto l742; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_3_CoverDecl, G->begin, G->end);  goto l743;
-  l742:;	  G->pos= yypos742; G->thunkpos= yythunkpos742;
+  l764:;	
+  {  int yypos765= G->pos, yythunkpos765= G->thunkpos;  if (!yy__(G)) { goto l765; }  if (!yy_FROM_KW(G)) { goto l765; }  if (!yy__(G)) { goto l765; }  if (!yy_Type(G)) { goto l765; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_3_CoverDecl, G->begin, G->end);  goto l766;
+  l765:;	  G->pos= yypos765; G->thunkpos= yythunkpos765;
   }
-  l743:;	
-  {  int yypos744= G->pos, yythunkpos744= G->thunkpos;  if (!yy__(G)) { goto l744; }  if (!yy_EXTENDS_KW(G)) { goto l744; }  if (!yy__(G)) { goto l744; }  if (!yy_Type(G)) { goto l744; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_4_CoverDecl, G->begin, G->end);  goto l745;
-  l744:;	  G->pos= yypos744; G->thunkpos= yythunkpos744;
+  l766:;	
+  {  int yypos767= G->pos, yythunkpos767= G->thunkpos;  if (!yy__(G)) { goto l767; }  if (!yy_EXTENDS_KW(G)) { goto l767; }  if (!yy__(G)) { goto l767; }  if (!yy_Type(G)) { goto l767; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_4_CoverDecl, G->begin, G->end);  goto l768;
+  l767:;	  G->pos= yypos767; G->thunkpos= yythunkpos767;
   }
-  l745:;	
-  {  int yypos746= G->pos, yythunkpos746= G->thunkpos;  if (!yy__(G)) { goto l746; }  if (!yy_IMPLEMENTS_KW(G)) { goto l746; }  if (!yy__(G)) { goto l746; }  if (!yy_Type(G)) { goto l746; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_5_CoverDecl, G->begin, G->end);
-  l748:;	
-  {  int yypos749= G->pos, yythunkpos749= G->thunkpos;  if (!yy__(G)) { goto l749; }  if (!yymatchChar(G, ',')) goto l749;  if (!yy__(G)) { goto l749; }  if (!yy_Type(G)) { goto l749; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_6_CoverDecl, G->begin, G->end);  goto l748;
-  l749:;	  G->pos= yypos749; G->thunkpos= yythunkpos749;
-  }  goto l747;
-  l746:;	  G->pos= yypos746; G->thunkpos= yythunkpos746;
+  l768:;	
+  {  int yypos769= G->pos, yythunkpos769= G->thunkpos;  if (!yy__(G)) { goto l769; }  if (!yy_IMPLEMENTS_KW(G)) { goto l769; }  if (!yy__(G)) { goto l769; }  if (!yy_Type(G)) { goto l769; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_5_CoverDecl, G->begin, G->end);
+  l771:;	
+  {  int yypos772= G->pos, yythunkpos772= G->thunkpos;  if (!yy__(G)) { goto l772; }  if (!yymatchChar(G, ',')) goto l772;  if (!yy__(G)) { goto l772; }  if (!yy_Type(G)) { goto l772; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_6_CoverDecl, G->begin, G->end);  goto l771;
+  l772:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;
+  }  goto l770;
+  l769:;	  G->pos= yypos769; G->thunkpos= yythunkpos769;
   }
-  l747:;	
-  {  int yypos750= G->pos, yythunkpos750= G->thunkpos;  if (!yy_WS(G)) { goto l750; }  if (!yymatchChar(G, '{')) goto l750;  if (!yy_WS(G)) { goto l750; }
-  l752:;	
-  {  int yypos753= G->pos, yythunkpos753= G->thunkpos;  if (!yy_WS(G)) { goto l753; }
-  {  int yypos754= G->pos, yythunkpos754= G->thunkpos;  if (!yy_VariableDecl(G)) { goto l755; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_7_CoverDecl, G->begin, G->end);  if (!yy_Terminator(G)) { goto l755; }
-  l756:;	
-  {  int yypos757= G->pos, yythunkpos757= G->thunkpos;  if (!yy_Terminator(G)) { goto l757; }  goto l756;
-  l757:;	  G->pos= yypos757; G->thunkpos= yythunkpos757;
-  }  goto l754;
-  l755:;	  G->pos= yypos754; G->thunkpos= yythunkpos754;  if (!yy_PropertyDecl(G)) { goto l758; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_8_CoverDecl, G->begin, G->end);  goto l754;
-  l758:;	  G->pos= yypos754; G->thunkpos= yythunkpos754;  if (!yy_FunctionDecl(G)) { goto l753; }  yyDo(G, yySet, -1, 0);
+  l770:;	
+  {  int yypos773= G->pos, yythunkpos773= G->thunkpos;  if (!yy_WS(G)) { goto l773; }  if (!yymatchChar(G, '{')) goto l773;  if (!yy_WS(G)) { goto l773; }
+  l775:;	
+  {  int yypos776= G->pos, yythunkpos776= G->thunkpos;  if (!yy_WS(G)) { goto l776; }
+  {  int yypos777= G->pos, yythunkpos777= G->thunkpos;  if (!yy_VariableDecl(G)) { goto l778; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_7_CoverDecl, G->begin, G->end);  if (!yy_Terminator(G)) { goto l778; }
+  l779:;	
+  {  int yypos780= G->pos, yythunkpos780= G->thunkpos;  if (!yy_Terminator(G)) { goto l780; }  goto l779;
+  l780:;	  G->pos= yypos780; G->thunkpos= yythunkpos780;
+  }  goto l777;
+  l778:;	  G->pos= yypos777; G->thunkpos= yythunkpos777;  if (!yy_PropertyDecl(G)) { goto l781; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_8_CoverDecl, G->begin, G->end);  goto l777;
+  l781:;	  G->pos= yypos777; G->thunkpos= yythunkpos777;  if (!yy_FunctionDecl(G)) { goto l776; }  yyDo(G, yySet, -1, 0);
   }
-  l754:;	  if (!yy_WS(G)) { goto l753; }  goto l752;
-  l753:;	  G->pos= yypos753; G->thunkpos= yythunkpos753;
-  }  if (!yy_WS(G)) { goto l750; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n", G->pos + G->offset); ; } goto l750; }  goto l751;
-  l750:;	  G->pos= yypos750; G->thunkpos= yythunkpos750;
+  l777:;	  if (!yy_WS(G)) { goto l776; }  goto l775;
+  l776:;	  G->pos= yypos776; G->thunkpos= yythunkpos776;
+  }  if (!yy_WS(G)) { goto l773; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n", G->pos + G->offset); ; } goto l773; }  goto l774;
+  l773:;	  G->pos= yypos773; G->thunkpos= yythunkpos773;
   }
-  l751:;	  yyDo(G, yy_9_CoverDecl, G->begin, G->end);
+  l774:;	  yyDo(G, yy_9_CoverDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "CoverDecl", G->buf+G->pos));  yyDo(G, yyPop, 7, 0);
   return 1;
-  l737:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l760:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CoverDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ClassDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 7, 0);
-  yyprintf((stderr, "%s\n", "ClassDecl"));  if (!yy_OocDoc(G)) { goto l759; }  yyDo(G, yySet, -7, 0);  if (!yy_IDENT(G)) { goto l759; }  yyDo(G, yySet, -6, 0);  yyDo(G, yy_1_ClassDecl, G->begin, G->end);  if (!yy__(G)) { goto l759; }  if (!yy_COLON(G)) { goto l759; }
-  l760:;	
-  {  int yypos761= G->pos, yythunkpos761= G->thunkpos;  if (!yy__(G)) { goto l761; }
-  {  int yypos762= G->pos, yythunkpos762= G->thunkpos;  if (!yy_ExternName(G)) { goto l763; }  goto l762;
-  l763:;	  G->pos= yypos762; G->thunkpos= yythunkpos762;  if (!yy_ABSTRACT_KW(G)) { goto l764; }  yyDo(G, yy_2_ClassDecl, G->begin, G->end);  goto l762;
-  l764:;	  G->pos= yypos762; G->thunkpos= yythunkpos762;  if (!yy_FINAL_KW(G)) { goto l761; }  yyDo(G, yy_3_ClassDecl, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "ClassDecl"));  if (!yy_OocDoc(G)) { goto l782; }  yyDo(G, yySet, -7, 0);  if (!yy_IDENT(G)) { goto l782; }  yyDo(G, yySet, -6, 0);  yyDo(G, yy_1_ClassDecl, G->begin, G->end);  if (!yy__(G)) { goto l782; }  if (!yy_COLON(G)) { goto l782; }
+  l783:;	
+  {  int yypos784= G->pos, yythunkpos784= G->thunkpos;  if (!yy__(G)) { goto l784; }
+  {  int yypos785= G->pos, yythunkpos785= G->thunkpos;  if (!yy_ExternName(G)) { goto l786; }  goto l785;
+  l786:;	  G->pos= yypos785; G->thunkpos= yythunkpos785;  if (!yy_ABSTRACT_KW(G)) { goto l787; }  yyDo(G, yy_2_ClassDecl, G->begin, G->end);  goto l785;
+  l787:;	  G->pos= yypos785; G->thunkpos= yythunkpos785;  if (!yy_FINAL_KW(G)) { goto l784; }  yyDo(G, yy_3_ClassDecl, G->begin, G->end);
   }
-  l762:;	  goto l760;
-  l761:;	  G->pos= yypos761; G->thunkpos= yythunkpos761;
-  }  if (!yy__(G)) { goto l759; }  if (!yy_CLASS_KW(G)) { goto l759; }
-  {  int yypos765= G->pos, yythunkpos765= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l765; }  goto l766;
-  l765:;	  G->pos= yypos765; G->thunkpos= yythunkpos765;
+  l785:;	  goto l783;
+  l784:;	  G->pos= yypos784; G->thunkpos= yythunkpos784;
+  }  if (!yy__(G)) { goto l782; }  if (!yy_CLASS_KW(G)) { goto l782; }
+  {  int yypos788= G->pos, yythunkpos788= G->thunkpos;  if (!yy_GenericArguments(G)) { goto l788; }  goto l789;
+  l788:;	  G->pos= yypos788; G->thunkpos= yythunkpos788;
   }
-  l766:;	
-  {  int yypos767= G->pos, yythunkpos767= G->thunkpos;  if (!yy__(G)) { goto l767; }  if (!yy_EXTENDS_KW(G)) { goto l767; }  if (!yy__(G)) { goto l767; }  if (!yy_Type(G)) { goto l767; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_4_ClassDecl, G->begin, G->end);  goto l768;
-  l767:;	  G->pos= yypos767; G->thunkpos= yythunkpos767;
+  l789:;	
+  {  int yypos790= G->pos, yythunkpos790= G->thunkpos;  if (!yy__(G)) { goto l790; }  if (!yy_EXTENDS_KW(G)) { goto l790; }  if (!yy__(G)) { goto l790; }  if (!yy_Type(G)) { goto l790; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_4_ClassDecl, G->begin, G->end);  goto l791;
+  l790:;	  G->pos= yypos790; G->thunkpos= yythunkpos790;
   }
-  l768:;	
-  {  int yypos769= G->pos, yythunkpos769= G->thunkpos;  if (!yy__(G)) { goto l769; }  if (!yy_IMPLEMENTS_KW(G)) { goto l769; }  if (!yy__(G)) { goto l769; }  if (!yy_Type(G)) { goto l769; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_5_ClassDecl, G->begin, G->end);
-  l771:;	
-  {  int yypos772= G->pos, yythunkpos772= G->thunkpos;  if (!yy__(G)) { goto l772; }  if (!yymatchChar(G, ',')) goto l772;  if (!yy__(G)) { goto l772; }  if (!yy_Type(G)) { goto l772; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_6_ClassDecl, G->begin, G->end);  goto l771;
-  l772:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;
-  }  goto l770;
-  l769:;	  G->pos= yypos769; G->thunkpos= yythunkpos769;
+  l791:;	
+  {  int yypos792= G->pos, yythunkpos792= G->thunkpos;  if (!yy__(G)) { goto l792; }  if (!yy_IMPLEMENTS_KW(G)) { goto l792; }  if (!yy__(G)) { goto l792; }  if (!yy_Type(G)) { goto l792; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_5_ClassDecl, G->begin, G->end);
+  l794:;	
+  {  int yypos795= G->pos, yythunkpos795= G->thunkpos;  if (!yy__(G)) { goto l795; }  if (!yymatchChar(G, ',')) goto l795;  if (!yy__(G)) { goto l795; }  if (!yy_Type(G)) { goto l795; }  yyDo(G, yySet, -5, 0);  yyDo(G, yy_6_ClassDecl, G->begin, G->end);  goto l794;
+  l795:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;
+  }  goto l793;
+  l792:;	  G->pos= yypos792; G->thunkpos= yythunkpos792;
   }
-  l770:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l759; }  if (!yymatchChar(G, '{')) goto l759;  if (!yy_WS(G)) { goto l759; }
-  l773:;	
-  {  int yypos774= G->pos, yythunkpos774= G->thunkpos;  if (!yy_WS(G)) { goto l774; }
-  {  int yypos775= G->pos, yythunkpos775= G->thunkpos;  if (!yy_VariableDecl(G)) { goto l776; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_8_ClassDecl, G->begin, G->end);  if (!yy_Terminator(G)) { goto l776; }
-  l777:;	
-  {  int yypos778= G->pos, yythunkpos778= G->thunkpos;  if (!yy_Terminator(G)) { goto l778; }  goto l777;
-  l778:;	  G->pos= yypos778; G->thunkpos= yythunkpos778;
-  }  goto l775;
-  l776:;	  G->pos= yypos775; G->thunkpos= yythunkpos775;  if (!yy_PropertyDecl(G)) { goto l779; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_9_ClassDecl, G->begin, G->end);  goto l775;
-  l779:;	  G->pos= yypos775; G->thunkpos= yythunkpos775;  if (!yy_FunctionDecl(G)) { goto l780; }  yyDo(G, yySet, -2, 0);  goto l775;
-  l780:;	  G->pos= yypos775; G->thunkpos= yythunkpos775;  if (!yy_Stmt(G)) { goto l774; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_10_ClassDecl, G->begin, G->end);
+  l793:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end);  if (!yy_WS(G)) { goto l782; }  if (!yymatchChar(G, '{')) goto l782;  if (!yy_WS(G)) { goto l782; }
+  l796:;	
+  {  int yypos797= G->pos, yythunkpos797= G->thunkpos;  if (!yy_WS(G)) { goto l797; }
+  {  int yypos798= G->pos, yythunkpos798= G->thunkpos;  if (!yy_VariableDecl(G)) { goto l799; }  yyDo(G, yySet, -4, 0);  yyDo(G, yy_8_ClassDecl, G->begin, G->end);  if (!yy_Terminator(G)) { goto l799; }
+  l800:;	
+  {  int yypos801= G->pos, yythunkpos801= G->thunkpos;  if (!yy_Terminator(G)) { goto l801; }  goto l800;
+  l801:;	  G->pos= yypos801; G->thunkpos= yythunkpos801;
+  }  goto l798;
+  l799:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;  if (!yy_PropertyDecl(G)) { goto l802; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_9_ClassDecl, G->begin, G->end);  goto l798;
+  l802:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;  if (!yy_FunctionDecl(G)) { goto l803; }  yyDo(G, yySet, -2, 0);  goto l798;
+  l803:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;  if (!yy_Stmt(G)) { goto l797; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_10_ClassDecl, G->begin, G->end);
   }
-  l775:;	  if (!yy_WS(G)) { goto l774; }  goto l773;
-  l774:;	  G->pos= yypos774; G->thunkpos= yythunkpos774;
-  }  if (!yy_WS(G)) { goto l759; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n", G->pos + G->offset); ; } goto l759; }  yyDo(G, yy_11_ClassDecl, G->begin, G->end);
+  l798:;	  if (!yy_WS(G)) { goto l797; }  goto l796;
+  l797:;	  G->pos= yypos797; G->thunkpos= yythunkpos797;
+  }  if (!yy_WS(G)) { goto l782; }  if (!yy_CLOS_BRACK(G)) { { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  nq_error(core->this, NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n", G->pos + G->offset); ; } goto l782; }  yyDo(G, yy_11_ClassDecl, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ClassDecl", G->buf+G->pos));  yyDo(G, yyPop, 7, 0);
   return 1;
-  l759:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l782:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ClassDecl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_IDENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "IDENT"));  if (!yy_IDENT_CORE(G)) { goto l781; }  yyDo(G, yySet, 0, 0);  if (!yy__(G)) { goto l781; }
+  yyprintf((stderr, "%s\n", "IDENT"));  if (!yy_IDENT_CORE(G)) { goto l804; }  yyDo(G, yySet, 0, 0);  if (!yy__(G)) { goto l804; }
   yyprintf((stderr, "  ok   %s @ %s\n", "IDENT", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l781:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l804:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IDENT", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_INTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "INTO_KW"));  if (!yymatchString(G, "into")) goto l782;
+  yyprintf((stderr, "%s\n", "INTO_KW"));  if (!yymatchString(G, "into")) goto l805;
   yyprintf((stderr, "  ok   %s @ %s\n", "INTO_KW", G->buf+G->pos));
   return 1;
-  l782:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l805:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INTO_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ImportName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "ImportName"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l783;
-  {  int yypos786= G->pos, yythunkpos786= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l787;  goto l786;
-  l787:;	  G->pos= yypos786; G->thunkpos= yythunkpos786;  if (!yymatchChar(G, '-')) goto l783;
+  yyprintf((stderr, "%s\n", "ImportName"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l806;
+  {  int yypos809= G->pos, yythunkpos809= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l810;  goto l809;
+  l810:;	  G->pos= yypos809; G->thunkpos= yythunkpos809;  if (!yymatchChar(G, '-')) goto l806;
   }
-  l786:;	
-  l784:;	
-  {  int yypos785= G->pos, yythunkpos785= G->thunkpos;
-  {  int yypos788= G->pos, yythunkpos788= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l789;  goto l788;
-  l789:;	  G->pos= yypos788; G->thunkpos= yythunkpos788;  if (!yymatchChar(G, '-')) goto l785;
+  l809:;	
+  l807:;	
+  {  int yypos808= G->pos, yythunkpos808= G->thunkpos;
+  {  int yypos811= G->pos, yythunkpos811= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l812;  goto l811;
+  l812:;	  G->pos= yypos811; G->thunkpos= yythunkpos811;  if (!yymatchChar(G, '-')) goto l808;
   }
-  l788:;	  goto l784;
-  l785:;	  G->pos= yypos785; G->thunkpos= yythunkpos785;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l783;  yyDo(G, yy_1_ImportName, G->begin, G->end);
+  l811:;	  goto l807;
+  l808:;	  G->pos= yypos808; G->thunkpos= yythunkpos808;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l806;  yyDo(G, yy_1_ImportName, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ImportName", G->buf+G->pos));
   return 1;
-  l783:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l806:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ImportName", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ImportPath(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "ImportPath"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l790;
-  l791:;	
-  {  int yypos792= G->pos, yythunkpos792= G->thunkpos;
-  {  int yypos795= G->pos, yythunkpos795= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l796;  goto l795;
-  l796:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;  if (!yymatchChar(G, '.')) goto l797;  goto l795;
-  l797:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;  if (!yymatchChar(G, '-')) goto l792;
+  yyprintf((stderr, "%s\n", "ImportPath"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l813;
+  l814:;	
+  {  int yypos815= G->pos, yythunkpos815= G->thunkpos;
+  {  int yypos818= G->pos, yythunkpos818= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l819;  goto l818;
+  l819:;	  G->pos= yypos818; G->thunkpos= yythunkpos818;  if (!yymatchChar(G, '.')) goto l820;  goto l818;
+  l820:;	  G->pos= yypos818; G->thunkpos= yythunkpos818;  if (!yymatchChar(G, '-')) goto l815;
   }
-  l795:;	
-  l793:;	
-  {  int yypos794= G->pos, yythunkpos794= G->thunkpos;
-  {  int yypos798= G->pos, yythunkpos798= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l799;  goto l798;
-  l799:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;  if (!yymatchChar(G, '.')) goto l800;  goto l798;
-  l800:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;  if (!yymatchChar(G, '-')) goto l794;
+  l818:;	
+  l816:;	
+  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;
+  {  int yypos821= G->pos, yythunkpos821= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l822;  goto l821;
+  l822:;	  G->pos= yypos821; G->thunkpos= yythunkpos821;  if (!yymatchChar(G, '.')) goto l823;  goto l821;
+  l823:;	  G->pos= yypos821; G->thunkpos= yythunkpos821;  if (!yymatchChar(G, '-')) goto l817;
   }
-  l798:;	  goto l793;
-  l794:;	  G->pos= yypos794; G->thunkpos= yythunkpos794;
-  }  if (!yymatchChar(G, '/')) goto l792;  goto l791;
-  l792:;	  G->pos= yypos792; G->thunkpos= yythunkpos792;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l790;  yyDo(G, yy_1_ImportPath, G->begin, G->end);
+  l821:;	  goto l816;
+  l817:;	  G->pos= yypos817; G->thunkpos= yythunkpos817;
+  }  if (!yymatchChar(G, '/')) goto l815;  goto l814;
+  l815:;	  G->pos= yypos815; G->thunkpos= yythunkpos815;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l813;  yyDo(G, yy_1_ImportPath, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ImportPath", G->buf+G->pos));
   return 1;
-  l790:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l813:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ImportPath", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_ImportAtom(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "ImportAtom"));  if (!yy_ImportPath(G)) { goto l801; }  yyDo(G, yySet, -3, 0);
-  {  int yypos802= G->pos, yythunkpos802= G->thunkpos;  if (!yy_ImportName(G)) { goto l803; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_1_ImportAtom, G->begin, G->end);  yyDo(G, yy_2_ImportAtom, G->begin, G->end);
-  {  int yypos804= G->pos, yythunkpos804= G->thunkpos;  if (!yy__(G)) { goto l804; }  if (!yy_INTO_KW(G)) { goto l804; }  if (!yy__(G)) { goto l804; }  if (!yy_IDENT(G)) { goto l804; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_ImportAtom, G->begin, G->end);  goto l805;
-  l804:;	  G->pos= yypos804; G->thunkpos= yythunkpos804;
+  yyprintf((stderr, "%s\n", "ImportAtom"));  if (!yy_ImportPath(G)) { goto l824; }  yyDo(G, yySet, -3, 0);
+  {  int yypos825= G->pos, yythunkpos825= G->thunkpos;  if (!yy_ImportName(G)) { goto l826; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_1_ImportAtom, G->begin, G->end);  yyDo(G, yy_2_ImportAtom, G->begin, G->end);
+  {  int yypos827= G->pos, yythunkpos827= G->thunkpos;  if (!yy__(G)) { goto l827; }  if (!yy_INTO_KW(G)) { goto l827; }  if (!yy__(G)) { goto l827; }  if (!yy_IDENT(G)) { goto l827; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_ImportAtom, G->begin, G->end);  goto l828;
+  l827:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;
   }
-  l805:;	  goto l802;
-  l803:;	  G->pos= yypos802; G->thunkpos= yythunkpos802;  if (!yymatchChar(G, '[')) goto l801;  yyDo(G, yy_4_ImportAtom, G->begin, G->end);
-  l806:;	
-  {  int yypos807= G->pos, yythunkpos807= G->thunkpos;  if (!yy_ImportName(G)) { goto l807; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_5_ImportAtom, G->begin, G->end);  if (!yy__(G)) { goto l807; }  if (!yymatchChar(G, ',')) goto l807;  if (!yy_WS(G)) { goto l807; }  yyDo(G, yy_6_ImportAtom, G->begin, G->end);  goto l806;
-  l807:;	  G->pos= yypos807; G->thunkpos= yythunkpos807;
-  }  if (!yy_ImportName(G)) { goto l801; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_7_ImportAtom, G->begin, G->end);  yyDo(G, yy_8_ImportAtom, G->begin, G->end);  if (!yymatchChar(G, ']')) goto l801;
-  {  int yypos808= G->pos, yythunkpos808= G->thunkpos;  if (!yy__(G)) { goto l808; }  if (!yy_INTO_KW(G)) { goto l808; }  if (!yy__(G)) { goto l808; }  if (!yy_IDENT(G)) { goto l808; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_9_ImportAtom, G->begin, G->end);  goto l809;
-  l808:;	  G->pos= yypos808; G->thunkpos= yythunkpos808;
+  l828:;	  goto l825;
+  l826:;	  G->pos= yypos825; G->thunkpos= yythunkpos825;  if (!yymatchChar(G, '[')) goto l824;  yyDo(G, yy_4_ImportAtom, G->begin, G->end);
+  l829:;	
+  {  int yypos830= G->pos, yythunkpos830= G->thunkpos;  if (!yy_ImportName(G)) { goto l830; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_5_ImportAtom, G->begin, G->end);  if (!yy__(G)) { goto l830; }  if (!yymatchChar(G, ',')) goto l830;  if (!yy_WS(G)) { goto l830; }  yyDo(G, yy_6_ImportAtom, G->begin, G->end);  goto l829;
+  l830:;	  G->pos= yypos830; G->thunkpos= yythunkpos830;
+  }  if (!yy_ImportName(G)) { goto l824; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_7_ImportAtom, G->begin, G->end);  yyDo(G, yy_8_ImportAtom, G->begin, G->end);  if (!yymatchChar(G, ']')) goto l824;
+  {  int yypos831= G->pos, yythunkpos831= G->thunkpos;  if (!yy__(G)) { goto l831; }  if (!yy_INTO_KW(G)) { goto l831; }  if (!yy__(G)) { goto l831; }  if (!yy_IDENT(G)) { goto l831; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_9_ImportAtom, G->begin, G->end);  goto l832;
+  l831:;	  G->pos= yypos831; G->thunkpos= yythunkpos831;
   }
-  l809:;	
+  l832:;	
   }
-  l802:;	
+  l825:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "ImportAtom", G->buf+G->pos));  yyDo(G, yyPop, 3, 0);
   return 1;
-  l801:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l824:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ImportAtom", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_IMPORT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "IMPORT_KW"));  if (!yymatchString(G, "import")) goto l810;
+  yyprintf((stderr, "%s\n", "IMPORT_KW"));  if (!yymatchString(G, "import")) goto l833;
   yyprintf((stderr, "  ok   %s @ %s\n", "IMPORT_KW", G->buf+G->pos));
   return 1;
-  l810:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l833:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IMPORT_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_DefineValue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "DefineValue"));
-  {  int yypos812= G->pos, yythunkpos812= G->thunkpos;
-  {  int yypos814= G->pos, yythunkpos814= G->thunkpos;  if (!yymatchChar(G, '=')) goto l814;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l814;
-  {  int yypos818= G->pos, yythunkpos818= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l819;  goto l818;
-  l819:;	  G->pos= yypos818; G->thunkpos= yythunkpos818;  if (!yymatchChar(G, '-')) goto l814;
+  {  int yypos835= G->pos, yythunkpos835= G->thunkpos;
+  {  int yypos837= G->pos, yythunkpos837= G->thunkpos;  if (!yymatchChar(G, '=')) goto l837;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l837;
+  {  int yypos841= G->pos, yythunkpos841= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l842;  goto l841;
+  l842:;	  G->pos= yypos841; G->thunkpos= yythunkpos841;  if (!yymatchChar(G, '-')) goto l837;
   }
-  l818:;	
-  l816:;	
-  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;
-  {  int yypos820= G->pos, yythunkpos820= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l821;  goto l820;
-  l821:;	  G->pos= yypos820; G->thunkpos= yythunkpos820;  if (!yymatchChar(G, '-')) goto l817;
+  l841:;	
+  l839:;	
+  {  int yypos840= G->pos, yythunkpos840= G->thunkpos;
+  {  int yypos843= G->pos, yythunkpos843= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l844;  goto l843;
+  l844:;	  G->pos= yypos843; G->thunkpos= yythunkpos843;  if (!yymatchChar(G, '-')) goto l840;
   }
-  l820:;	  goto l816;
-  l817:;	  G->pos= yypos817; G->thunkpos= yythunkpos817;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l814;  goto l815;
-  l814:;	  G->pos= yypos814; G->thunkpos= yythunkpos814;
+  l843:;	  goto l839;
+  l840:;	  G->pos= yypos840; G->thunkpos= yythunkpos840;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l837;  goto l838;
+  l837:;	  G->pos= yypos837; G->thunkpos= yythunkpos837;
   }
-  l815:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end);  goto l812;
-  l813:;	  G->pos= yypos812; G->thunkpos= yythunkpos812;  yyDo(G, yy_2_DefineValue, G->begin, G->end);
+  l838:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end);  goto l835;
+  l836:;	  G->pos= yypos835; G->thunkpos= yythunkpos835;  yyDo(G, yy_2_DefineValue, G->begin, G->end);
   }
-  l812:;	
+  l835:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "DefineValue", G->buf+G->pos));
   return 1;
-  l811:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l834:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DefineValue", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_DefineName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "DefineName"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l822;
-  {  int yypos825= G->pos, yythunkpos825= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l826;  goto l825;
-  l826:;	  G->pos= yypos825; G->thunkpos= yythunkpos825;  if (!yymatchChar(G, '-')) goto l822;
+  yyprintf((stderr, "%s\n", "DefineName"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l845;
+  {  int yypos848= G->pos, yythunkpos848= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l849;  goto l848;
+  l849:;	  G->pos= yypos848; G->thunkpos= yythunkpos848;  if (!yymatchChar(G, '-')) goto l845;
   }
-  l825:;	
-  l823:;	
-  {  int yypos824= G->pos, yythunkpos824= G->thunkpos;
-  {  int yypos827= G->pos, yythunkpos827= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l828;  goto l827;
-  l828:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;  if (!yymatchChar(G, '-')) goto l824;
+  l848:;	
+  l846:;	
+  {  int yypos847= G->pos, yythunkpos847= G->thunkpos;
+  {  int yypos850= G->pos, yythunkpos850= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l851;  goto l850;
+  l851:;	  G->pos= yypos850; G->thunkpos= yythunkpos850;  if (!yymatchChar(G, '-')) goto l847;
   }
-  l827:;	  goto l823;
-  l824:;	  G->pos= yypos824; G->thunkpos= yythunkpos824;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l822;  yyDo(G, yy_1_DefineName, G->begin, G->end);
+  l850:;	  goto l846;
+  l847:;	  G->pos= yypos847; G->thunkpos= yythunkpos847;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l845;  yyDo(G, yy_1_DefineName, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "DefineName", G->buf+G->pos));
   return 1;
-  l822:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l845:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DefineName", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_IncludeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "IncludeCore"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l829;
-  {  int yypos832= G->pos, yythunkpos832= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l833;  goto l832;
-  l833:;	  G->pos= yypos832; G->thunkpos= yythunkpos832;  if (!yymatchChar(G, '-')) goto l829;
+  yyprintf((stderr, "%s\n", "IncludeCore"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l852;
+  {  int yypos855= G->pos, yythunkpos855= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l856;  goto l855;
+  l856:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yymatchChar(G, '-')) goto l852;
   }
-  l832:;	
-  l830:;	
-  {  int yypos831= G->pos, yythunkpos831= G->thunkpos;
-  {  int yypos834= G->pos, yythunkpos834= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l835;  goto l834;
-  l835:;	  G->pos= yypos834; G->thunkpos= yythunkpos834;  if (!yymatchChar(G, '-')) goto l831;
+  l855:;	
+  l853:;	
+  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;
+  {  int yypos857= G->pos, yythunkpos857= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l858;  goto l857;
+  l858:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yymatchChar(G, '-')) goto l854;
   }
-  l834:;	  goto l830;
-  l831:;	  G->pos= yypos831; G->thunkpos= yythunkpos831;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l829;  yyDo(G, yy_1_IncludeCore, G->begin, G->end);
-  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy__(G)) { goto l836; }  if (!yymatchChar(G, '|')) goto l836;  if (!yy__(G)) { goto l836; }  if (!yymatchChar(G, '(')) goto l836;  if (!yy__(G)) { goto l836; }  if (!yy_DefineName(G)) { goto l836; }  yyDo(G, yySet, -2, 0);  if (!yy_DefineValue(G)) { goto l836; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_IncludeCore, G->begin, G->end);
-  l838:;	
-  {  int yypos839= G->pos, yythunkpos839= G->thunkpos;  if (!yy__(G)) { goto l839; }  if (!yymatchChar(G, ',')) goto l839;  if (!yy__(G)) { goto l839; }  if (!yy_DefineName(G)) { goto l839; }  yyDo(G, yySet, -2, 0);  if (!yy_DefineValue(G)) { goto l839; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_IncludeCore, G->begin, G->end);  goto l838;
-  l839:;	  G->pos= yypos839; G->thunkpos= yythunkpos839;
-  }  if (!yy__(G)) { goto l836; }  if (!yymatchChar(G, ')')) goto l836;  goto l837;
-  l836:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;
+  l857:;	  goto l853;
+  l854:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l852;  yyDo(G, yy_1_IncludeCore, G->begin, G->end);
+  {  int yypos859= G->pos, yythunkpos859= G->thunkpos;  if (!yy__(G)) { goto l859; }  if (!yymatchChar(G, '|')) goto l859;  if (!yy__(G)) { goto l859; }  if (!yymatchChar(G, '(')) goto l859;  if (!yy__(G)) { goto l859; }  if (!yy_DefineName(G)) { goto l859; }  yyDo(G, yySet, -2, 0);  if (!yy_DefineValue(G)) { goto l859; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_IncludeCore, G->begin, G->end);
+  l861:;	
+  {  int yypos862= G->pos, yythunkpos862= G->thunkpos;  if (!yy__(G)) { goto l862; }  if (!yymatchChar(G, ',')) goto l862;  if (!yy__(G)) { goto l862; }  if (!yy_DefineName(G)) { goto l862; }  yyDo(G, yySet, -2, 0);  if (!yy_DefineValue(G)) { goto l862; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_3_IncludeCore, G->begin, G->end);  goto l861;
+  l862:;	  G->pos= yypos862; G->thunkpos= yythunkpos862;
+  }  if (!yy__(G)) { goto l859; }  if (!yymatchChar(G, ')')) goto l859;  goto l860;
+  l859:;	  G->pos= yypos859; G->thunkpos= yythunkpos859;
   }
-  l837:;	
+  l860:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IncludeCore", G->buf+G->pos));  yyDo(G, yyPop, 2, 0);
   return 1;
-  l829:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l852:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IncludeCore", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "INCLUDE_KW"));  if (!yymatchString(G, "include")) goto l840;
+  yyprintf((stderr, "%s\n", "INCLUDE_KW"));  if (!yymatchString(G, "include")) goto l863;
   yyprintf((stderr, "  ok   %s @ %s\n", "INCLUDE_KW", G->buf+G->pos));
   return 1;
-  l840:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l863:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INCLUDE_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_UseCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "UseCore"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l841;
-  {  int yypos844= G->pos, yythunkpos844= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l845;  goto l844;
-  l845:;	  G->pos= yypos844; G->thunkpos= yythunkpos844;  if (!yymatchChar(G, '-')) goto l841;
+  yyprintf((stderr, "%s\n", "UseCore"));  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l864;
+  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l868;  goto l867;
+  l868:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;  if (!yymatchChar(G, '-')) goto l864;
   }
-  l844:;	
-  l842:;	
-  {  int yypos843= G->pos, yythunkpos843= G->thunkpos;
-  {  int yypos846= G->pos, yythunkpos846= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l847;  goto l846;
-  l847:;	  G->pos= yypos846; G->thunkpos= yythunkpos846;  if (!yymatchChar(G, '-')) goto l843;
+  l867:;	
+  l865:;	
+  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;
+  {  int yypos869= G->pos, yythunkpos869= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l870;  goto l869;
+  l870:;	  G->pos= yypos869; G->thunkpos= yythunkpos869;  if (!yymatchChar(G, '-')) goto l866;
   }
-  l846:;	  goto l842;
-  l843:;	  G->pos= yypos843; G->thunkpos= yythunkpos843;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l841;  yyDo(G, yy_1_UseCore, G->begin, G->end);
+  l869:;	  goto l865;
+  l866:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l864;  yyDo(G, yy_1_UseCore, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "UseCore", G->buf+G->pos));
   return 1;
-  l841:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l864:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "UseCore", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_USE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "USE_KW"));  if (!yymatchString(G, "use")) goto l848;
+  yyprintf((stderr, "%s\n", "USE_KW"));  if (!yymatchString(G, "use")) goto l871;
   yyprintf((stderr, "  ok   %s @ %s\n", "USE_KW", G->buf+G->pos));
   return 1;
-  l848:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l871:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "USE_KW", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_VersionName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "VersionName"));  if (!yy__(G)) { goto l849; }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l849;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l849;
-  l850:;	
-  {  int yypos851= G->pos, yythunkpos851= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l851;  goto l850;
-  l851:;	  G->pos= yypos851; G->thunkpos= yythunkpos851;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l849;  yyDo(G, yy_1_VersionName, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "VersionName"));  if (!yy__(G)) { goto l872; }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l872;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l872;
+  l873:;	
+  {  int yypos874= G->pos, yythunkpos874= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l874;  goto l873;
+  l874:;	  G->pos= yypos874; G->thunkpos= yythunkpos874;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l872;  yyDo(G, yy_1_VersionName, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "VersionName", G->buf+G->pos));
   return 1;
-  l849:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l872:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VersionName", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_VersionNegation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "VersionNegation"));  if (!yy__(G)) { goto l852; }  if (!yymatchChar(G, '!')) goto l852;  yyDo(G, yy_1_VersionNegation, G->begin, G->end);  if (!yy__(G)) { goto l852; }  if (!yy_VersionSpec(G)) { goto l852; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_VersionNegation, G->begin, G->end);
+  yyprintf((stderr, "%s\n", "VersionNegation"));  if (!yy__(G)) { goto l875; }  if (!yymatchChar(G, '!')) goto l875;  yyDo(G, yy_1_VersionNegation, G->begin, G->end);  if (!yy__(G)) { goto l875; }  if (!yy_VersionSpec(G)) { goto l875; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_VersionNegation, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "VersionNegation", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l852:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l875:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VersionNegation", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_VersionCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "VersionCore"));
-  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy_VersionNegation(G)) { goto l855; }  goto l854;
-  l855:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;  if (!yy_VersionName(G)) { goto l853; }
+  {  int yypos877= G->pos, yythunkpos877= G->thunkpos;  if (!yy_VersionNegation(G)) { goto l878; }  goto l877;
+  l878:;	  G->pos= yypos877; G->thunkpos= yythunkpos877;  if (!yy_VersionName(G)) { goto l876; }
   }
-  l854:;	
+  l877:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "VersionCore", G->buf+G->pos));
   return 1;
-  l853:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l876:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VersionCore", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Decl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "Decl"));
-  {  int yypos857= G->pos, yythunkpos857= G->thunkpos;  if (!yy_ClassDecl(G)) { goto l858; }  goto l857;
-  l858:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_CoverDecl(G)) { goto l859; }  goto l857;
-  l859:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_ExtendDecl(G)) { goto l860; }  goto l857;
-  l860:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_EnumDecl(G)) { goto l861; }  goto l857;
-  l861:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_InterfaceDecl(G)) { goto l862; }  goto l857;
-  l862:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_OperatorDecl(G)) { goto l863; }  goto l857;
-  l863:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_FunctionDecl(G)) { goto l864; }  goto l857;
-  l864:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_PropertyDecl(G)) { goto l865; }  goto l857;
-  l865:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;  if (!yy_VariableDecl(G)) { goto l856; }  yyDo(G, yySet, -1, 0);  if (!yy_Terminator(G)) { goto l856; }
-  l866:;	
-  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;  if (!yy_Terminator(G)) { goto l867; }  goto l866;
-  l867:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;
+  {  int yypos880= G->pos, yythunkpos880= G->thunkpos;  if (!yy_ClassDecl(G)) { goto l881; }  goto l880;
+  l881:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_CoverDecl(G)) { goto l882; }  goto l880;
+  l882:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_ExtendDecl(G)) { goto l883; }  goto l880;
+  l883:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_EnumDecl(G)) { goto l884; }  goto l880;
+  l884:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_InterfaceDecl(G)) { goto l885; }  goto l880;
+  l885:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_OperatorDecl(G)) { goto l886; }  goto l880;
+  l886:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_FunctionDecl(G)) { goto l887; }  goto l880;
+  l887:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_PropertyDecl(G)) { goto l888; }  goto l880;
+  l888:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy_VariableDecl(G)) { goto l879; }  yyDo(G, yySet, -1, 0);  if (!yy_Terminator(G)) { goto l879; }
+  l889:;	
+  {  int yypos890= G->pos, yythunkpos890= G->thunkpos;  if (!yy_Terminator(G)) { goto l890; }  goto l889;
+  l890:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;
   }  yyDo(G, yy_1_Decl, G->begin, G->end);
   }
-  l857:;	
+  l880:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Decl", G->buf+G->pos));  yyDo(G, yyPop, 1, 0);
   return 1;
-  l856:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l879:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Decl", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Use(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "Use"));  if (!yy_USE_KW(G)) { goto l868; }  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l868;  if (!yy__(G)) { goto l868; }  if (!yy_UseCore(G)) { goto l868; }
-  l869:;	
-  {  int yypos870= G->pos, yythunkpos870= G->thunkpos;  if (!yy__(G)) { goto l870; }  if (!yymatchChar(G, ',')) goto l870;  if (!yy__(G)) { goto l870; }  if (!yy_UseCore(G)) { goto l870; }  goto l869;
-  l870:;	  G->pos= yypos870; G->thunkpos= yythunkpos870;
+  yyprintf((stderr, "%s\n", "Use"));  if (!yy_USE_KW(G)) { goto l891; }  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l891;  if (!yy__(G)) { goto l891; }  if (!yy_UseCore(G)) { goto l891; }
+  l892:;	
+  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;  if (!yy__(G)) { goto l893; }  if (!yymatchChar(G, ',')) goto l893;  if (!yy__(G)) { goto l893; }  if (!yy_UseCore(G)) { goto l893; }  goto l892;
+  l893:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "Use", G->buf+G->pos));
   return 1;
-  l868:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l891:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Use", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Import(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "Import"));  if (!yy_IMPORT_KW(G)) { goto l871; }  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l871;  if (!yy__(G)) { goto l871; }  if (!yy_ImportAtom(G)) { goto l871; }
-  l872:;	
-  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;  if (!yymatchChar(G, ',')) goto l873;  if (!yy_WS(G)) { goto l873; }  if (!yy__(G)) { goto l873; }  if (!yy_ImportAtom(G)) { goto l873; }  goto l872;
-  l873:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;
+  yyprintf((stderr, "%s\n", "Import"));  if (!yy_IMPORT_KW(G)) { goto l894; }  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l894;  if (!yy__(G)) { goto l894; }  if (!yy_ImportAtom(G)) { goto l894; }
+  l895:;	
+  {  int yypos896= G->pos, yythunkpos896= G->thunkpos;  if (!yymatchChar(G, ',')) goto l896;  if (!yy_WS(G)) { goto l896; }  if (!yy__(G)) { goto l896; }  if (!yy_ImportAtom(G)) { goto l896; }  goto l895;
+  l896:;	  G->pos= yypos896; G->thunkpos= yythunkpos896;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "Import", G->buf+G->pos));
   return 1;
-  l871:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l894:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Import", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Include(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
-  yyprintf((stderr, "%s\n", "Include"));  if (!yy_INCLUDE_KW(G)) { goto l874; }  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l874;  if (!yy__(G)) { goto l874; }  if (!yy_IncludeCore(G)) { goto l874; }
-  l875:;	
-  {  int yypos876= G->pos, yythunkpos876= G->thunkpos;  if (!yy__(G)) { goto l876; }  if (!yymatchChar(G, ',')) goto l876;  if (!yy__(G)) { goto l876; }  if (!yy_IncludeCore(G)) { goto l876; }  goto l875;
-  l876:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;
+  yyprintf((stderr, "%s\n", "Include"));  if (!yy_INCLUDE_KW(G)) { goto l897; }  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l897;  if (!yy__(G)) { goto l897; }  if (!yy_IncludeCore(G)) { goto l897; }
+  l898:;	
+  {  int yypos899= G->pos, yythunkpos899= G->thunkpos;  if (!yy__(G)) { goto l899; }  if (!yymatchChar(G, ',')) goto l899;  if (!yy__(G)) { goto l899; }  if (!yy_IncludeCore(G)) { goto l899; }  goto l898;
+  l899:;	  G->pos= yypos899; G->thunkpos= yythunkpos899;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "Include", G->buf+G->pos));
   return 1;
-  l874:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l897:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Include", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Stmt(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
   yyprintf((stderr, "%s\n", "Stmt"));
-  {  int yypos878= G->pos, yythunkpos878= G->thunkpos;  if (!yy_Old(G)) { goto l879; }  yyDo(G, yySet, -4, 0);  if (!yy_WS(G)) { goto l879; }  if (!yymatchString(G, "version")) goto l879;  yyDo(G, yy_1_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l879; }  if (!yymatchChar(G, '(')) goto l879;  if (!yy__(G)) { goto l879; }  if (!yy_VersionSpec(G)) { goto l879; }  yyDo(G, yySet, -3, 0);  if (!yy_WS(G)) { goto l879; }  if (!yymatchChar(G, ')')) goto l879;
-  {  int yypos880= G->pos, yythunkpos880= G->thunkpos;  if (!yy__(G)) { goto l881; }  if (!yymatchChar(G, '{')) goto l881;  yyDo(G, yy_2_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l881; }
-  l882:;	
-  {  int yypos883= G->pos, yythunkpos883= G->thunkpos;  if (!yy_Stmt(G)) { goto l883; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_Stmt, G->begin, G->end);  goto l882;
-  l883:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;
-  }  if (!yy_WS(G)) { goto l881; }  if (!yy__(G)) { goto l881; }  if (!yymatchChar(G, '}')) goto l881;  yyDo(G, yy_4_Stmt, G->begin, G->end);  goto l880;
-  l881:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yy__(G)) { goto l879; }  if (!yy_Stmt(G)) { goto l879; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_5_Stmt, G->begin, G->end);
+  {  int yypos901= G->pos, yythunkpos901= G->thunkpos;  if (!yy_Old(G)) { goto l902; }  yyDo(G, yySet, -4, 0);  if (!yy_WS(G)) { goto l902; }  if (!yymatchString(G, "version")) goto l902;  yyDo(G, yy_1_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l902; }  if (!yymatchChar(G, '(')) goto l902;  if (!yy__(G)) { goto l902; }  if (!yy_VersionSpec(G)) { goto l902; }  yyDo(G, yySet, -3, 0);  if (!yy_WS(G)) { goto l902; }  if (!yymatchChar(G, ')')) goto l902;
+  {  int yypos903= G->pos, yythunkpos903= G->thunkpos;  if (!yy__(G)) { goto l904; }  if (!yymatchChar(G, '{')) goto l904;  yyDo(G, yy_2_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l904; }
+  l905:;	
+  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yy_Stmt(G)) { goto l906; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_3_Stmt, G->begin, G->end);  goto l905;
+  l906:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;
+  }  if (!yy_WS(G)) { goto l904; }  if (!yy__(G)) { goto l904; }  if (!yymatchChar(G, '}')) goto l904;  yyDo(G, yy_4_Stmt, G->begin, G->end);  goto l903;
+  l904:;	  G->pos= yypos903; G->thunkpos= yythunkpos903;  if (!yy__(G)) { goto l902; }  if (!yy_Stmt(G)) { goto l902; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_5_Stmt, G->begin, G->end);
   }
-  l880:;	
-  l884:;	
-  {  int yypos885= G->pos, yythunkpos885= G->thunkpos;  if (!yy_WS(G)) { goto l885; }  if (!yymatchString(G, "else")) goto l885;  if (!yy__(G)) { goto l885; }  if (!yymatchString(G, "version")) goto l885;  yyDo(G, yy_6_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l885; }  if (!yymatchChar(G, '(')) goto l885;  if (!yy__(G)) { goto l885; }  if (!yy_VersionSpec(G)) { goto l885; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l885; }  if (!yymatchChar(G, ')')) goto l885;
-  {  int yypos886= G->pos, yythunkpos886= G->thunkpos;  if (!yy__(G)) { goto l887; }  if (!yymatchChar(G, '{')) goto l887;  yyDo(G, yy_7_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l887; }
-  l888:;	
-  {  int yypos889= G->pos, yythunkpos889= G->thunkpos;  if (!yy_Stmt(G)) { goto l889; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_8_Stmt, G->begin, G->end);  goto l888;
-  l889:;	  G->pos= yypos889; G->thunkpos= yythunkpos889;
-  }  if (!yy_WS(G)) { goto l887; }  if (!yy__(G)) { goto l887; }  if (!yymatchChar(G, '}')) goto l887;  yyDo(G, yy_9_Stmt, G->begin, G->end);  goto l886;
-  l887:;	  G->pos= yypos886; G->thunkpos= yythunkpos886;  if (!yy__(G)) { goto l885; }  if (!yy_Stmt(G)) { goto l885; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_10_Stmt, G->begin, G->end);
+  l903:;	
+  l907:;	
+  {  int yypos908= G->pos, yythunkpos908= G->thunkpos;  if (!yy_WS(G)) { goto l908; }  if (!yymatchString(G, "else")) goto l908;  if (!yy__(G)) { goto l908; }  if (!yymatchString(G, "version")) goto l908;  yyDo(G, yy_6_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l908; }  if (!yymatchChar(G, '(')) goto l908;  if (!yy__(G)) { goto l908; }  if (!yy_VersionSpec(G)) { goto l908; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l908; }  if (!yymatchChar(G, ')')) goto l908;
+  {  int yypos909= G->pos, yythunkpos909= G->thunkpos;  if (!yy__(G)) { goto l910; }  if (!yymatchChar(G, '{')) goto l910;  yyDo(G, yy_7_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l910; }
+  l911:;	
+  {  int yypos912= G->pos, yythunkpos912= G->thunkpos;  if (!yy_Stmt(G)) { goto l912; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_8_Stmt, G->begin, G->end);  goto l911;
+  l912:;	  G->pos= yypos912; G->thunkpos= yythunkpos912;
+  }  if (!yy_WS(G)) { goto l910; }  if (!yy__(G)) { goto l910; }  if (!yymatchChar(G, '}')) goto l910;  yyDo(G, yy_9_Stmt, G->begin, G->end);  goto l909;
+  l910:;	  G->pos= yypos909; G->thunkpos= yythunkpos909;  if (!yy__(G)) { goto l908; }  if (!yy_Stmt(G)) { goto l908; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_10_Stmt, G->begin, G->end);
   }
-  l886:;	  goto l884;
-  l885:;	  G->pos= yypos885; G->thunkpos= yythunkpos885;
+  l909:;	  goto l907;
+  l908:;	  G->pos= yypos908; G->thunkpos= yythunkpos908;
   }
-  {  int yypos890= G->pos, yythunkpos890= G->thunkpos;  if (!yy_WS(G)) { goto l890; }  if (!yymatchString(G, "else")) goto l890;  yyDo(G, yy_11_Stmt, G->begin, G->end);
-  {  int yypos892= G->pos, yythunkpos892= G->thunkpos;  if (!yy__(G)) { goto l893; }  if (!yymatchChar(G, '{')) goto l893;  yyDo(G, yy_12_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l893; }
-  l894:;	
-  {  int yypos895= G->pos, yythunkpos895= G->thunkpos;  if (!yy_Stmt(G)) { goto l895; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_13_Stmt, G->begin, G->end);  goto l894;
-  l895:;	  G->pos= yypos895; G->thunkpos= yythunkpos895;
-  }  if (!yy_WS(G)) { goto l893; }  if (!yy__(G)) { goto l893; }  if (!yymatchChar(G, '}')) goto l893;  yyDo(G, yy_14_Stmt, G->begin, G->end);  goto l892;
-  l893:;	  G->pos= yypos892; G->thunkpos= yythunkpos892;  if (!yy__(G)) { goto l890; }  if (!yy_Stmt(G)) { goto l890; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_15_Stmt, G->begin, G->end);
+  {  int yypos913= G->pos, yythunkpos913= G->thunkpos;  if (!yy_WS(G)) { goto l913; }  if (!yymatchString(G, "else")) goto l913;  yyDo(G, yy_11_Stmt, G->begin, G->end);
+  {  int yypos915= G->pos, yythunkpos915= G->thunkpos;  if (!yy__(G)) { goto l916; }  if (!yymatchChar(G, '{')) goto l916;  yyDo(G, yy_12_Stmt, G->begin, G->end);  if (!yy_WS(G)) { goto l916; }
+  l917:;	
+  {  int yypos918= G->pos, yythunkpos918= G->thunkpos;  if (!yy_Stmt(G)) { goto l918; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_13_Stmt, G->begin, G->end);  goto l917;
+  l918:;	  G->pos= yypos918; G->thunkpos= yythunkpos918;
+  }  if (!yy_WS(G)) { goto l916; }  if (!yy__(G)) { goto l916; }  if (!yymatchChar(G, '}')) goto l916;  yyDo(G, yy_14_Stmt, G->begin, G->end);  goto l915;
+  l916:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;  if (!yy__(G)) { goto l913; }  if (!yy_Stmt(G)) { goto l913; }  yyDo(G, yySet, -2, 0);  yyDo(G, yy_15_Stmt, G->begin, G->end);
   }
-  l892:;	  goto l891;
-  l890:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;
+  l915:;	  goto l914;
+  l913:;	  G->pos= yypos913; G->thunkpos= yythunkpos913;
   }
-  l891:;	  goto l878;
-  l879:;	  G->pos= yypos878; G->thunkpos= yythunkpos878;  if (!yy_StmtCore(G)) { goto l877; }
+  l914:;	  goto l901;
+  l902:;	  G->pos= yypos901; G->thunkpos= yythunkpos901;  if (!yy_StmtCore(G)) { goto l900; }
   }
-  l878:;	
+  l901:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Stmt", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l877:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l900:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Stmt", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_VersionSpec(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "VersionSpec"));
-  {  int yypos897= G->pos, yythunkpos897= G->thunkpos;  if (!yy__(G)) { goto l898; }  if (!yymatchChar(G, '(')) goto l898;  if (!yy__(G)) { goto l898; }  if (!yy_VersionSpec(G)) { goto l898; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l898; }  if (!yymatchChar(G, ')')) goto l898;  goto l897;
-  l898:;	  G->pos= yypos897; G->thunkpos= yythunkpos897;  if (!yy_VersionCore(G)) { goto l896; }  yyDo(G, yySet, -2, 0);
+  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;  if (!yy__(G)) { goto l921; }  if (!yymatchChar(G, '(')) goto l921;  if (!yy__(G)) { goto l921; }  if (!yy_VersionSpec(G)) { goto l921; }  yyDo(G, yySet, -2, 0);  if (!yy__(G)) { goto l921; }  if (!yymatchChar(G, ')')) goto l921;  goto l920;
+  l921:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;  if (!yy_VersionCore(G)) { goto l919; }  yyDo(G, yySet, -2, 0);
   }
-  l897:;	
-  l899:;	
-  {  int yypos900= G->pos, yythunkpos900= G->thunkpos;
-  {  int yypos901= G->pos, yythunkpos901= G->thunkpos;  if (!yy__(G)) { goto l902; }  if (!yymatchString(G, "&&")) goto l902;  yyDo(G, yy_1_VersionSpec, G->begin, G->end);  if (!yy__(G)) { goto l902; }  if (!yy_VersionSpec(G)) { goto l902; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_VersionSpec, G->begin, G->end);  goto l901;
-  l902:;	  G->pos= yypos901; G->thunkpos= yythunkpos901;  if (!yy__(G)) { goto l900; }  if (!yymatchString(G, "||")) goto l900;  yyDo(G, yy_3_VersionSpec, G->begin, G->end);  if (!yy__(G)) { goto l900; }  if (!yy_VersionSpec(G)) { goto l900; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_4_VersionSpec, G->begin, G->end);
+  l920:;	
+  l922:;	
+  {  int yypos923= G->pos, yythunkpos923= G->thunkpos;
+  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;  if (!yy__(G)) { goto l925; }  if (!yymatchString(G, "&&")) goto l925;  yyDo(G, yy_1_VersionSpec, G->begin, G->end);  if (!yy__(G)) { goto l925; }  if (!yy_VersionSpec(G)) { goto l925; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_2_VersionSpec, G->begin, G->end);  goto l924;
+  l925:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;  if (!yy__(G)) { goto l923; }  if (!yymatchString(G, "||")) goto l923;  yyDo(G, yy_3_VersionSpec, G->begin, G->end);  if (!yy__(G)) { goto l923; }  if (!yy_VersionSpec(G)) { goto l923; }  yyDo(G, yySet, -1, 0);  yyDo(G, yy_4_VersionSpec, G->begin, G->end);
   }
-  l901:;	  goto l899;
-  l900:;	  G->pos= yypos900; G->thunkpos= yythunkpos900;
+  l924:;	  goto l922;
+  l923:;	  G->pos= yypos923; G->thunkpos= yythunkpos923;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "VersionSpec", G->buf+G->pos));  yyDo(G, yyPop, 2, 0);
   return 1;
-  l896:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l919:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VersionSpec", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy__(GREG *G)
 {
   yyprintf((stderr, "%s\n", "_"));
-  l904:;	
-  {  int yypos905= G->pos, yythunkpos905= G->thunkpos;
-  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l907;  goto l906;
-  l907:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;  if (!yy_CommentMultiLine(G)) { goto l905; }
+  l927:;	
+  {  int yypos928= G->pos, yythunkpos928= G->thunkpos;
+  {  int yypos929= G->pos, yythunkpos929= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l930;  goto l929;
+  l930:;	  G->pos= yypos929; G->thunkpos= yythunkpos929;  if (!yy_CommentMultiLine(G)) { goto l928; }
   }
-  l906:;	  goto l904;
-  l905:;	  G->pos= yypos905; G->thunkpos= yythunkpos905;
+  l929:;	  goto l927;
+  l928:;	  G->pos= yypos928; G->thunkpos= yythunkpos928;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "_", G->buf+G->pos));
   return 1;
@@ -8114,28 +8506,28 @@ YY_RULE(int) yy__(GREG *G)
 YY_RULE(int) yy_EOL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "EOL"));
-  {  int yypos909= G->pos, yythunkpos909= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l910;  goto l909;
-  l910:;	  G->pos= yypos909; G->thunkpos= yythunkpos909;  if (!yymatchString(G, "\r\n")) goto l911;  goto l909;
-  l911:;	  G->pos= yypos909; G->thunkpos= yythunkpos909;  if (!yymatchChar(G, '\r')) goto l908;
+  {  int yypos932= G->pos, yythunkpos932= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l933;  goto l932;
+  l933:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;  if (!yymatchString(G, "\r\n")) goto l934;  goto l932;
+  l934:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;  if (!yymatchChar(G, '\r')) goto l931;
   }
-  l909:;	  yyDo(G, yy_1_EOL, G->begin, G->end);
+  l932:;	  yyDo(G, yy_1_EOL, G->begin, G->end);
   yyprintf((stderr, "  ok   %s @ %s\n", "EOL", G->buf+G->pos));
   return 1;
-  l908:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l931:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EOL", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_WS(GREG *G)
 {
   yyprintf((stderr, "%s\n", "WS"));
-  l913:;	
-  {  int yypos914= G->pos, yythunkpos914= G->thunkpos;
-  {  int yypos915= G->pos, yythunkpos915= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l916;  goto l915;
-  l916:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;  if (!yy_Comment(G)) { goto l917; }  goto l915;
-  l917:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;  if (!yy_EOL(G)) { goto l914; }
+  l936:;	
+  {  int yypos937= G->pos, yythunkpos937= G->thunkpos;
+  {  int yypos938= G->pos, yythunkpos938= G->thunkpos;  if (!yymatchClass(G, (unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l939;  goto l938;
+  l939:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;  if (!yy_Comment(G)) { goto l940; }  goto l938;
+  l940:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;  if (!yy_EOL(G)) { goto l937; }
   }
-  l915:;	  goto l913;
-  l914:;	  G->pos= yypos914; G->thunkpos= yythunkpos914;
+  l938:;	  goto l936;
+  l937:;	  G->pos= yypos937; G->thunkpos= yythunkpos937;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "WS", G->buf+G->pos));
   return 1;
@@ -8143,72 +8535,72 @@ YY_RULE(int) yy_WS(GREG *G)
 YY_RULE(int) yy_ModuleCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0);
   yyprintf((stderr, "%s\n", "ModuleCore"));
-  {  int yypos919= G->pos, yythunkpos919= G->thunkpos;  if (!yy_WS(G)) { goto l920; }  if (!yymatchString(G, "version")) goto l920;  yyDo(G, yy_1_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l920; }  if (!yymatchChar(G, '(')) goto l920;  if (!yy__(G)) { goto l920; }  if (!yy_VersionSpec(G)) { goto l920; }  yyDo(G, yySet, -4, 0);  if (!yy_WS(G)) { goto l920; }  if (!yymatchChar(G, ')')) goto l920;
-  {  int yypos921= G->pos, yythunkpos921= G->thunkpos;  if (!yy__(G)) { goto l922; }  if (!yymatchChar(G, '{')) goto l922;  yyDo(G, yy_2_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l922; }
-  l923:;	
-  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l924; }  goto l923;
-  l924:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;
-  }  if (!yy_WS(G)) { goto l922; }  if (!yy__(G)) { goto l922; }  if (!yymatchChar(G, '}')) goto l922;  yyDo(G, yy_3_ModuleCore, G->begin, G->end);  goto l921;
-  l922:;	  G->pos= yypos921; G->thunkpos= yythunkpos921;  if (!yy__(G)) { goto l920; }  if (!yy_Stmt(G)) { goto l920; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_4_ModuleCore, G->begin, G->end);
+  {  int yypos942= G->pos, yythunkpos942= G->thunkpos;  if (!yy_WS(G)) { goto l943; }  if (!yymatchString(G, "version")) goto l943;  yyDo(G, yy_1_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l943; }  if (!yymatchChar(G, '(')) goto l943;  if (!yy__(G)) { goto l943; }  if (!yy_VersionSpec(G)) { goto l943; }  yyDo(G, yySet, -4, 0);  if (!yy_WS(G)) { goto l943; }  if (!yymatchChar(G, ')')) goto l943;
+  {  int yypos944= G->pos, yythunkpos944= G->thunkpos;  if (!yy__(G)) { goto l945; }  if (!yymatchChar(G, '{')) goto l945;  yyDo(G, yy_2_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l945; }
+  l946:;	
+  {  int yypos947= G->pos, yythunkpos947= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l947; }  goto l946;
+  l947:;	  G->pos= yypos947; G->thunkpos= yythunkpos947;
+  }  if (!yy_WS(G)) { goto l945; }  if (!yy__(G)) { goto l945; }  if (!yymatchChar(G, '}')) goto l945;  yyDo(G, yy_3_ModuleCore, G->begin, G->end);  goto l944;
+  l945:;	  G->pos= yypos944; G->thunkpos= yythunkpos944;  if (!yy__(G)) { goto l943; }  if (!yy_Stmt(G)) { goto l943; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_4_ModuleCore, G->begin, G->end);
   }
-  l921:;	
-  l925:;	
-  {  int yypos926= G->pos, yythunkpos926= G->thunkpos;  if (!yy_WS(G)) { goto l926; }  if (!yymatchString(G, "else")) goto l926;  if (!yy__(G)) { goto l926; }  if (!yymatchString(G, "version")) goto l926;  yyDo(G, yy_5_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l926; }  if (!yymatchChar(G, '(')) goto l926;  if (!yy__(G)) { goto l926; }  if (!yy_VersionSpec(G)) { goto l926; }  yyDo(G, yySet, -2, 0);  if (!yy_WS(G)) { goto l926; }  if (!yymatchChar(G, ')')) goto l926;
-  {  int yypos927= G->pos, yythunkpos927= G->thunkpos;  if (!yy__(G)) { goto l928; }  if (!yymatchChar(G, '{')) goto l928;  yyDo(G, yy_6_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l928; }
-  l929:;	
-  {  int yypos930= G->pos, yythunkpos930= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l930; }  goto l929;
-  l930:;	  G->pos= yypos930; G->thunkpos= yythunkpos930;
-  }  if (!yy_WS(G)) { goto l928; }  if (!yy__(G)) { goto l928; }  if (!yymatchChar(G, '}')) goto l928;  yyDo(G, yy_7_ModuleCore, G->begin, G->end);  goto l927;
-  l928:;	  G->pos= yypos927; G->thunkpos= yythunkpos927;  if (!yy__(G)) { goto l926; }  if (!yy_Stmt(G)) { goto l926; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_8_ModuleCore, G->begin, G->end);
+  l944:;	
+  l948:;	
+  {  int yypos949= G->pos, yythunkpos949= G->thunkpos;  if (!yy_WS(G)) { goto l949; }  if (!yymatchString(G, "else")) goto l949;  if (!yy__(G)) { goto l949; }  if (!yymatchString(G, "version")) goto l949;  yyDo(G, yy_5_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l949; }  if (!yymatchChar(G, '(')) goto l949;  if (!yy__(G)) { goto l949; }  if (!yy_VersionSpec(G)) { goto l949; }  yyDo(G, yySet, -2, 0);  if (!yy_WS(G)) { goto l949; }  if (!yymatchChar(G, ')')) goto l949;
+  {  int yypos950= G->pos, yythunkpos950= G->thunkpos;  if (!yy__(G)) { goto l951; }  if (!yymatchChar(G, '{')) goto l951;  yyDo(G, yy_6_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l951; }
+  l952:;	
+  {  int yypos953= G->pos, yythunkpos953= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l953; }  goto l952;
+  l953:;	  G->pos= yypos953; G->thunkpos= yythunkpos953;
+  }  if (!yy_WS(G)) { goto l951; }  if (!yy__(G)) { goto l951; }  if (!yymatchChar(G, '}')) goto l951;  yyDo(G, yy_7_ModuleCore, G->begin, G->end);  goto l950;
+  l951:;	  G->pos= yypos950; G->thunkpos= yythunkpos950;  if (!yy__(G)) { goto l949; }  if (!yy_Stmt(G)) { goto l949; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_8_ModuleCore, G->begin, G->end);
   }
-  l927:;	  goto l925;
-  l926:;	  G->pos= yypos926; G->thunkpos= yythunkpos926;
+  l950:;	  goto l948;
+  l949:;	  G->pos= yypos949; G->thunkpos= yythunkpos949;
   }
-  {  int yypos931= G->pos, yythunkpos931= G->thunkpos;  if (!yy_WS(G)) { goto l931; }  if (!yymatchString(G, "else")) goto l931;  yyDo(G, yy_9_ModuleCore, G->begin, G->end);
-  {  int yypos933= G->pos, yythunkpos933= G->thunkpos;  if (!yy__(G)) { goto l934; }  if (!yymatchChar(G, '{')) goto l934;  yyDo(G, yy_10_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l934; }
-  l935:;	
-  {  int yypos936= G->pos, yythunkpos936= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l936; }  goto l935;
-  l936:;	  G->pos= yypos936; G->thunkpos= yythunkpos936;
-  }  if (!yy_WS(G)) { goto l934; }  if (!yy__(G)) { goto l934; }  if (!yymatchChar(G, '}')) goto l934;  yyDo(G, yy_11_ModuleCore, G->begin, G->end);  goto l933;
-  l934:;	  G->pos= yypos933; G->thunkpos= yythunkpos933;  if (!yy__(G)) { goto l931; }  if (!yy_Stmt(G)) { goto l931; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_12_ModuleCore, G->begin, G->end);
+  {  int yypos954= G->pos, yythunkpos954= G->thunkpos;  if (!yy_WS(G)) { goto l954; }  if (!yymatchString(G, "else")) goto l954;  yyDo(G, yy_9_ModuleCore, G->begin, G->end);
+  {  int yypos956= G->pos, yythunkpos956= G->thunkpos;  if (!yy__(G)) { goto l957; }  if (!yymatchChar(G, '{')) goto l957;  yyDo(G, yy_10_ModuleCore, G->begin, G->end);  if (!yy_WS(G)) { goto l957; }
+  l958:;	
+  {  int yypos959= G->pos, yythunkpos959= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l959; }  goto l958;
+  l959:;	  G->pos= yypos959; G->thunkpos= yythunkpos959;
+  }  if (!yy_WS(G)) { goto l957; }  if (!yy__(G)) { goto l957; }  if (!yymatchChar(G, '}')) goto l957;  yyDo(G, yy_11_ModuleCore, G->begin, G->end);  goto l956;
+  l957:;	  G->pos= yypos956; G->thunkpos= yythunkpos956;  if (!yy__(G)) { goto l954; }  if (!yy_Stmt(G)) { goto l954; }  yyDo(G, yySet, -3, 0);  yyDo(G, yy_12_ModuleCore, G->begin, G->end);
   }
-  l933:;	  goto l932;
-  l931:;	  G->pos= yypos931; G->thunkpos= yythunkpos931;
+  l956:;	  goto l955;
+  l954:;	  G->pos= yypos954; G->thunkpos= yythunkpos954;
   }
-  l932:;	  goto l919;
-  l920:;	  G->pos= yypos919; G->thunkpos= yythunkpos919;
-  {  int yypos937= G->pos, yythunkpos937= G->thunkpos;  if (!yy_WS(G)) { goto l938; }  if (!yy_Include(G)) { goto l938; }  if (!yy_WS(G)) { goto l938; }  goto l937;
-  l938:;	  G->pos= yypos937; G->thunkpos= yythunkpos937;  if (!yy_WS(G)) { goto l939; }  if (!yy_Import(G)) { goto l939; }  if (!yy_WS(G)) { goto l939; }  goto l937;
-  l939:;	  G->pos= yypos937; G->thunkpos= yythunkpos937;  if (!yy_WS(G)) { goto l940; }  if (!yy_Use(G)) { goto l940; }  if (!yy_WS(G)) { goto l940; }  goto l937;
-  l940:;	  G->pos= yypos937; G->thunkpos= yythunkpos937;  if (!yy_WS(G)) { goto l941; }  if (!yy_Decl(G)) { goto l941; }  if (!yy_WS(G)) { goto l941; }  goto l937;
-  l941:;	  G->pos= yypos937; G->thunkpos= yythunkpos937;  if (!yy_WS(G)) { goto l918; }  if (!yy_Stmt(G)) { goto l918; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l918; }  yyDo(G, yy_13_ModuleCore, G->begin, G->end);
+  l955:;	  goto l942;
+  l943:;	  G->pos= yypos942; G->thunkpos= yythunkpos942;
+  {  int yypos960= G->pos, yythunkpos960= G->thunkpos;  if (!yy_WS(G)) { goto l961; }  if (!yy_Include(G)) { goto l961; }  if (!yy_WS(G)) { goto l961; }  goto l960;
+  l961:;	  G->pos= yypos960; G->thunkpos= yythunkpos960;  if (!yy_WS(G)) { goto l962; }  if (!yy_Import(G)) { goto l962; }  if (!yy_WS(G)) { goto l962; }  goto l960;
+  l962:;	  G->pos= yypos960; G->thunkpos= yythunkpos960;  if (!yy_WS(G)) { goto l963; }  if (!yy_Use(G)) { goto l963; }  if (!yy_WS(G)) { goto l963; }  goto l960;
+  l963:;	  G->pos= yypos960; G->thunkpos= yythunkpos960;  if (!yy_WS(G)) { goto l964; }  if (!yy_Decl(G)) { goto l964; }  if (!yy_WS(G)) { goto l964; }  goto l960;
+  l964:;	  G->pos= yypos960; G->thunkpos= yythunkpos960;  if (!yy_WS(G)) { goto l941; }  if (!yy_Stmt(G)) { goto l941; }  yyDo(G, yySet, -1, 0);  if (!yy_WS(G)) { goto l941; }  yyDo(G, yy_13_ModuleCore, G->begin, G->end);
   }
-  l937:;	
+  l960:;	
   }
-  l919:;	
+  l942:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "ModuleCore", G->buf+G->pos));  yyDo(G, yyPop, 4, 0);
   return 1;
-  l918:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l941:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ModuleCore", G->buf+G->pos));
   return 0;
 }
 YY_RULE(int) yy_Module(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;
   yyprintf((stderr, "%s\n", "Module"));
-  {  int yypos943= G->pos, yythunkpos943= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l944; }  goto l943;
-  l944:;	  G->pos= yypos943; G->thunkpos= yythunkpos943;  if (!yy_WS(G)) { goto l942; }
-  l945:;	
-  {  int yypos946= G->pos, yythunkpos946= G->thunkpos;
-  {  int yypos947= G->pos, yythunkpos947= G->thunkpos;  if (!yy_EOL(G)) { goto l947; }  goto l946;
-  l947:;	  G->pos= yypos947; G->thunkpos= yythunkpos947;
-  }  if (!yymatchDot(G)) goto l946;  goto l945;
-  l946:;	  G->pos= yypos946; G->thunkpos= yythunkpos946;
-  }  if (!yy_EOL(G)) { goto l942; }  yyDo(G, yy_1_Module, G->begin, G->end);
+  {  int yypos966= G->pos, yythunkpos966= G->thunkpos;  if (!yy_ModuleCore(G)) { goto l967; }  goto l966;
+  l967:;	  G->pos= yypos966; G->thunkpos= yythunkpos966;  if (!yy_WS(G)) { goto l965; }
+  l968:;	
+  {  int yypos969= G->pos, yythunkpos969= G->thunkpos;
+  {  int yypos970= G->pos, yythunkpos970= G->thunkpos;  if (!yy_EOL(G)) { goto l970; }  goto l969;
+  l970:;	  G->pos= yypos970; G->thunkpos= yythunkpos970;
+  }  if (!yymatchDot(G)) goto l969;  goto l968;
+  l969:;	  G->pos= yypos969; G->thunkpos= yythunkpos969;
+  }  if (!yy_EOL(G)) { goto l965; }  yyDo(G, yy_1_Module, G->begin, G->end);
   }
-  l943:;	
+  l966:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "Module", G->buf+G->pos));
   return 1;
-  l942:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
+  l965:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "Module", G->buf+G->pos));
   return 0;
 }

--- a/source/rock/middle/BaseType.ooc
+++ b/source/rock/middle/BaseType.ooc
@@ -81,6 +81,7 @@ BaseType: class extends Type {
     }
 
     equals?: func (other: This) -> Bool {
+        if(other instanceOf?(NamespaceType)) other = other as NamespaceType inner
         if(other class != this class) return false
         return (other as BaseType name equals?(name))
     }


### PR DESCRIPTION
Closes #46
Note that there is room for improving, namely by removing the need for parenthesis in every case but rather limiting it to cases where it is clearer, as when used in casting expressions.

This is a test that compiles:

<pre lang="ooc">

import io/File into IO
import structs/[ArrayList, HashBag] into AL

f: func -> (IO File) {
    IO File new("whatever")
}

e: func(foo: (AL HashBag), bar: (AL ArrayList)) -> (IO File) {
    f()
}

g: func -> Func((AL HashBag), (AL ArrayList)) -> (IO File) { e }

h: func -> (AL ArrayList<Int>) {
    [1,2,3] as (AL ArrayList<Int>)
}

obj: Object
file: (IO File) = obj as (IO File)
</pre>
