### PR TITLE
Throw warn on invalid path element

### DIFF
--- a/source/rock/frontend/PathList.ooc
+++ b/source/rock/frontend/PathList.ooc
@@ -23,10 +23,12 @@ PathList: class {
         file := File new(path)
 
         if (!file exists?()) {
-            Exception new(This, "Classpath element cannot be found: %s" format(path)) throw()
+            CommandLine warn ("Classpath element cannot be found: %s" format(path))
+            return
         }
         else if (!file dir?()) {
-            Exception new(This, "Classpath element is not a directory: %s" format(path)) throw()
+            CommandLine warn("Classpath element is not a directory: %s" format(path))
+            return
         }
 
         absolutePath := file getAbsolutePath()
@@ -52,14 +54,9 @@ PathList: class {
     remove: func(path: String) {
         file := File new(path)
 
-        if (!file exists?()) {
-            Exception new(This, "Classpath element cannot be found: " + file getPath()) throw()
-        }
-        else if (!file dir?()) {
-            Exception new(This, "Classpath element is not a directory: " + file getPath()) throw()
-        }
-        else if (!paths contains?(file getAbsolutePath())) {
-            Exception new(This, "Attempting to remove a nonexistant path: " + file getPath()) throw()
+        if (!paths contains?(file getAbsolutePath())) {
+            CommandLine warn("Attempting to remove a nonexistant path: " + file getPath())
+            return
         }
 
         paths remove(file getAbsolutePath())


### PR DESCRIPTION
Related issue: #908 

PathList uses `Exception` when find invalid path element, this path changes it to `CommandLine warn`.

One more thing, `PathList remove` checks existence of files before removing them, but I think it is unnecessary because only valid path can be added to `PathList`.