### PR TITLE
Should make `make rescue` work almost universally.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,9 @@ backup:
 # Attempt to grab a rock bootstrap from Alpaca and recompile
 rescue:
 	rm -rf build/
-	# Note: don't use --no-check-certificate, OSX is retarded
-	# Note: someone make a curl fallback already
-	wget --no-check-certificate http://www.fileville.net/ooc/bootstrap.tar.bz2 -O - | tar xjvmpf - 1>/dev/null
+	# Note: ./utils/downloader tries curl, ftp, and then wget.
+	#        GNU ftp will _not_ work: it does not accept a url as an argument.
+	./utils/downloader.sh http://www.fileville.net/ooc/bootstrap.tar.bz2 | tar xjvmpf - 1>/dev/null
 	if [ ! -e build ]; then cp -rfv rock-*/build ./; fi	
 	$(MAKE) clean bootstrap
 

--- a/utils/downloader.sh
+++ b/utils/downloader.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+curl -L $1 || ftp -o - $1 || wget --no-check-certificate -O - $1 || wget -O - $1


### PR DESCRIPTION
This should change it so `make rescue` works on almost all UNIX and UNIX-like systems.

It tries curl, ftp (which will not work with GNU ftp), then wget.
It also takes into account the fact that some versions of wget barf when passed `--no-check-certificate`.
