### PR TITLE
Fix zero length strings

### DIFF
--- a/sdk/lang/Buffer.ooc
+++ b/sdk/lang/Buffer.ooc
@@ -113,8 +113,8 @@ Buffer: class extends Iterable<Char> {
 
     /** sets capacity and size flag, and a zero termination */
     setLength: func (newLength: SizeT) {
-        if(newLength != size) {
-            if(newLength > capacity) {
+        if(newLength != size || newLength == 0) {
+            if(newLength > capacity || newLength == 0) {
                 setCapacity(newLength)
             }
             size = newLength


### PR DESCRIPTION
Now it should allocate some memory even for empty strings. Recompiled rock twice, still works!

`size := -1` is a way cooler idea, but size is a SizeT and I didn't think this was worth changing the type to SSizeT.
