### PR TITLE
Operator calls on objects of a child class can now correctly call the operator declaration for the base class

### DIFF
--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -500,10 +500,10 @@ BinaryOp: class extends Expression {
             return -1
         }
 
-        leftScore  := left  getType() getStrictScore(opLeft  getType())
+        leftScore  := left  getType() getScore(opLeft  getType())
         if(leftScore  == -1) return -1
 
-        rightScore := right getType() getStrictScore(opRight getType())
+        rightScore := right getType() getScore(opRight getType())
         if(rightScore == -1) return -1
 
         reqScore   := reqType ? fDecl getReturnType() getScore(reqType) : 0

--- a/source/rock/middle/UnaryOp.ooc
+++ b/source/rock/middle/UnaryOp.ooc
@@ -136,7 +136,7 @@ UnaryOp: class extends Expression {
 
         if(args get(0) getType() == null || inner getType() == null) { return -1 }
 
-        argScore := args get(0) getType() getStrictScore(inner getType())
+        argScore := args get(0) getType() getScore(inner getType())
         if(argScore == -1) return -1
         reqScore := reqType ? fDecl getReturnType() getScore(reqType) : 0
         if(reqScore == -1) return -1


### PR DESCRIPTION
Why this change is ok:
- When two types are unrelated, Type NOLUCK_SCORE is returned by Type getScore() anyway
- The more unrelated two types are (further away in an inheritance diagram), the lower the score Type getScore() returns
- If two types are the same, Type getScore() returns TYPE SEED_SCORE, which is the maximum score
- The direct result of the two points above is that the most correct declaration will be chosen when using Type getScore(), rather than discarding every declaration when the call's argument and the declaration's argument are not the same

Here are some tests that pass using this version of rock and fail using the version before this commit:

<pre lang="ooc">
// Every test must be compiled as an independent program

/* Test 1 */
operator + (left: String, right: LLong) {
    "Test 1 passed" println()
}

"foo" + 42 as Int

/* Test 2 */
Foo: class {}
Bar: class extends Foo {}

operator + <T> (left: Foo, right: T) {
    "Test 2 passed" println()
}

bar: Bar
bar + 42


/* Test 3 */
Foo: class {}
Bar: class extends Foo {}

operator + <T> (left: Foo, right: T) {
    "Test 3 failed" println()
}

operator + <T> (left: Bar, right: T) {
    "Test 3 passed" println()
}

bar: Bar
bar + 42


/* Test 4 */
Foo: interface {}
Bar: interface {}
Baz: class implements Foo, Bar {}

// First declaration wins; Same as function behaviour
operator + <T> (left: Foo, right: T) {
    "Test 4 passed" println()
}

operator + <T> (left: Bar, right: T) {
    "Test 4 failed" println()
}

baz: Baz
baz + 42

/* Test 5 */
Foo: class {}
Bar: class extends Foo {}
Baz: class extends Bar {}

operator + <T> (left: Foo, right: T) {
    "Test 5 failed" println()
}

operator + <T> (left: Bar, right: T) {
    "Test 5 passed" println()
}

baz: Baz
baz + 42
</pre>
