### PR TITLE
Dereference generics in comparison

### DIFF
--- a/sdk/structs/HashMap.ooc
+++ b/sdk/structs/HashMap.ooc
@@ -1,5 +1,5 @@
 
-import ArrayList
+import ArrayList, Utils
 
 /**
  * Container for key/value entries in the hash table
@@ -17,153 +17,6 @@ HashEntry: cover {
 
 nullHashEntry: HashEntry
 memset(nullHashEntry&, 0, HashEntry size)
-
-stringEquals: func <K> (k1, k2: K) -> Bool {
-    assert(K == String)
-    k1 as String equals?(k2 as String)
-}
-
-cstringEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as CString == k2 as CString
-}
-
-
-pointerEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as Pointer == k2 as Pointer
-}
-
-intEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as Int == k2 as Int
-}
-
-charEquals: func <K> (k1, k2: K) -> Bool {
-    k1 as Char == k2 as Char
-}
-
-/** used when we don't have a custom comparing function for the key type */
-genericEquals: func <K> (k1, k2: K) -> Bool {
-    // FIXME rock should turn == between generic vars into a memcmp itself
-    memcmp(k1, k2, K size) == 0
-}
-
-intHash: func <K> (key: K) -> SizeT {
-    result: SizeT = key as Int
-    return result
-}
-
-pointerHash: func <K> (key: K) -> SizeT {
-    return (key as Pointer) as SizeT
-}
-
-charHash: func <K> (key: K) -> SizeT {
-    // both casts are necessary
-    // Casting 'key' directly to UInt would deref a pointer to UInt
-    // which would read random memory just after the char, which is not a good idea..
-    return (key as Char) as SizeT
-}
-
-/**
-   Port of Austin Appleby's Murmur Hash implementation
-   http://code.google.com/p/smhasher/
-
-   :param: key The key to hash
-   :param: seed The seed value
- */
-murmurHash: func <K> (keyTagazok: K) -> SizeT {
-
-    seed: SizeT = 1 // TODO: figure out what makes a good seed value?
-
-    len := K size
-    m = 0x5bd1e995 : const SizeT
-    r = 24 : const SSizeT
-    l := len
-
-    h : SizeT = seed ^ len
-    data := (keyTagazok&) as Octet*
-
-    while (true) {
-        k := (data as SizeT*)@
-
-        k *= m
-        k ^= k >> r
-        k *= m
-
-        h *= m
-        h ^= k
-
-        data += 4
-        if(len < 4) break
-        len -= 4
-    }
-
-    t := 0
-
-    if(len == 3) h ^= data[2] << 16
-    if(len == 2) h ^= data[1] << 8
-    if(len == 1) h ^= data[0]
-
-    t *= m; t ^= t >> r; t *= m; h *= m; h ^= t;
-    l *= m; l ^= l >> r; l *= m; h *= m; h ^= l;
-
-    h ^= h >> 13
-    h *= m
-    h ^= h >> 15
-
-    return h
-}
-
-/**
- * khash's ac_X31_hash_string
- * http://attractivechaos.awardspace.com/khash.h.html
- * @access private
- * @param s The string to hash
- * @return UInt
- */
-ac_X31_hash: func <K> (key: K) -> SizeT {
-    assert(key as Pointer != null)
-    s : Char* = (K == String) ? (key as String) toCString() as Char* : key as Char*
-    h = s@ : SizeT
-    if (h) {
-        s += 1
-        while (s@) {
-            h = (h << 5) - h + s@
-            s += 1
-        }
-    }
-    return h
-}
-
-/* this function seem is called by List */
-getStandardEquals: func <T> (T: Class) -> Func <T> (T, T) -> Bool {
-    // choose comparing function for key type
-    if(T == String) {
-        stringEquals
-    } else if(T == CString) {
-        cstringEquals
-    } else if(T size == Pointer size) {
-        pointerEquals
-    } else if(T size == UInt size) {
-        intEquals
-    } else if(T size == Char size) {
-        charEquals
-    } else {
-        genericEquals
-    }
-}
-
-getStandardHashFunc: func <T> (T: Class) -> Func <T> (T) -> SizeT {
-    if(T == String || T == CString) {
-        ac_X31_hash
-    } else if(T size == Pointer size) {
-        pointerHash
-    } else if(T size == UInt size) {
-        intHash
-    } else if(T size == Char size) {
-        charHash
-    } else {
-        murmurHash
-    }
-}
 
 /**
  * Simple hash table implementation
@@ -202,8 +55,8 @@ HashMap: class <K, V> extends BackIterable<V> {
         buckets = HashEntry[capacity] new()
         keys = ArrayList<K> new()
 
-        keyEquals = getStandardEquals(K)
-        hashKey = getStandardHashFunc(K)
+        keyEquals = Utils getStandardEquals(K)
+        hashKey = Utils getStandardHashFunc(K)
 
         T = V // workarounds ftw
     }

--- a/sdk/structs/HashMap.ooc
+++ b/sdk/structs/HashMap.ooc
@@ -120,7 +120,7 @@ murmurHash: func <K> (keyTagazok: K) -> SizeT {
  * @return UInt
  */
 ac_X31_hash: func <K> (key: K) -> SizeT {
-    assert(key != null)
+    assert(key as Pointer != null)
     s : Char* = (K == String) ? (key as String) toCString() as Char* : key as Char*
     h = s@ : SizeT
     if (h) {

--- a/sdk/structs/List.ooc
+++ b/sdk/structs/List.ooc
@@ -1,5 +1,5 @@
 import math/Random, structs/ArrayList /* for List shuffle */
-import structs/HashMap /* for getStandardEquals() - should probably move that in a separate Module */
+import structs/Utils
 
 /**
  * List interface for a data container
@@ -12,7 +12,7 @@ List: abstract class <T> extends BackIterable<T> {
         }
     }
 
-    equals? := getStandardEquals(T)
+    equals? := Utils getStandardEquals(T)
 
     /**
      * Appends the specified element to the end of this list.

--- a/sdk/structs/Utils.ooc
+++ b/sdk/structs/Utils.ooc
@@ -1,0 +1,150 @@
+Utils: class {
+
+    stringEquals: static func <K> (k1, k2: K) -> Bool {
+        assert(K == String)
+        k1 as String equals?(k2 as String)
+    }
+
+    cstringEquals: static func <K> (k1, k2: K) -> Bool {
+        k1 as CString == k2 as CString
+    }
+
+
+    pointerEquals: static func <K> (k1, k2: K) -> Bool {
+        k1 as Pointer == k2 as Pointer
+    }
+
+    intEquals: static func <K> (k1, k2: K) -> Bool {
+        k1 as Int == k2 as Int
+    }
+
+    charEquals: static func <K> (k1, k2: K) -> Bool {
+        k1 as Char == k2 as Char
+    }
+
+    /** used when we don't have a custom comparing function for the key type */
+    genericEquals: static func <K> (k1, k2: K) -> Bool {
+        // FIXME rock should turn == between generic vars into a memcmp itself
+        memcmp(k1, k2, K size) == 0
+    }
+
+    intHash: static func <K> (key: K) -> SizeT {
+        result: SizeT = key as Int
+        return result
+    }
+
+    pointerHash: static func <K> (key: K) -> SizeT {
+        return (key as Pointer) as SizeT
+    }
+
+    charHash: static func <K> (key: K) -> SizeT {
+        // both casts are necessary
+        // Casting 'key' directly to UInt would deref a pointer to UInt
+        // which would read random memory just after the char, which is not a good idea..
+        return (key as Char) as SizeT
+    }
+
+    /**
+       Port of Austin Appleby's Murmur Hash implementation
+       http://code.google.com/p/smhasher/
+
+       :param: key The key to hash
+       :param: seed The seed value
+     */
+    murmurHash: static func <K> (keyTagazok: K) -> SizeT {
+
+        seed: SizeT = 1 // TODO: figure out what makes a good seed value?
+
+        len := K size
+        m = 0x5bd1e995 : const SizeT
+        r = 24 : const SSizeT
+        l := len
+
+        h : SizeT = seed ^ len
+        data := (keyTagazok&) as Octet*
+
+        while (true) {
+            k := (data as SizeT*)@
+
+            k *= m
+            k ^= k >> r
+            k *= m
+
+            h *= m
+            h ^= k
+
+            data += 4
+            if(len < 4) break
+            len -= 4
+        }
+
+        t := 0
+
+        if(len == 3) h ^= data[2] << 16
+        if(len == 2) h ^= data[1] << 8
+        if(len == 1) h ^= data[0]
+
+        t *= m; t ^= t >> r; t *= m; h *= m; h ^= t;
+        l *= m; l ^= l >> r; l *= m; h *= m; h ^= l;
+
+        h ^= h >> 13
+        h *= m
+        h ^= h >> 15
+
+        return h
+    }
+
+    /**
+     * khash's ac_X31_hash_string
+     * http://attractivechaos.awardspace.com/khash.h.html
+     * @access private
+     * @param s The string to hash
+     * @return UInt
+     */
+    ac_X31_hash: static func <K> (key: K) -> SizeT {
+        assert(key as Pointer != null)
+        s : Char* = (K == String) ? (key as String) toCString() as Char* : key as Char*
+        h = s@ : SizeT
+        if (h) {
+            s += 1
+            while (s@) {
+                h = (h << 5) - h + s@
+                s += 1
+            }
+        }
+        return h
+    }
+
+    /* this function seem is called by List */
+    getStandardEquals: static func <T> (T: Class) -> Func <T> (T, T) -> Bool {
+        // choose comparing function for key type
+        if(T == String) {
+            Utils stringEquals
+        } else if(T == CString) {
+            Utils cstringEquals
+        } else if(T size == Pointer size) {
+            Utils pointerEquals
+        } else if(T size == UInt size) {
+            Utils intEquals
+        } else if(T size == Char size) {
+            Utils charEquals
+        } else {
+            Utils genericEquals
+        }
+    }
+
+    getStandardHashFunc: static func <T> (T: Class) -> Func <T> (T) -> SizeT {
+        if(T == String || T == CString) {
+            Utils ac_X31_hash
+        } else if(T size == Pointer size) {
+            Utils pointerHash
+        } else if(T size == UInt size) {
+            Utils intHash
+        } else if(T size == Char size) {
+            Utils charHash
+        } else {
+            Utils murmurHash
+        }
+    }
+}
+

--- a/source/rock/backend/cnaughty/CGenerator.ooc
+++ b/source/rock/backend/cnaughty/CGenerator.ooc
@@ -415,18 +415,30 @@ CGenerator: class extends Skeleton {
     }
 
     visitComparison: func (comp: Comparison) {
-        current app(comp left). app(" "). app(comp repr()). app(" ")
-
-        leftType  := comp left  getType()
-        while(leftType  instanceOf?(ReferenceType)) { leftType  = leftType  as ReferenceType inner }
-
+        leftType  := comp left getType()
         rightType := comp right getType()
+        if(leftType isGeneric()){
+            current app("(*(")
+            current app(comp left). app(")) "). app(comp repr()). app(" ")
+        } else {
+            current app(comp left). app(" "). app(comp repr()). app(" ")
+        }
+        while(leftType instanceOf?(ReferenceType)) { leftType  = leftType  as ReferenceType inner }
+
         while(rightType instanceOf?(ReferenceType)) { rightType = rightType as ReferenceType inner }
 
-        if(!rightType equals?(leftType)) {
-            current app('('). app (leftType). app(") ")
+        if(rightType isGeneric()){
+            current app("(*(")
+            if(!rightType equals?(leftType)) {
+                current app('('). app (leftType). app("*) ")
+            }
+            current app(comp right). app("))")
+        } else {
+            if(!rightType equals?(leftType)) {
+                current app('('). app (leftType). app(") ")
+            }
+            current app(comp right)
         }
-        current app(comp right)
     }
 
     visitTernary: func (tern: Ternary) {

--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -1,7 +1,7 @@
 
 import io/File, text/[EscapeSequence]
 
-import structs/[ArrayList, List, Stack, HashMap]
+import structs/[ArrayList, List, Stack, HashMap, Utils]
 
 import ../utils/FileUtils
 import ../frontend/[Token, BuildParams]
@@ -41,7 +41,7 @@ computeReservedHashs: func (words: String[]) -> ArrayList<Int> {
     list := ArrayList<Int> new()
     words length times(|i|
         word := words[i]
-        list add(ac_X31_hash(word))
+        list add(Utils ac_X31_hash(word))
     )
     list
 }
@@ -475,7 +475,7 @@ AstBuilder: class {
     }
 
     gotVarDecl: func (vd: VariableDecl) {
-        hash := ac_X31_hash(vd getName())
+        hash := Utils ac_X31_hash(vd getName())
         idx := reservedHashs indexOf(hash)
         if(idx != -1) {
             // same hash? compare length and then full-string comparison

--- a/source/rock/frontend/drivers/SequenceDriver.ooc
+++ b/source/rock/frontend/drivers/SequenceDriver.ooc
@@ -2,7 +2,8 @@
 // sdk stuff
 import io/File
 import os/[Terminal, Process, JobPool, ShellUtils, Pipe]
-import structs/[List, ArrayList, HashMap]
+import structs/[List, ArrayList, HashMap, Utils]
+import threading/[Thread, ThreadPool]
 
 // our stuff
 import Driver, Archive, SourceFolder, Flags, CCompiler, DependencyGraph
@@ -54,7 +55,7 @@ SequenceDriver: class extends Driver {
         for (sourceFolder in reverseList) {
             if(params verbose) {
                 // generate random colors for every source folder
-                hash := ac_X31_hash(sourceFolder identifier) + 42
+                hash := Utils ac_X31_hash(sourceFolder identifier) + 42
                 Terminal setFgColor(Color fromHash(hash))
                 if(hash & 0b01) Terminal setAttr(Attr bright)
                 "%s, " printf(sourceFolder identifier)
@@ -184,6 +185,7 @@ SequenceDriver: class extends Driver {
         for(module in dirtyModules) {
             CGenerator new(params, module) write()
         }
+
         dirtyModules
 
     }

--- a/source/rock/frontend/drivers/SequenceDriver.ooc
+++ b/source/rock/frontend/drivers/SequenceDriver.ooc
@@ -3,7 +3,7 @@
 import io/File
 import os/[Terminal, Process, JobPool, ShellUtils, Pipe]
 import structs/[List, ArrayList, HashMap, Utils]
-import threading/[Thread, ThreadPool]
+import threading/Thread
 
 // our stuff
 import Driver, Archive, SourceFolder, Flags, CCompiler, DependencyGraph

--- a/source/rock/frontend/drivers/SequenceDriver.ooc
+++ b/source/rock/frontend/drivers/SequenceDriver.ooc
@@ -3,7 +3,6 @@
 import io/File
 import os/[Terminal, Process, JobPool, ShellUtils, Pipe]
 import structs/[List, ArrayList, HashMap, Utils]
-import threading/Thread
 
 // our stuff
 import Driver, Archive, SourceFolder, Flags, CCompiler, DependencyGraph

--- a/source/rock/io/CachedFileWriter.ooc
+++ b/source/rock/io/CachedFileWriter.ooc
@@ -1,4 +1,4 @@
-import io/[BufferReader, BufferWriter, File], structs/HashMap
+import io/[BufferReader, BufferWriter, File], structs/Utils
 
 /**
    Cached file writer.
@@ -37,8 +37,8 @@ CachedFileWriter: class extends BufferWriter {
             thisContent := buffer toString()
             fileContent := file read()
 
-            hash1 := ac_X31_hash(thisContent)
-            hash2 := ac_X31_hash(fileContent)
+            hash1 := Utils ac_X31_hash(thisContent)
+            hash2 := Utils ac_X31_hash(fileContent)
 
             if(hash1 == hash2) {
                 // same hash? don't rewrite.

--- a/test/compiler/generics/generic-comparison.ooc
+++ b/test/compiler/generics/generic-comparison.ooc
@@ -1,0 +1,27 @@
+IEquatable: interface <T> {
+    equals: func(other: T) -> Bool
+}
+
+ValueEquatable: class <T> implements IEquatable<T> {
+    value : Int = 0
+    init: func(=value) {}
+    equals: func(other: T) -> Bool {
+        this value == other
+    }
+}
+
+main: func -> Int{
+    c := ValueEquatable <Int> new(1337)
+    if(!c equals(1337) || (c equals(1338))){
+        "class error" println()
+        return 1
+    }
+
+    i := c as IEquatable<Int>
+    if(!i equals(1337) || (i equals(1338))) {
+        "interface error" println()
+        return 1
+    }
+
+    0
+}


### PR DESCRIPTION
Currently generics are compared as pointer. The following code prints false:

    foo: class <T> {
		a: T
	}
	bar := foo <Int> new()
	foo a = 1
	(foo a == 1) toString() println()


This commit deference variable in comparison if it is generic.

And also, it breaks some the function ac_X31_hash. I don't really think ac_X31_hash is correctly implemented. Because (when using with typeargs) template function can not even be parsed by current rock.


Change to ac_X31_hash:

	 ac_X31_hash: func <K> (key: K) -> SizeT {
	     assert(key as Pointer != null) // not Key != null, because generics will be deferenced 
		 s : Char* = (K == String) ? (key as String) toCString() as Char* : key as Char*
		 h = s@ : SizeT
		 if (h) {
			..........

This patch also move hash/equal functions out from hashmap
And change template function to static member of class
