### PR TITLE
Fix @showstopper's silliness :)

### DIFF
--- a/source/rock/middle/ClassDecl.ooc
+++ b/source/rock/middle/ClassDecl.ooc
@@ -138,12 +138,12 @@ ClassDecl: class extends TypeDecl {
     getBaseClass: func (fDecl: FunctionDecl, withInterfaces: Bool, comeBack: Bool*) -> ClassDecl {
         sRef := getSuperRef() as ClassDecl
         // An interface might not yet be resolved.
-        comeBack = false 
+        comeBack@ = false 
         // first look in the supertype, if any
         if(sRef != null) {
              
             base := sRef getBaseClass(fDecl, comeBack)
-            if (comeBack) { // ugly_
+            if (comeBack@) { // ugly_
                 return null
             }
             if(base != null) {


### PR DESCRIPTION
Why did this happen? Because pointers.

This fixes the issue where on OpenBSD it can compile `c_rock`, but `c_rock` can't compile the ooc sources.
