### PR TITLE
fix callcombo

### DIFF
--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -821,9 +821,10 @@ AstBuilder: class {
         vDecl isGlobal = true // well, that's not true, but at least this way it won't be marked for partialing...
 
         commaSeq := CommaSequence new(expr token)
-        commaSeq body add(BinaryOp new(VariableAccess new(name, expr token), expr, OpType ass, expr token)) . add(call)
+        commaSeq body add(vDecl).
+            add(BinaryOp new(VariableAccess new(name, expr token), expr, OpType ass, expr token)).
+            add(call)
 
-        onStatement(vDecl)
         return commaSeq
     }
 
@@ -901,8 +902,8 @@ AstBuilder: class {
             case vd: VariableDecl =>
                 gotVarDecl(vd)
             case seq: CommaSequence =>
-                for(vd: VariableDecl in seq body) {
-                    gotVarDecl(vd)
+                for(vd: Statement in seq body) {
+                    onStatement(vd)
                 }
             case =>
                 gotStatement(stmt)
@@ -1005,7 +1006,9 @@ AstBuilder: class {
     onIfEnd: unmangled(nq_onIfEnd) func -> If {
         pop(If)
     }
-
+    onElseMatched: unmangled(nq_onElseMatched) func(s: If, e: Else){
+        s setElse(e)
+    }
     // else
     onElseStart: unmangled(nq_onElseStart) func {
         stack push(Else new(token()))

--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -1006,9 +1006,7 @@ AstBuilder: class {
     onIfEnd: unmangled(nq_onIfEnd) func -> If {
         pop(If)
     }
-    onElseMatched: unmangled(nq_onElseMatched) func(s: If, e: Else){
-        s setElse(e)
-    }
+
     // else
     onElseStart: unmangled(nq_onElseStart) func {
         stack push(Else new(token()))


### PR DESCRIPTION
Test code:


```ooc
foo: class{
    v : Int
    isOdd :Bool {
        get { v % 2 == 1 }
    }

    isEven ::= v %2 == 0

    init: func

    test: func -> Func(Int) {
        return func(a: Int){ a toString() println()}
    }
}

bar := foo new()

a := bar test()
a(1)

bar test()(1)

```

`bar test()(1)` can not be correctly recognized in this case.
Parser may break callcombo into two function call `bar test()` and `null ()`.

This commit fix this problem.



Another testcase:(should throw error that can not call on void function instead of crash)

```ooc

//!shouldfail

foo: class{
    v : Int
    isOdd :Bool {
        get { v % 2 == 1 }
    }

    isEven ::= v %2 == 0

    init: func

    test: func {}
}

bar := foo new()

bar test()()
```
