### PR TITLE
fix #864

### DIFF
--- a/source/rock/middle/VariableDecl.ooc
+++ b/source/rock/middle/VariableDecl.ooc
@@ -432,7 +432,7 @@ VariableDecl: class extends Declaration {
                             // Find out if our access is between the kid closure and the parent closure
                             isDefined? := false
                             intermediateScopeIndex := closureIndex - 1
-                            while(intermediateScopeIndex > scopeDepth) {
+                            while(intermediateScopeIndex >= scopeDepth) {
                                 interScope? := trail get(intermediateScopeIndex, Node)
                                 if(interScope? instanceOf?(Scope)) {
                                     interScope := interScope? as Scope

--- a/test/compiler/closures/variable-in-closure.ooc
+++ b/test/compiler/closures/variable-in-closure.ooc
@@ -1,0 +1,18 @@
+func1 := func {
+    a := 1
+    b := 2
+    func2 := func { println((a + b) toString()) }
+    func2()
+}
+func1()
+
+
+func3 := func(f: Func(Int)){
+    c := 1
+    f(c)
+}
+
+func3(|x| 
+    a := 2
+    "%d %d" printfln(a, x)
+)


### PR DESCRIPTION
It is unnecessary(incorrect) to generate context for variables declared in parent closure.