### PR TITLE
Avoid using _impl when func is final or abstract

### DIFF
--- a/source/rock/backend/cnaughty/ClassDeclWriter.ooc
+++ b/source/rock/backend/cnaughty/ClassDeclWriter.ooc
@@ -427,7 +427,7 @@ ClassDeclWriter: abstract class extends Skeleton {
 
         decl := realDecl ? realDecl : parentDecl
         FunctionDeclWriter writeFullName(this, decl)
-        if(!decl isExternWithName() && impl) current app("_impl")
+        if(!decl isFinal && !decl isAbstract && !decl isExternWithName() && impl) current app("_impl")
         current app(',')
 
     }


### PR DESCRIPTION
See https://github.com/fasterthanlime/rock/issues/851

The following code causes c compilation error

	First: class {
		init: func
		test: func
	}

	Second: class extends First {
		init: func
		test: final func
	}

	s := Second new()
	s test()

because final function does not have impl but it is still used in backend/ClassDeclWriter/writeDesignatedInit()