### PR TITLE
Separate driver-related stuff into its own file

### DIFF
--- a/source/rock/frontend/drivers/GenericDriver.ooc
+++ b/source/rock/frontend/drivers/GenericDriver.ooc
@@ -1,0 +1,115 @@
+
+// sdk stuff
+import io/[File, FileWriter]
+import structs/[List, ArrayList, HashMap]
+
+// our stuff
+import Driver, SequenceDriver, CCompiler, Flags, SourceFolder
+
+import rock/frontend/[BuildParams, Target]
+import rock/middle/[Module, UseDef]
+import rock/backend/cnaughty/CGenerator
+import rock/io/TabbedWriter
+
+GenericDriver: class extends SequenceDriver {
+
+    // the self-containing directory containing buildable C sources
+    builddir: File
+
+    // Our output file
+    makefile: File
+    filepath: String
+
+    // Original output path (e.g. "rock_tmp")
+    originalOutPath: File
+
+    // The string name
+    driverName: String
+
+    getWriter: func (flags: Flags, toCompile: ArrayList<Module>, module: Module) -> GenericWriter { null }
+
+    init: func(=filepath, =driverName, .params) { super(params) }
+
+    setup: func {
+        wasSetup := static false
+        if(wasSetup) return
+
+        // no lib-caching!
+        params libcache = false
+
+        // keeping them for later (ie. invocation)
+        params clean = false
+
+        // build/
+        builddir = File new("build")
+
+        // build/rock_tmp/
+        originalOutPath = params outPath
+        params outPath = File new(builddir, params outPath getPath())
+        params outPath mkdirs()
+
+        // the file to write
+        makefile = File new(builddir, filepath)
+
+        wasSetup = true
+    }
+
+    compile: func (module: Module) -> Int {
+
+        if(params verbose) {
+           driverName println()
+        }
+
+        setup()
+
+        params outPath mkdirs()
+
+        toCompile := ArrayList<Module> new()
+        sourceFolders := collectDeps(module, HashMap<String, SourceFolder> new(), toCompile)
+
+        for(candidate in toCompile) {
+            CGenerator new(params, candidate) write()
+        }
+
+        params libcachePath = params outPath path
+        copyLocals(module, params)
+
+        params libcachePath = originalOutPath path
+        params libcache = true
+        flags := Flags new(null, params)
+
+        // we'll do that ourselves
+        flags doTargetSpecific = false
+
+        // we'll handle the GC flags ourselves, thanks
+        enableGC := params enableGC
+        params enableGC = false
+        flags absorb(params)
+        params enableGC = enableGC
+
+        for (sourceFolder in sourceFolders) {
+            flags absorb(sourceFolder)
+        }
+
+        for (module in toCompile) {
+            flags absorb(module)
+        }
+        params libcache = false
+
+        // do the actual writing
+        mw := getWriter(flags, toCompile, module)
+        mw write()
+        mw close()
+
+        return 0
+
+    }
+
+}
+
+
+
+GenericWriter: class {
+    write: func
+    close: func
+}


### PR DESCRIPTION
I'm new to ooc and Rock; this is my first *real* ooc programming I've done, so please bear with any mistakes.

I saw the PR for a CMake driver and freaked out with all the code duplication. It's scary. So, I decided to factor out the common stuff into `GenericDriver.ooc`, which contains some base classes for `MakeDriver` (and the not-yet-merged `CMakeDriver`) to remove all the code duplication.

Cons? This is likely going to 100% break #847, which (ironically) is the very issue that started this whole thing to begin with.