### PR TITLE
Closes #436

### DIFF
--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -228,6 +228,27 @@ VariableAccess: class extends Expression {
                                     bOp := trail get(bOpIDX, BinaryOp)
                                     if (bOp getLeft() == this && bOp isAssign()) mode = "r"
                                 }
+
+                                // Find the first Scope that is the body of a function declaration in the top of the trail
+                                scopeDepth := closureIndex - 1
+                                while(scopeDepth > 0) {
+                                    maybeScope := trail get(scopeDepth, Node)
+                                    if(maybeScope instanceOf?(Scope)) {
+                                        maybeClosure := trail get(scopeDepth - 1, Node)
+                                        // Only partial the variable in the top function if it has not be defined by it and it is not one of its arguments
+                                        if(maybeClosure instanceOf?(FunctionDecl) && maybeClosure as FunctionDecl isAnon \
+                                           && !maybeClosure as FunctionDecl args contains?(|arg| arg name == name || arg name == name + "_generic") \
+                                           && !maybeScope as Scope list contains?(|stmt| stmt instanceOf?(VariableDecl) && stmt as VariableDecl name == name)) {
+                                            // Mark the variable for partialing to top level closure
+                                            maybeClosure as FunctionDecl markForPartialing(ref as VariableDecl, mode)
+                                            if(!maybeClosure as FunctionDecl clsAccesses contains?(this)) {
+                                                maybeClosure as FunctionDecl clsAccesses add(this)
+                                            }
+                                        }
+                                    }
+                                    scopeDepth -= 1
+                                }
+
                                 closure markForPartialing(ref as VariableDecl, mode)
                                 closure clsAccesses add(this)
                             }


### PR DESCRIPTION
I think I took care of any possibility so that we don't get duplicate function declarations.
This code compiles:

<pre lang="ooc">

f: func(g: Func) {
    g()
}

g: func {
    foo := 42
    f(|| f(|| f(|| f(|| foo toString() println()))))
}

g()
</pre>


And prints out 42, as expected.
Also, twisted stuff like the following compile too:

<pre lang="ooc">

id: func(x: Int) -> Int { x }

f: func(g: Func(Func(Int)->Int)) {
    g(|x| x)
}

g: func {
    foo := 42
    f(|g| f(|h| f(|j| g(foo) toString() println())))
}

g()
</pre>


Which previously failed

I may be missing something as I am too tired right now so it would be ideal if you could also take a look at my code.
