### PR TITLE
Throw an error when trying to reassign a typeArg

### DIFF
--- a/sdk/text/json/Parser.ooc
+++ b/sdk/text/json/Parser.ooc
@@ -318,8 +318,8 @@ Parser: class {
     pushSimpleValue: func (token: Token@) {
         T: Class
         valuePtr := _parseSimpleValue(token&, T&)
-        cell := Cell<Pointer> new((valuePtr as Pointer*)@) // TODO: EVIL, evil hack.
-        cell T = T
+
+        cell := Cell new(valuePtr as T)
         stack data add(cell)
     }
 

--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -692,7 +692,7 @@ BinaryOp: class extends Expression {
                                 case vDecl: VariableDecl =>
                                     if (vDecl owner) {
                                         if (vDecl owner typeArgs contains?(vDecl)) {
-                                            token module params errorHandler onError(Warning new(vAccess token,
+                                            token module params errorHandler onError(InvalidOperatorUse new(vAccess token,
                                                 "Trying to reassign typeArg #{vAccess}"))
                                         }
                                     }

--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -692,8 +692,8 @@ BinaryOp: class extends Expression {
                                 case vDecl: VariableDecl =>
                                     if (vDecl owner) {
                                         if (vDecl owner typeArgs contains?(vDecl)) {
-                                            token module params errorHandler onError(InvalidOperatorUse new(token,
-                                                "#{vAccess} is a typeArg. You cannot reassign it."))
+                                            token module params errorHandler onError(Warning new(vAccess token,
+                                                "Trying to reassign typeArg #{vAccess}"))
                                         }
                                     }
                             }

--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -679,6 +679,29 @@ BinaryOp: class extends Expression {
     }
 
     isLegal: func (res: Resolver) -> Bool {
+        if (type == OpType ass) {
+            // This makes sure we do not reassign a type arg
+            // To be more precise, it disallows reassignment outside the class
+            match left {
+                case vAccess: VariableAccess =>
+                    match (vAccess expr) {
+                        case null =>
+                        case potentialThis: VariableAccess =>
+                            if (potentialThis name != "this") match (vAccess ref) {
+                                case null =>
+                                case vDecl: VariableDecl =>
+                                    if (vDecl owner) {
+                                        if (vDecl owner typeArgs contains?(vDecl)) {
+                                            token module params errorHandler onError(InvalidOperatorUse new(token,
+                                                "#{vAccess} is a typeArg. You cannot reassign it."))
+                                        }
+                                    }
+                            }
+                    }
+            }
+        }
+
+
         (lType, rType) := (left getType(), right getType())
 
         if(lType == null || lType getRef() == null || rType == null || rType getRef() == null) {

--- a/test/compiler/generics/cannot-reassign-typeargs.ooc
+++ b/test/compiler/generics/cannot-reassign-typeargs.ooc
@@ -1,0 +1,4 @@
+//! shouldfail
+
+c := Cell new(42)
+c T = String


### PR DESCRIPTION
Reassigning on a this instance is allowed because it basically what every init method is doing.  

Closes #415

EDIT: Fixed that instance in the SDK, reverted back to an error