### PR TITLE
Add -pipe to the list of flags rock directly recognizes.

### DIFF
--- a/docs/rock.1
+++ b/docs/rock.1
@@ -58,6 +58,16 @@ Choose the rock backend\&. Currently, only the default backend
 is supported\&.
 .RE
 .PP
+\fB\-O0, \-O1, \-O2, \-O3, \-Os\fR
+.RS 4
+Choose an optimization level.
+.RE
+.PP
+\fB\-pipe\fR
+.RS 4
+Use pipes rather than temporary files for communication between the various stage of compilation.
+.RE
+.PP
 \fB\-gcc,\-tcc,\-icc,\-clang,\-onlygen\fR
 .RS 4
 Choose the compiler backend\&. (default=gcc) Available compilers are the GNU Compiler Collection, TinyCC, Intel C++ Compiler and the LLVM\(cqs clang frontend\&. Also, you can pass

--- a/docs/rock.1.txt
+++ b/docs/rock.1.txt
@@ -39,6 +39,13 @@ OPTIONS
     and the LLVM's clang frontend. Also, you can pass 'onlygen' to only generate the code
     and not to run any compiler.
 
+*-O0, -O1, -O2, -O3, -Os*::
+    Choose an optimization level.
+
+*-pipe*::
+    Use pipes rather than temporary files for communication between the
+    various stages of compilation.
+
 *-gc=[dynamic,static,off]*::
     Link dynamically, link statically, or don't link with the boehm GC at all.
     Linking dynamically is -lgc, linking statically uses libs/'ARCH'/libgc.a

--- a/source/rock/frontend/BuildParams.ooc
+++ b/source/rock/frontend/BuildParams.ooc
@@ -169,6 +169,9 @@ BuildParams: class {
     // Optimization level
     optimization := OptimizationLevel O0
 
+    // Use pipes instead of temporary files
+    pipe := false
+
     // Do inlining
     inlining := false
 
@@ -408,6 +411,9 @@ BuildParams: class {
                 b append(" -O3")
             case OptimizationLevel Os =>
                 b append(" -Os")
+        }
+        if(pipe) {
+            b append(" -pipe")
         }
         b append(" -gc=")
         if(enableGC) {

--- a/source/rock/frontend/CommandLine.ooc
+++ b/source/rock/frontend/CommandLine.ooc
@@ -297,6 +297,10 @@ CommandLine: class {
 
                     params optimization = OptimizationLevel Os
 
+                } else if (option == "pipe") {
+
+                    params pipe = true
+
                 } else if (option == "verbose" || option == "v") {
 
                     if(!longOption && option != "v") warnUseLong("verbose")

--- a/source/rock/frontend/Help.ooc
+++ b/source/rock/frontend/Help.ooc
@@ -58,6 +58,10 @@ or a library (if it only has a 'SourcePath: something' directive)
 -O0, -O1, -O2, -O3, -Os
     Choose an optimization level
 
+-pipe
+    Use pipes rather than temporary files for communication between the
+    various stages of compilation.
+
 --gc=[dynamic,static,off]
     Link dynamically, link statically, or don't link with the boehm
     GC at all.

--- a/source/rock/frontend/drivers/Flags.ooc
+++ b/source/rock/frontend/drivers/Flags.ooc
@@ -206,6 +206,10 @@ Flags: class {
             case OptimizationLevel Os => addCompilerFlag("-Os")
         }
 
+        if (params pipe) {
+            addCompilerFlag("-pipe")
+        }
+
         if (params libcache) {
             addCompilerFlag("-I" + params libcachePath)
         } else {


### PR DESCRIPTION
While here, Flags.ooc has MSDOS line endings. Convert to Unix line endings.

As it says on the tin.
Rationale: OpenBSD (and I think some if not all of the BSDs) default to CFLAGS '-O2 -pipe'
This way rock won't complain it doesn't understand -pipe and force us to do '-O2 -pipe +-pipe'