### PR TITLE
Fix issue912

### DIFF
--- a/test/compiler/literals/array-literal-in-class.ooc
+++ b/test/compiler/literals/array-literal-in-class.ooc
@@ -1,0 +1,19 @@
+Foo: class{
+    test := [1, 2, 3]
+    init: func
+}
+
+Bar: class{
+    test := static const [1, 2, 3]
+    init: func
+}
+
+describe("ArrayLiteral should be correctly unwrapped",||
+    foo := Foo new()
+    assert(foo test[0] == 1)
+    assert(foo test[1] == 2)
+    assert(foo test[2] == 3)
+    assert(Bar test[0] == 1)
+    assert(Bar test[1] == 2)
+    assert(Bar test[2] == 3)
+)


### PR DESCRIPTION
This commit change arraylit from `CommaSeq` to `FunctionCall` if it is a member of a class.
The Function is defined as static inline so if once we complete `inline` func, it will not slow down our code.