### PR TITLE
Closes #420

### DIFF
--- a/source/rock/backend/cnaughty/FunctionCallWriter.ooc
+++ b/source/rock/backend/cnaughty/FunctionCallWriter.ooc
@@ -72,7 +72,8 @@ FunctionCallWriter: abstract class extends Skeleton {
             // TODO maybe check there's some kind of inheritance/compatibility here?
             // or in the tinker phase?
             if(shouldCastThis || !(callType equals?(declType))) {
-                current app("("). app(declType). app(") ")
+                // If this is a ref call, we should write down the referenced type that is passed as the callType (as determined in tinkering phase)
+                current app("("). app(fDecl isThisRef ? callType : declType). app(") ")
             }
 
             if(fDecl isThisRef) current app("&("). app(fCall expr). app(")")


### PR DESCRIPTION
Rock bootstraps and the following tests pass:

<pre lang="ooc">
Foo: cover {
    bar: func@ {
        "bar" println()
    }

    baz: func@ {
        bar()
        "baz" println()
    }
}
</pre>


<pre lang="ooc">
Foo: cover {
    bar: func@ {
        "bar" println()
    }

    baz: func {
        bar()
        "baz" println()
    }
}
</pre>


<pre lang="ooc">
Foo: cover {
    bar: func {
        "bar" println()
    }

    baz: func@ {
        bar()
        "baz" println()
    }
}
</pre>
