### PR TITLE
Improved limit externs in Numbers.ooc.

### DIFF
--- a/sdk/lang/Numbers.ooc
+++ b/sdk/lang/Numbers.ooc
@@ -55,19 +55,14 @@ UInt:   cover from unsigned int   extends ULLong {
 }
 UShort: cover from unsigned short extends ULLong
 
-//INT_MIN,    INT_MAX  : extern const static Int
-//UINT_MAX           : extern const static UInt
-//LONG_MIN,  LONG_MAX  : extern const static Long
-//ULONG_MAX          : extern const static ULong
-//LLONG_MIN, LLONG_MAX : extern const static LLong
-//ULLONG_MAX             : extern const static ULLong
-
-INT_MAX := 2147483647
-INT_MIN := -INT_MAX - 1
-INFINITY: extern Double
-NAN: extern Double
-FLT_MIN: extern Float
-DBL_MIN: extern Double
+SHRT_MIN, SHRT_MAX: extern static Short
+USHRT_MAX: extern static UShort
+INT_MIN, INT_MAX: extern static Int
+UINT_MAX: extern static UInt
+LONG_MIN, LONG_MAX: extern static Long
+ULONG_MAX: extern static ULong
+LLONG_MIN, LLONG_MAX: extern static LLong
+ULLONG_MAX: extern static ULLong
 
 /**
  * fixed-size integer types
@@ -114,9 +109,9 @@ Float: cover from float extends LDouble {
     }
 }
 
-DBL_MIN,  DBL_MAX : extern static const Double
-FLT_MIN,  FLT_MAX : extern static const Float
-LDBL_MIN, LDBL_MAX: extern static const LDouble
+FLT_MIN, FLT_MAX: extern static Float
+DBL_MIN, DBL_MAX, INFINITY, NAN: extern static Double
+LDBL_MIN, LDBL_MAX: extern static LDouble
 
 /**
  * custom types

--- a/test/sdk/lang/limits.ooc
+++ b/test/sdk/lang/limits.ooc
@@ -1,0 +1,29 @@
+describe("Numeric limits should be defined",||
+    shortMin := SHRT_MIN
+    shortMax := SHRT_MAX
+    unsignedShortMax := USHRT_MAX
+
+    intMin := INT_MIN
+    intMax := INT_MAX
+    unsignedIntMax := UINT_MAX
+
+    longMin := LONG_MIN
+    longMax := LONG_MAX
+    unsignedLongMax := ULONG_MAX
+
+    longLongMin := LLONG_MIN
+    longLongMax := LLONG_MAX
+    unsignedLongLongMax := ULLONG_MAX
+
+    floatMin := FLT_MIN
+    floatMax := FLT_MAX
+    
+    doubleMin := DBL_MIN
+    doubleMax := DBL_MAX
+
+    longDoubleMin := LDBL_MIN
+    longDoubleMax := LDBL_MAX
+
+    infinity := INFINITY
+    notANumber := NAN
+)


### PR DESCRIPTION
I tried to clean this up a little bit, and I also added limits for `Short` and `UShort`. I'm guessing you want to redo this your own way, though (formatting etc).

`FLT_MIN` and `DBL_MIN` were defined twice for some reason, so I removed the ones that seemed to be in the wrong place.