### PR TITLE
Fix wrong use search

### DIFF
--- a/source/rock/middle/UseDef.ooc
+++ b/source/rock/middle/UseDef.ooc
@@ -110,7 +110,23 @@ UseDef: class {
     }
 
     findUse: static func (fileName: String, params: BuildParams) -> File {
+        getName := func(path: String)->String{
+            len := path size - 1
+            while(len > 0){
+                if(path[len] == '/' || path[len] == '\\'){
+                    break
+                }
+                len -= 1
+            }
+            ret := ""
+            for(i in len+1..path size){
+                ret += path[i]
+            }
+            ret
+        }
         set := params libsPaths
+
+        _cache: File = null
 
         for(path in set) {
             if(path getPath() == null) continue
@@ -125,14 +141,16 @@ UseDef: class {
                     }
                 }
                 if(subPath file?() || subPath link?()) {
-                    if(subPath getPath() endsWith?(fileName)) {
+                    if(getName(subPath getPath()) == fileName){
                         return subPath
+                    } else if(subPath getPath() endsWith?(fileName)) {
+                        if(!_cache) _cache = subPath
                     }
                 }
             }
         }
 
-        return null
+        return _cache
     }
 
     apply: func (params: BuildParams) {

--- a/source/rock/middle/UseDef.ooc
+++ b/source/rock/middle/UseDef.ooc
@@ -113,8 +113,10 @@ UseDef: class {
         getName := func(path: String)->String{
             len := path size - 1
             while(len > 0){
-                if(path[len] == '/' || path[len] == '\\'){
-                    break
+                version(windows){
+                    if(path[len] == '/' || path[len] == '\\'){ break }
+                } else {
+                    if(path[len] == '/'){ break }
                 }
                 len -= 1
             }


### PR DESCRIPTION
### Problem Description:
 
UseDef findUse() return wrong path according to the order of soures.

Assume that we have ./ooc-math.use and ./source/sdk/math.use. When searching for math.use, the following code

    if(subPath getPath() endsWith?(fileName))

gives ooc-math.use instead of math.use because both of them have suffixes "math.use" but ooc-math is searched first. This will cause circle dependency problem.

### How to reproduce:
Compile ooc-kean with the lastest rock.

### Fix:

* Added getName() to extract filename from path.
* When getName() does not work well, it will return the first match of endWiths.
