### PR TITLE
Detect common root for numbers

### DIFF
--- a/source/rock/middle/algo/typeAnalysis.ooc
+++ b/source/rock/middle/algo/typeAnalysis.ooc
@@ -73,6 +73,14 @@ findTypeRoot: func(t: BaseType) -> BaseType{
     t
 }
 
+
+baseRank : func -> Int{
+    version (x86 || i386) {
+        return 60
+    } 
+    100
+}
+
 /* C99 6.3.1.8 Usual arithmetic conversions */
 numberTypeScore: func(t: BaseType) -> Int{
     realType := findTypeRoot(t)
@@ -105,14 +113,17 @@ numberTypeScore: func(t: BaseType) -> Int{
         case "signed long" => 63
         case "int32_t" => 62
 
-        case "size_t" => 60
-        case "ptrdiff_t" => 59
+        case "size_t" => baseRank() 
+        case "ptrdiff_t" => baseRank() - 1
+        case "ssize_t" => baseRank() - 2 
 
         case "unsigned int" => 34
         case "int" => 33
         case "signed int" => 33
+
         case "unsigned short" => 32
-        case "uint16_t" => 31
+        case "signed short" => 31
+        case "uint16_t" => 30
 
         case "unsigned char" => 17
         case "uint8_t" => 16

--- a/source/rock/middle/algo/typeAnalysis.ooc
+++ b/source/rock/middle/algo/typeAnalysis.ooc
@@ -1,5 +1,5 @@
 import structs/ArrayList
-import ../[Type, BaseType, TypeDecl, CoverDecl, ClassDecl, Expression]
+import ../[Type, BaseType, TypeDecl, CoverDecl, ClassDecl, Expression, EnumDecl]
 
 
 distanceFromObject: func(type: BaseType) -> Int {
@@ -105,6 +105,9 @@ numberTypeScore: func(t: BaseType) -> Int{
         case "signed long" => 63
         case "int32_t" => 62
 
+        case "size_t" => 60
+        case "ptrdiff_t" => 59
+
         case "unsigned int" => 34
         case "int" => 33
         case "signed int" => 33
@@ -148,7 +151,9 @@ findCommonRoot: func(type1, type2: Type) -> Type {
 
     basic := func(t1, t2: Type) -> Type {
         if(t1 equals?(type2)) return t1
-        if(t1 isNumericType() && t2 isNumericType()) {
+        if((t1 isNumericType() && t2 isNumericType()) || \
+            t1 getRef() instanceOf?(EnumDecl) && t2 isNumericType() || \
+            t1 isNumericType() && t2 getRef() instanceOf?(EnumDecl)) {
             if(t1 instanceOf?(BaseType) && t2 instanceOf?(BaseType)){
                 return numberType(t1 as BaseType, t2 as BaseType)
             }

--- a/source/rock/middle/algo/typeAnalysis.ooc
+++ b/source/rock/middle/algo/typeAnalysis.ooc
@@ -64,6 +64,68 @@ getInnermostType: func(type: Type) -> Type {
     type
 }
 
+findTypeRoot: func(t: BaseType) -> BaseType{
+    if(t getRef() != null && t getRef() instanceOf?(CoverDecl)){
+        if(t getRef() as CoverDecl getFromType() != null && t getRef() as CoverDecl getFromType() instanceOf?(BaseType)){
+            return findTypeRoot(t getRef() as CoverDecl getFromType() as BaseType)
+        }
+    }
+    t
+}
+
+/* C99 6.3.1.8 Usual arithmetic conversions */
+numberTypeScore: func(t: BaseType) -> Int{
+    realType := findTypeRoot(t)
+    match(realType name){
+        /* First, if the corresponding real type of either operand is long double, 
+         the other operand is converted, without change of type domain, 
+         to a type whose corresponding real type is long double. */
+        case "long double" => 1024
+        /* Otherwise, if the corresponding real type of either operand is double
+         the other operand is converted, without change of type domain,
+         to a type whose corresponding real type is double.*/
+        case "double" => 512
+        /* Otherwise, if the corresponding real type of either operand is float,
+         the other operand is converted, without change of type domain,
+         to a type whose corresponding real type is float. */
+        case "float" => 256
+        /* Otherwise, the integer promotions are performed on both operands. */
+
+        /* The following is not a C99 implementation, we need a better one */
+
+        case "unsigned long long" => 129
+        case "uint64_t" => 128
+        case "long long" => 127
+        case "signed long long" => 127
+        case "int64_t" => 126
+
+        case "unsigned long" => 65
+        case "uint32_t" => 64
+        case "long" => 63
+        case "signed long" => 63
+        case "int32_t" => 62
+
+        case "unsigned int" => 34
+        case "int" => 33
+        case "signed int" => 33
+        case "unsigned short" => 32
+        case "uint16_t" => 31
+
+        case "unsigned char" => 17
+        case "uint8_t" => 16
+        case "Octet" => 15
+        case "char" => 14
+        case "signed char" => 14
+        case "int8_t" => 12
+
+        case => 0
+    }
+}
+
+numberType: func(type1, type2: BaseType) -> Type{
+    numberTypeScore(type1) < numberTypeScore(type2) ? type2 : type1
+}
+
 // Returns the clsoer common root of two types
 // A common root is a type that represents both of the types it comes from
 // For example, if Bar extends Foo and Baz extends Foo, Foo is the closer common root of Foo and Bar
@@ -87,6 +149,9 @@ findCommonRoot: func(type1, type2: Type) -> Type {
     basic := func(t1, t2: Type) -> Type {
         if(t1 equals?(type2)) return t1
         if(t1 isNumericType() && t2 isNumericType()) {
+            if(t1 instanceOf?(BaseType) && t2 instanceOf?(BaseType)){
+                return numberType(t1 as BaseType, t2 as BaseType)
+            }
             // The root of an integer and a floating point type is the floating point type
             if(t2 isFloatingPointType()) return t2
             return t1


### PR DESCRIPTION
The first step to detect common root for numbers.
The following codes will work after this commit:


	check: func<T>(t: T, name: String){
		if(t class name != name){
			Exception new("Expected %s, get %s!" format(name, t class name)) throw()
		}
	}

	mydouble: cover from Double

	check(1.f + 1.l, "LDouble")
	check(1.f + 1., "Double")
	check(1.f + 1.f, "Float")
	check(1l + 1.f, "Float")
	check(1.f + 1. as mydouble, "mydouble")


In this patch, every "base type" (c type) has a score. For ooc types are cover from c types, we find the root and return the type with higher score.
This is not a really "good" solution, just as @shamanas said, we need to handle each case manually.

And also, Standard says that:

`Otherwise, if one operand is a long int and the other unsigned int, then if a long int can represent all the values of an unsigned int, the unsigned int shall be converted to a long int; otherwise both operands shall be converted to unsigned long int.`

I am not sure how to judge if a type can represent other at compile time....
