### PR TITLE
Extern const does not work with generics

### DIFF
--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -721,7 +721,8 @@ VariableAccess: class extends Expression {
         expr ? (expr toString() + " " + prettyName) : prettyName
     }
 
-    isReferencable: func -> Bool { true }
+    isReferencable: func -> Bool { ref && ref instanceOf?(VariableDecl) && 
+    (ref as VariableDecl isExtern() && ref as VariableDecl isConst()) ? false : true }
 
     replace: func (oldie, kiddo: Node) -> Bool {
         match oldie {

--- a/test/compiler/values/constnum.h
+++ b/test/compiler/values/constnum.h
@@ -1,0 +1,1 @@
+#define SIG1 1

--- a/test/compiler/values/extern-const-reference.ooc
+++ b/test/compiler/values/extern-const-reference.ooc
@@ -1,0 +1,12 @@
+include ./constnum
+
+SIG1: extern const Int
+
+foo: func<T>(a: T){
+    match(a){
+        case b: Int => "matched!" 
+        case => Exception new("error") throw()
+    }
+}
+
+main: func{ foo(SIG1) }


### PR DESCRIPTION

```ooc
include ./constnum

SIG1: extern const Int

foo: func<T>(a: T){
    match(a){
        case b: Int => "matched!" 
        case => Exception new("error") throw()
    }
}

main: func{ foo(SIG1) }
```


constnum is an extern c header file:

```
#define SIG1 1
```


Because SIG1 is a const, taking reference of it will cause compiler error.
