### PR TITLE
Versioned enums should push generated symbols to their respective versions

### DIFF
--- a/test/compiler/enums/versioned-enum.ooc
+++ b/test/compiler/enums/versioned-enum.ooc
@@ -1,0 +1,5 @@
+version (!gc) {
+    Foo: enum {
+        test = UNDEFINED_C_CONST
+    }
+}


### PR DESCRIPTION
Closes #935.

Kind of hackish, but I see no way around it, I will be thinking about it some more and maybe changing some stuff.