### PR TITLE
Properly add OpenBSD support.

### DIFF
--- a/libs/Makefile
+++ b/libs/Makefile
@@ -41,6 +41,8 @@ UNIARCH:=$(ARCH)
 ifneq ($(ARCH), osx)
   ifeq ($(MACHINE), x86_64)
     ARCH:=${ARCH}64
+  else ifeq ($(MACHINE), amd64)
+    ARCH:=${ARCH}64
   else ifeq (${MINGW64_PRESENT}, 1)
     ARCH:=${ARCH}64
   else

--- a/sdk/threading/native/ThreadUnix.ooc
+++ b/sdk/threading/native/ThreadUnix.ooc
@@ -24,7 +24,7 @@ version(unix || apple) {
         }
 
         wait: func ~timed (seconds: Double) -> Bool {
-            version (!apple) {
+            version (!openbsd) {
                 ts: TimeSpec
                 __setupTimeout(ts&, seconds)
                     
@@ -32,7 +32,7 @@ version(unix || apple) {
                 return (result == 0)
             }
 
-            version (apple) {
+            version (openbsd) {
                 return __fake_timedjoin(seconds)
             }
             false
@@ -104,7 +104,7 @@ version(unix || apple) {
         tv_nsec: extern Long
     }
 
-    version (!apple) {
+    version (!openbsd) {
         // Using proto here as defining '_GNU_SOURCE' seems to cause more trouble than anything else...
         pthread_timedjoin_np: extern proto func (thread: PThread, retval: Pointer, abstime: TimeSpec*) -> Int
     }

--- a/source/rock/frontend/drivers/Archive.ooc
+++ b/source/rock/frontend/drivers/Archive.ooc
@@ -321,7 +321,8 @@ Archive: class {
         if (thin) {
             // Apple's linker thinks -T means truncate. Who's living
             // in the 18th century? It's OpenStep's bastard child!
-            if (params target != Target OSX) {
+            // OpenBSD's binutils (binutils-2.15) predates ar -T.
+            if (params target != Target OSX && params target != Target OPENBSD) {
                 flags add("T")
             }
         }

--- a/source/rock/frontend/drivers/MakeDriver.ooc
+++ b/source/rock/frontend/drivers/MakeDriver.ooc
@@ -133,6 +133,8 @@ MakeDriver: class extends SequenceDriver {
         fW write("ifneq ($(ARCH), osx)\n")
         fW write("  ifeq ($(MACHINE), x86_64)\n")
         fW write("    ARCH:=${ARCH}64\n")
+        fW write("  ifeq ($(MACHINE), amd64)\n")
+        fW write("    ARCH:=${ARCH}64\n")
         fW write("  else ifeq (${PROCESSOR_ARCHITECTURE}, AMD64)\n")
         fW write("    ARCH:=${ARCH}64\n")
         fW write("  else\n")


### PR DESCRIPTION
This patch allows 64-bit x86 OpenBSD machines to be properly detected, to allow rock to build.
OpenBSD's ar does not have the -T option, so disable it like Mac OS X.

The sdk/threading/native/ThreadUnix.ooc patch is obviously not correct, but
version (!apple && !openbsd)
and
version (apple || openbsd)
did not work either. Guidance for that would be appreciated.

With this patch, rock builds and runs on OpenBSD/amd64.