### PR TITLE
Do not generate expr for properties

### DIFF
--- a/source/rock/middle/VariableDecl.ooc
+++ b/source/rock/middle/VariableDecl.ooc
@@ -2,7 +2,7 @@ import structs/[ArrayList]
 import Type, Declaration, Expression, Visitor, TypeDecl, VariableAccess,
        Node, ClassDecl, FunctionCall, Argument, BinaryOp, Cast, Module,
        Block, Scope, FunctionDecl, Argument, BaseType, FuncType, Statement,
-       NullLiteral, Tuple, TypeList, AddressOf
+       NullLiteral, Tuple, TypeList, AddressOf, PropertyDecl
 import tinker/[Response, Resolver, Trail, Errors]
 import ../frontend/BuildParams
 
@@ -311,12 +311,14 @@ VariableDecl: class extends Declaration {
                 }
                 expr = null
             }
-            fCall := FunctionCall new("gc_malloc", token)
-            tAccess := VariableAccess new(type getName(), token)
-            sizeAccess := VariableAccess new(tAccess, "size", token)
-            fCall getArguments() add(sizeAccess)
-            expr = fCall
-            res wholeAgain(this, "just set expr to gc_malloc cause generic!")
+            if(!this instanceOf?(PropertyDecl)){
+                fCall := FunctionCall new("gc_malloc", token)
+                tAccess := VariableAccess new(type getName(), token)
+                sizeAccess := VariableAccess new(tAccess, "size", token)
+                fCall getArguments() add(sizeAccess)
+                expr = fCall
+                res wholeAgain(this, "just set expr to gc_malloc cause generic!")
+            }
         }
 
         if(expr != null && !isLegal(res)) {

--- a/test/compiler/properties/issue840-generic-properties.ooc
+++ b/test/compiler/properties/issue840-generic-properties.ooc
@@ -1,0 +1,31 @@
+tfoo: class<T>{
+    init: func(){}
+    a: T
+    b: T{
+        get { a }
+        set(c){ a = c }
+    }
+}
+
+main: func -> Int{
+    tbar := tfoo<Int> new()
+    tbar a = 1
+    if(tbar a as Int != 1){
+        "error get_a" println()
+        return 1
+    }
+    if(tbar b != 1){
+        "error get_b" println()
+        return 1
+    }
+    tbar b = 2
+    if(tbar a as Int != 2){
+        "error set_b, a %s" printfln()
+        return 1
+    }
+    if(tbar b != 2){
+        "error set_get_b" println()
+        return 1
+    }
+    0
+}


### PR DESCRIPTION
Issue: https://github.com/fasterthanlime/rock/issues/840
gc_malloc unresolved is caused by the unused auto-generated initialization in __default__.