### PR TITLE
Fix EscapeSequence escape function

### DIFF
--- a/sdk/text/EscapeSequence.ooc
+++ b/sdk/text/EscapeSequence.ooc
@@ -137,7 +137,7 @@ EscapeSequence: class {
                     case '\r' => "\\r"
                     case '\t' => "\\t"
                     case '\v' => "\\v"
-                    case => "\\x%hhx" format(chr)
+                    case => "\\x%02hhx" format(chr)
                 })
             } else {
                 buf append(chr)


### PR DESCRIPTION
The current escape function outputs "\x1" instead of "\x01", which can cause problems with strings like "\x01ABCD", as the escaped output turns it into "\x1ABCD", which is not expected.