### PR TITLE
Fix windows build

### DIFF
--- a/sdk/os/native/PipeWin32.ooc
+++ b/sdk/os/native/PipeWin32.ooc
@@ -108,8 +108,8 @@ WriteFile:     extern func (hFile: Handle, buffer: Pointer, numberOfBytesToWrite
 CloseHandle:   extern func (handle: Handle) -> Bool
 SetNamedPipeHandleState: extern func (handle: Handle, mode: Long*, maxCollectionCount: Long*, collectDataTimeout: Long*)
 
-PIPE_WAIT, PIPE_NOWAIT: Long
-ERROR_NO_DATA: Long
+PIPE_WAIT, PIPE_NOWAIT: extern Long
+ERROR_NO_DATA: extern Long
 
 SecurityAttributes: cover from SECURITY_ATTRIBUTES {
     length: extern(nLength) Int


### PR DESCRIPTION
Some variables in recent modifications of windows pipes were not marked as extern.
Because of that, they were declared as ooc variables in the module's load function and used in other functions, causing C errors.
