### PR TITLE
Make curl ignore certs

### DIFF
--- a/utils/downloader.sh
+++ b/utils/downloader.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-curl -L $1 || ftp -o - $1 || wget --no-check-certificate -O - $1 || wget -O - $1
+curl -k -L $1 || ftp -o - $1 || wget --no-check-certificate -O - $1 || wget -O - $1


### PR DESCRIPTION
On a fresh NetBSD install, cacert stuff isn't set up, so passing -k to curl should do the trick.
