### PR TITLE
Use GetConsoleScreenBufferInfo in TerminalWin32

### DIFF
--- a/sdk/native/win32/types.ooc
+++ b/sdk/native/win32/types.ooc
@@ -82,4 +82,49 @@ version(windows) {
     LPTSTR: extern cover from CString
 
     MAKEWORD: extern func (low, high: BYTE) -> WORD
+
+    /*
+     * Defines the coordinates of a character cell in a console screen buffer. 
+     * The origin of the coordinate system (0,0) is at the top, left cell of the buffer.
+     */
+    Coord: cover from COORD{
+        x: extern(X) Short
+        y: extern(Y) Short
+    }
+    PCoord: cover from Coord*
+
+    /*
+     * Defines the coordinates of the upper left and lower right corners of a rectangle.
+     */
+    SmallRect: cover from SMALL_RECT{
+        left: extern(Left) Short
+        top: extern(Top) Short
+        right: extern(Right) Short
+        bottom: extern(Bottom) Short
+    }
+
+    ConsoleScreenBufferInfo: cover from CONSOLE_SCREEN_BUFFER_INFO{
+        size: extern(dwSize) Coord
+        cursorPosition: extern(dwCursorPosition) Coord
+        attributes: extern(wAttributes) UInt16
+        window: extern(srWindow) SmallRect
+        maximumWindowSize: extern(dwMaximumWindowSize) Coord
+    }
+    PConsoleScreenBufferInfo: cover from ConsoleScreenBufferInfo*
+
+    FOREGROUND_BLUE            : extern const UInt16
+    FOREGROUND_GREEN           : extern const UInt16
+    FOREGROUND_RED             : extern const UInt16
+    FOREGROUND_INTENSITY       : extern const UInt16
+    BACKGROUND_BLUE            : extern const UInt16
+    BACKGROUND_GREEN           : extern const UInt16
+    BACKGROUND_RED             : extern const UInt16
+    BACKGROUND_INTENSITY       : extern const UInt16
+    COMMON_LVB_LEADING_BYTE    : extern const UInt16
+    COMMON_LVB_TRAILING_BYTE   : extern const UInt16
+    COMMON_LVB_GRID_HORIZONTAL : extern const UInt16
+    COMMON_LVB_GRID_LVERTICAL  : extern const UInt16
+    COMMON_LVB_GRID_RVERTICAL  : extern const UInt16
+    COMMON_LVB_REVERSE_VIDEO   : extern const UInt16
+    COMMON_LVB_UNDERSCORE      : extern const UInt16
 }

--- a/sdk/os/native/TerminalWin32.ooc
+++ b/sdk/os/native/TerminalWin32.ooc
@@ -4,10 +4,9 @@ version (windows) {
     import os/Terminal
     import native/win32/types
 
-    // TODO: Try to use GetConsoleScreenBufferInfo to keep
-    // bg/fg color when using SetFg/BgColor functions
     GetStdHandle: extern func(mode: ULong) -> Handle
     SetConsoleTextAttribute: extern func(console: Handle, attr: UShort) -> Bool
+    GetConsoleScreenBufferInfo: extern func(console: Handle, info: PConsoleScreenBufferInfo) -> Bool
 
     STD_OUTPUT_HANDLE: extern ULong
 
@@ -15,13 +14,13 @@ version (windows) {
      * Implementation of TerminalHandler for Windows systems
      */
     TerminalWin32: class extends TerminalHandler {
-        bg := Color black
-        fg := Color white
+        bg := (-1) as Color
+        fg := (-1) as Color
 
         init: func
 
         /* Color codes */
-        colors := [
+        colors := static const [
             0 , // black
             12, // red
             10, // green
@@ -43,17 +42,22 @@ version (windows) {
         }
 
         setColor: func (=fg, =bg) {
+            hStdOut := GetStdHandle(STD_OUTPUT_HANDLE)
+            info: ConsoleScreenBufferInfo
+            wColor: UShort = 0
+            if(GetConsoleScreenBufferInfo(hStdOut, info&)){
+                wColor = info attributes
+            }
             b := _lookupColor(bg)
             f := _lookupColor(fg)
-            if (b == -1) {
-                b = _lookupColor(Color black)
-            }
-            if (f == -1) {
-                f = _lookupColor(Color grey)
-            }
+            if (b != -1) {
+                wColor = wColor & 0xFF0F
+            } else { b = 0 }
+            if (f != -1) {
+                wColor = wColor & 0xFFF0
+            } else { f = 0 }
 
-            wColor: UShort = ((b & 0x0F) << 4) + (f & 0x0F)
-            hStdOut := GetStdHandle(STD_OUTPUT_HANDLE)
+            wColor = wColor | (((b & 0x0F) << 4) + (f & 0x0F))
             SetConsoleTextAttribute(hStdOut, wColor)
         }
 

--- a/sdk/os/native/TerminalWin32.ooc
+++ b/sdk/os/native/TerminalWin32.ooc
@@ -14,10 +14,8 @@ version (windows) {
      * Implementation of TerminalHandler for Windows systems
      */
     TerminalWin32: class extends TerminalHandler {
-        bg := (-1) as Color
-        fg := (-1) as Color
-
-        init: func
+        bg : Color
+        fg : Color
 
         /* Color codes */
         colors := static const [
@@ -31,6 +29,29 @@ version (windows) {
             7 , // grey
             31  // white
         ]
+
+        _toColor: func(c: Int) -> Color{
+            match(c){
+                case 0 => Color black
+                case 12 => Color red
+                case 10 => Color green
+                case 14 => Color yellow
+                case 9 => Color blue
+                case 13 => Color magenta
+                case 7 => Color grey
+                case 31 => Color white
+                case => (-1) as Color
+            }
+        }
+
+        init: func {
+            hStdOut := GetStdHandle(STD_OUTPUT_HANDLE)
+            info: ConsoleScreenBufferInfo
+            if(GetConsoleScreenBufferInfo(hStdOut, info&)){
+                fg = _toColor(info attributes & 0x0F)
+                bg = _toColor(info attributes & 0xF0)
+            }
+        }
 
         _lookupColor: func (c: Color) -> Int {
             value := c as Int


### PR DESCRIPTION
Use GetConsoleScreenBufferInfo to get the information about current terminal.