### PR TITLE
fix if-else generation in version block (issue #534)

### DIFF
--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -1005,7 +1005,9 @@ AstBuilder: class {
     onIfEnd: unmangled(nq_onIfEnd) func -> If {
         pop(If)
     }
-
+    onElseMatched: unmangled(nq_onElseMatched) func(s: If, e: Else){
+        s setElse(e)
+    }
     // else
     onElseStart: unmangled(nq_onElseStart) func {
         stack push(Else new(token()))

--- a/source/rock/middle/Else.ooc
+++ b/source/rock/middle/Else.ooc
@@ -22,38 +22,9 @@ Else: class extends Conditional {
 
     resolve: func(trail: Trail, res: Resolver) -> Response {
         trail push(this)
-        scope := trail get(trail findScope()) as Scope
-        // Check if an Else has got an If in front of it
-        if (scope) {
-            self := scope list indexOf(this)
-            foundIf := false
-            scope list each(|elem| if (elem instanceOf?(If)) {
-                    if (scope list indexOf(elem) <= self) {
-                        foundIf = true
-                    }
-                }
-            ) 
-            if (!foundIf) 
-                res throwError(LonesomeElse new(this))
-
-            
-        }
         response := body resolve(trail, res)
         trail pop(this)
         return response
-        
-    }
-
-}
-
-LonesomeElse: class extends Error {
-
-    first: Statement
-    init: func (=first) {
-        message = first token formatMessage("Found a single-standing `else`. (Note, there must be an if before)", "[ERROR]")
-    }
-    format: func -> String {
-        message
     }
 
 }

--- a/source/rock/middle/If.ooc
+++ b/source/rock/middle/If.ooc
@@ -1,9 +1,15 @@
 import ../frontend/Token
-import Conditional, Expression, Visitor
+import Conditional, Expression, Visitor, Else
+import tinker/[Trail, Resolver, Response, Errors]
 
 If: class extends Conditional {
+    elze: Else
+    unwrapped: Bool = false
 
     init: func ~_if (.condition, .token) { super(condition, token) }
+
+    setElse: func(=elze)
+    getElse: func -> Else { elze }
 
     clone: func -> This {
         copy := new(condition ? condition clone() : null, token)
@@ -21,4 +27,25 @@ If: class extends Conditional {
 
     isDeadEnd: func -> Bool { false }
 
+    resolve: func(trail: Trail, res: Resolver) -> Response {
+        if(elze != null && !unwrapped){
+            trail push(this)
+            if(!trail addAfterInScope(this, elze)){
+                trail pop(this)
+                res throwError(FailedUnwrapElse new(elze token, "Failed to unwrap else"))
+            }
+            unwrapped = true
+            elze resolve(trail, res)
+            trail pop(this)
+            res wholeAgain(this, "just unwrapped else")
+            return Response OK
+        }
+
+        super(trail, res)
+    }
+
+}
+
+FailedUnwrapElse: class extends Error{
+   init: super func ~tokenMessage
 }

--- a/source/rock/middle/Try.ooc
+++ b/source/rock/middle/Try.ooc
@@ -72,12 +72,12 @@ Try: class extends ControlStatement {
 
         // else {
         else_ := Else new(token)
+        if_ setElse(else_)
         // match (_getException()) { ... }
         match_ := Match new(token)
         match_ setExpr(FunctionCall new("_getException", token))
         match_ cases addAll(catches)
         else_ add(match_)
-        block add(else_)
         // add the last "fall-through" case if needed.
         rethrow? := true
         for(caze in catches) {


### PR DESCRIPTION
This commit makes the following code work:

```ooc

version(windows) {
  if (false) {
    // something
    "a" println()
  } else {
    // something else
    "b" println()
  }
} else {
    if(true){
        "c" println()
    } else {
        "d" println()
    }
}

version(!windows) {
  if (false) {
    // something
    "a" println()
  } else {
    // something else
    "b" println()
  }
} else {
    if(true){
        "c" println()
    } else {
        "d" println()
    }
}
```