### PR TITLE
Moved closure capturing from VariableAccess and FunctionCall to VariableDecl, removes a lot of duplicate code

### DIFF
--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -349,52 +349,7 @@ FunctionCall: class extends Expression {
                         }
 
                         if(ref && ref vDecl) {
-                            closureIndex := trail find(FunctionDecl)
-
-                            if(closureIndex > depth) { // if it's not found (-1), this will be false anyway
-                                closure := trail get(closureIndex) as FunctionDecl
-                                // the ref may also be a closure's argument, in wich case we just ignore this
-
-                                // Find the closer Scope that is a function body upstream
-                                scopeDepth := closureIndex - 1
-                                while(scopeDepth > 0) {
-                                    maybeScope := trail get(scopeDepth, Node)
-                                    if(maybeScope instanceOf?(Scope)) {
-                                        scope := maybeScope as Scope
-                                        maybeClosure := trail get(scopeDepth - 1, Node)
-                                        if(maybeClosure instanceOf?(FunctionDecl)) {
-                                            closure := maybeClosure as FunctionDecl
-                                            // Find out if our access is between the kid closure and the parent closure
-                                            isDefined? := false
-                                            intermediateScopeIndex := closureIndex - 1
-                                            while(intermediateScopeIndex > scopeDepth) {
-                                                interScope? := trail get(intermediateScopeIndex, Node)
-                                                if(interScope? instanceOf?(Scope)) {
-                                                    interScope := interScope? as Scope
-                                                    if(interScope list contains?(|stmt| stmt instanceOf?(VariableDecl) && stmt as VariableDecl name == name)) {
-                                                        isDefined? = true
-                                                    }
-                                                }
-                                                intermediateScopeIndex -= 1
-                                            }
-                                            // Only partial the variable in the top function if it has not be defined by it and it is not one of its arguments
-                                            if(closure isAnon && !closure args contains?(|arg| arg name == ref vDecl name || arg name == ref vDecl name + "_generic") \
-                                                && !isDefined?) {
-                                                // Mark the variable for partialing to top level closure
-                                                closure markForPartialing(ref vDecl, "v")
-                                            }
-                                        }
-                                    }
-                                    scopeDepth -= 1
-                                }
-
-                                // if our function was defined in the closure's body or arguments, we need not mark it for partialing
-                                definedInClosure? := closure getBody() list ? closure getBody() list contains?(ref vDecl) : false
-                                if(closure isAnon && !ref vDecl isGlobal && !definedInClosure? &&
-                                    !closure args contains?(|arg| arg == ref vDecl || arg name == ref vDecl name + "_generic")) {
-                                    closure markForPartialing(ref vDecl, "v")
-                                }
-                            }
+                            ref vDecl captureInUpstreamClosures(trail, depth)
                         }
                         depth -= 1
                     }


### PR DESCRIPTION
...Decl, removing a lot of duplicate code
