### PR TITLE
Remove need to allocate separate TCPReaderWriterPair for each socket.

### DIFF
--- a/sdk/net/TCPSocket.ooc
+++ b/sdk/net/TCPSocket.ooc
@@ -7,6 +7,25 @@ import berkeley into socket
  */
 TCPSocket: class extends Socket {
     remote: SocketAddress
+    readerWriter: TCPReaderWriterPair
+
+    /**
+      Getter for accessing `readerWriter in`
+    */
+    in: TCPSocketReader {
+        get {
+            readerWriter in
+        }
+    }
+
+    /**
+      Getter for accessing `readerWriter out`
+    */
+    out: TCPSocketWriter {
+        get {
+            readerWriter out
+        }
+    }
 
     /**
        Create a new socket to a given remote address
@@ -59,6 +78,9 @@ TCPSocket: class extends Socket {
         if(socket connect(descriptor, remote addr(), remote length()) == -1) {
             SocketError new() throw()
         }
+
+        readerWriter = TCPReaderWriterPair new(this)
+
         connected? = true
     }
 
@@ -72,9 +94,7 @@ TCPSocket: class extends Socket {
         if(!connected?)
             connect()
 
-        conn := TCPReaderWriterPair new(this)
-
-        f(conn)
+        f(readerWriter)
     }
 
     /**


### PR DESCRIPTION
Instead of:

``` ooc
sock := TCPSocket new(host, port)
sock connect()
pair := TCPReaderWriterPair new(sock)
pair out write("blah blah blah this goes to the socket\n")
pair in readAll() println()
```

you can now do:

``` ooc
sock := TCPSocket new(host, port)
sock connect()
sock out write("blah blah blah this goes to the socket\n")
sock in readAll() println()
```
