### PR TITLE
Fix octal escapes

### DIFF
--- a/sdk/text/EscapeSequence.ooc
+++ b/sdk/text/EscapeSequence.ooc
@@ -88,7 +88,7 @@ EscapeSequence: class {
                 /* escape sequence starting! */
                 i += 1
                 j := i
-                if(s[i] == '0') {
+                if(s[i] >= '0' && s[i] < '8') {
                     /* octal. */
                     while(j < s length() && s[j] >= '0' && s[j] < '8') {
                         j += 1


### PR DESCRIPTION
Well, the codes in #324 and #651 work now, so I guess this should be it? Guess nobody uses octal escape sequences anyway.
