### PR TITLE
Always use pthreads

### DIFF
--- a/source/rock/frontend/drivers/Flags.ooc
+++ b/source/rock/frontend/drivers/Flags.ooc
@@ -255,24 +255,25 @@ Flags: class {
             addLinkerFlag("-L" + vendorLib)
 
             addLinkerFlag("-lgc")
+        }
 
-            target := params target
+        // pthreads (mthreads on Windows) should be used unconditionally
+        target := params target
 
-            match target {
-                case Target WIN =>
-                    // The SDK doesn't use pthreads on Windows
-                    addCompilerFlag("-mthreads")
-                    addLinkerFlag("-mthreads")
-                case Target OSX =>
-                    // For OSX, -lpthread suffices, -pthread yields a warning
-                    addLinkerFlag("-lpthread")
-                case =>
-                    // for other unices, -pthread is apparently a good idea.
-                    // Some unices don't have a separate pthread library and it
-                    // might do some other stuff (like define D_REENTRANT)
-                    addCompilerFlag("-pthread")
-                    addLinkerFlag("-pthread")
-            }
+        match target {
+            case Target WIN =>
+                // The SDK doesn't use pthreads on Windows
+                addCompilerFlag("-mthreads")
+                addLinkerFlag("-mthreads")
+            case Target OSX =>
+                // For OSX, -lpthread suffices, -pthread yields a warning
+                addLinkerFlag("-lpthread")
+            case =>
+                // for other unices, -pthread is apparently a good idea.
+                // Some unices don't have a separate pthread library and it
+                // might do some other stuff (like define D_REENTRANT)
+                addCompilerFlag("-pthread")
+                addLinkerFlag("-pthread")
         }
     }
 


### PR DESCRIPTION
Even the most simple helloworld.ooc program needs -pthread in order to compile and run. Currently, running `rock -v -gc=off helloworld` will result in a linker error: undefined references for some pthread functions. So always use -pthread.