### PR TITLE
Consp force libgc compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 	@echo "Done!"
 
 boehmgc:
-	cd libs && $(MAKE)
+	cd libs && $(MAKE) LIBGC_FORCE_COMPILE=${LIBGC_FORCE_COMPILE}
 
 # For c-source based rock releases, 'make bootstrap' will compile a version
 # of rock from the C sources in build/, then use that version to re-compile itself

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -47,6 +47,10 @@ GC_PREFIX?=/usr/lib/
 LIBGC_PRESENT=$(wildcard ${GC_PREFIX}/libgc.a)
 LIBGC_SUPPORTS_THREADS=$(shell nm $(wildcard ${GC_PREFIX}/libgc.a) | grep GC_pthread_create)
 
+ifneq (${LIBGC_FORCE_COMPILE},)
+  LIBGC_PRESENT=
+endif
+
 all:
 	mkdir -p ${GC_PATH}
 ifneq (${LIBGC_PRESENT},)


### PR DESCRIPTION
This forces it to compile libgc. Useful in cases where the system libgc
does not work as it should. (I ran into this problem on ArchLinux. Not
sure what happened.)

[Cherry-picked from master]
