### PR TITLE
Left side of the nullco operator should not be evaluated twice.

### DIFF
--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -554,7 +554,7 @@ BinaryOp: class extends Expression {
             seq add(ternary)
 
             if(!trail peek() replace(this, seq)) {
-                res throwError(CouldntReplace new(token, this, ternary, trail))
+                res throwError(CouldntReplace new(token, this, seq, trail))
                 return Response OK
             }
 

--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -4,7 +4,7 @@ import Expression, Visitor, Type, Node, FunctionCall, OperatorDecl,
        Import, Module, FunctionCall, ClassDecl, CoverDecl, AddressOf,
        ArrayAccess, VariableAccess, Cast, NullLiteral, PropertyDecl,
        Tuple, VariableDecl, FuncType, TypeDecl, StructLiteral, TypeList,
-       Scope, TemplateDef, Ternary, Comparison
+       Scope, TemplateDef, Ternary, Comparison, CommaSequence
 import tinker/[Trail, Resolver, Response, Errors]
 import algo/typeAnalysis
 
@@ -532,16 +532,33 @@ BinaryOp: class extends Expression {
 
         // We must replace the null-coalescing operator with a ternary operator
         if(type == OpType nullCoal) {
-            // The final expression we want is (left != null ? left : right)
-            condition := Comparison new(left, NullLiteral new(token), CompType notEqual, token)
-            ternary := Ternary new(condition, left, right, token)
+            // So we generate a variable declaration that will hold the value of the 'left' expression
+            // Then a comma sequence that assigns the value and the ternary
 
-            if(!trail peek() replace(this, ternary)) {
+            vDecl := VariableDecl new(left getType(), generateTempName("nullCoalLeft"), token)
+            vAccess := VariableAccess new(vDecl, token)
+
+            if (!trail addBeforeInScope(this, vDecl)) {
+                res throwError(CouldntAddBeforeInScope new(token, this, vDecl, trail))
+                return Response OK
+            }
+
+            seq := CommaSequence new(token)
+            assignment := BinaryOp new(vAccess, left, OpType ass, token)
+
+            seq add(assignment)
+
+            condition := Comparison new(vAccess, NullLiteral new(token), CompType notEqual, token)
+            ternary := Ternary new(condition, vAccess, right, token)
+
+            seq add(ternary)
+
+            if(!trail peek() replace(this, seq)) {
                 res throwError(CouldntReplace new(token, this, ternary, trail))
                 return Response OK
             }
 
-            res wholeAgain(this, "replaced null coalescing operator with ternary")
+            res wholeAgain(this, "replaced null coalescing operator with comma sequence of assignment and ternary")
             return Response OK
         }
 

--- a/test/compiler/operators/null-coalescing-single-evaluation.ooc
+++ b/test/compiler/operators/null-coalescing-single-evaluation.ooc
@@ -1,0 +1,13 @@
+
+counter := 0
+
+fun: func -> String {
+    counter += 1
+    ""
+}
+
+describe("Left side of the null coalescing operator should only be evaluated once", ||
+    temp := fun() ?? "foo"
+
+    expect(1, counter)
+)


### PR DESCRIPTION
Instead, create a temporary variable, assign the value of the left side in a comma sequence right before evaluating the ternary expression.  

Also, I think nullco rolls off the tongue nicely.