### PR TITLE
Check operators in BinaryOp if Func-types are involved (Issue #376)

### DIFF
--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -387,7 +387,15 @@ BinaryOp: class extends Expression {
             if (!isAssign()) {
                 return false
             }
+
+            // If the left side is an immutable function, fail immediately.
+            l := lRef as FuncType
+            if (!(l isClosure)) {
+            token module params errorHandler onError(InvalidBinaryOverload new(token,
+                "%s is an immutable function. You must not reassign it. (Perhaps you want to use a first-class function instead?)" format(left toString())))
+            }
         }
+
         if(isAssign()) {
             score := lType getScore(rType)
             if(score == -1) {


### PR DESCRIPTION
```
f: func
g: func
f + g
```

^ fails (correctly). If the operator is overloaded, the operation succeeds.

```
f: func
g: func
f + g

operator + (f1: Func, f2: Func) -> Int {42}
```
