### PR TITLE
Reduce warning in c sources

### DIFF
--- a/source/rock/backend/cnaughty/FunctionCallWriter.ooc
+++ b/source/rock/backend/cnaughty/FunctionCallWriter.ooc
@@ -73,7 +73,7 @@ FunctionCallWriter: abstract class extends Skeleton {
             // or in the tinker phase?
             if(shouldCastThis || !(callType equals?(declType))) {
                 // If this is a ref call, we should write down the referenced type that is passed as the callType (as determined in tinkering phase)
-                //current app("("). app(fDecl isThisRef ? callType : declType). app(") ")
+                // We should not cast it when it is non-ref ArrayType
                 if(!(callType class == ArrayType && !fDecl isThisRef))
                     current app("("). app(fDecl isThisRef ? (fDecl owner thisRefDecl getType()) : declType). app(") ")
             }


### PR DESCRIPTION
current c sources generated by rock give the follow warnings:

```
clang: warning: argument unused during compilation: '-rdynamic'
/home/housezet/kplex/todot/./input.ooc:75:49: warning: incompatible pointer types passing 'structs_ArrayList__ArrayList *' (aka 'struct _structs_ArrayList__ArrayList *') to parameter of type
      'structs_ArrayList__ArrayList **' (aka 'struct _structs_ArrayList__ArrayList **') [-Wincompatible-pointer-types]
            structs_ArrayList__ArrayList_addSND((structs_ArrayList__ArrayList*) &(r), (structs_ArrayList____OP_IDX_ArrayList_Int__T((uint8_t*) &(_____input_genCall16), (lang_types__Cl...
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rock_tmp/ooc/./input/./input-fwd.h:65:73: note: passing argument to parameter 'this' here
```

This patch removes these warnings by reducing unnecessary type-cast.
I've been using this patch for some days( https://github.com/zhaihj/rock/commit/e0ce8cfa40389d2a09bc7c5cf68e0c5d66659f03 ), and everything seems to work well
