### PR TITLE
Warn on non-ref init function in cover

### DIFF
--- a/source/rock/middle/ClassDecl.ooc
+++ b/source/rock/middle/ClassDecl.ooc
@@ -18,6 +18,7 @@ ClassDecl: class extends TypeDecl {
     isFinal := false
     
     shouldCheckNoArgConstructor := false
+    isInitReported := false
 
     init: func ~classDeclNoSuper(.name, .token) {
         super(name, token)
@@ -55,6 +56,14 @@ ClassDecl: class extends TypeDecl {
                     fDecl isThisRef = true
                     fDecl isFinal = true
                     addFunction(fDecl)
+                }
+            }
+
+            if(!isInitReported && isCover) {
+                initDecl := functions get("init")
+                if(initDecl && !initDecl isThisRef){
+                    isInitReported = true
+                    res throwError(Warning new(initDecl token, "init in cover is non-ref."))
                 }
             }
 


### PR DESCRIPTION
Currently

```
foo: cover{
    a : Int = 0
    init: func{ a = 1 }
}
```

compiles but clearly init func won't work.
At least we should throw a warning on this suitation.
