### PR TITLE
Print dependcygraph when circular dependencies occurs

### DIFF
--- a/source/rock/frontend/drivers/DependencyGraph.ooc
+++ b/source/rock/frontend/drivers/DependencyGraph.ooc
@@ -126,6 +126,21 @@ DependencyGraph: class {
             } else {
                 repr := pool map(|sf| sf identifier) join(", ")
                 message := "Circular dependencies among remaining modules: [%s]" format(repr)
+
+                if (params verbose) {
+                    message += "\nDependcy Graph: \n"
+                    for(sf in pool){
+                        message += "%s : %d [\n" \
+                                format(sf identifier, _numDependencies(sf))
+                        for (dep in deps) {
+                            if (!dep satisfied && dep lhs == sf) {
+                                message += "\t"+dep toString()+"\n"
+                            }
+                        }
+                        message += "]\n"
+                    }
+                }
+
                 _throwError(nullToken, message)
             }
         }

--- a/source/rock/frontend/drivers/DependencyGraph.ooc
+++ b/source/rock/frontend/drivers/DependencyGraph.ooc
@@ -128,7 +128,7 @@ DependencyGraph: class {
                 message := "Circular dependencies among remaining modules: [%s]" format(repr)
 
                 if (params verbose) {
-                    message += "\nDependcy Graph: \n"
+                    message += "\nDependency Graph: \n"
                     for(sf in pool){
                         message += "%s : %d [\n" \
                                 format(sf identifier, _numDependencies(sf))


### PR DESCRIPTION
Print a simple dependency graph : (--verbose)

	From unknown source [error] Circular dependencies among remaining modules: [test/base/CLIParserTest, sdk, ooc-math, ooc-collections, ooc-base]
	Dependency Graph: 
	test/base/CLIParserTest : 3 [
		test/base/CLIParserTest => sdk
		test/base/CLIParserTest => ooc-collections
		test/base/CLIParserTest => ooc-base
	]
	sdk : 1 [
		sdk => ooc-math
	]
	ooc-math : 1 [
		ooc-math => sdk
	]
	ooc-collections : 1 [
		ooc-collections => sdk
	]
	ooc-base : 2 [
		ooc-base => sdk
		ooc-base => ooc-collections
	]

	[FAIL]
