### PR TITLE
Fixing #385 (Wrapping function into a closure when assigned)

### DIFF
--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -245,12 +245,14 @@ VariableAccess: class extends Expression {
             parent := trail peek()
 
             if (!fType isClosure) {
+
                 closureElements := [
                     this
                     NullLiteral new(token)
                 ] as ArrayList<VariableAccess>
 
                 closureType: FuncType = null
+
 
                 if (parent instanceOf?(FunctionCall)) {
                     /*
@@ -291,6 +293,24 @@ VariableAccess: class extends Expression {
                     fIndex := trail find(FunctionDecl)
                     if (fIndex != -1) {
                         closureType = trail get(fIndex, FunctionDecl) returnType clone()
+                    }
+                } elseif (parent instanceOf?(VariableDecl)) {
+                    /*
+                    Handle the assignment of a first-class function.
+                    Example:
+
+                    f: func() {}
+                    g := f
+
+                    The right side needs to be a Closure having f and null as context.
+                    */
+                    p := parent as VariableDecl
+                    if (p expr == this) {
+                        closureType = ref getType()
+                        if (!closureType) {
+                            res wholeAgain(this, "need type of FDecl")
+                            return Response OK
+                        }
                     }
                 }
 


### PR DESCRIPTION
```
f: func(Int) -> Int
g := f
```

^ now compiles properly. Tested by successfully recompiling rock several times.
