### PR TITLE
Add safe navigation accesses to the language

### DIFF
--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -15,7 +15,7 @@ import ../middle/[FunctionDecl, VariableDecl, TypeDecl, ClassDecl, CoverDecl,
     Match, FlowControl, While, CharLiteral, InterfaceDecl, NamespaceDecl,
     Version, Use, Block, ArrayLiteral, EnumDecl, BaseType, FuncType,
     Declaration, PropertyDecl, CallChain, Tuple, Addon, Try, CommaSequence,
-    TemplateDef]
+    TemplateDef, SafeNavigation]
 
 nq_parse: extern proto func (AstBuilder, CString) -> Int
 
@@ -1278,6 +1278,19 @@ AstBuilder: class {
 
     onNullCoalescing: unmangled(nq_onNullCoalescing) func (left, right: Expression) -> BinaryOp {
         BinaryOp new(left, right, OpType nullCoal, token())
+    }
+
+    onSafeNavigationStart: unmangled(nq_onSafeNavigationStart) func (expr: Expression) {
+        safeNav := SafeNavigation new(expr, token())
+        stack push(safeNav)
+    }
+
+    onSafeNavigationIdent: unmangled(nq_onSafeNavigationIdent) func (ident: CString) {
+        peek(SafeNavigation) idents add(ident toString())
+    }
+
+    onSafeNavigationEnd: unmangled(nq_onSafeNavigationEnd) func -> SafeNavigation {
+        pop(SafeNavigation)
     }
 
     onLogicalOr: unmangled(nq_onLogicalOr) func (left, right: Expression) -> BinaryOp {

--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -1285,8 +1285,12 @@ AstBuilder: class {
         stack push(safeNav)
     }
 
+    onSafeNavigationSection: unmangled(nq_onSafeNavigationSection) func {
+        peek(SafeNavigation) sections add(ArrayList<String> new())
+    }
+
     onSafeNavigationIdent: unmangled(nq_onSafeNavigationIdent) func (ident: CString) {
-        peek(SafeNavigation) idents add(ident toString())
+        peek(SafeNavigation) sections last() add(ident toString())
     }
 
     onSafeNavigationEnd: unmangled(nq_onSafeNavigationEnd) func -> SafeNavigation {

--- a/source/rock/frontend/NagaQueen.c
+++ b/source/rock/frontend/NagaQueen.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 struct _GREG;
-#define YYRULECOUNT 220
+#define YYRULECOUNT 222
 
 #include <stdio.h>
 #include <string.h>
@@ -401,6 +401,10 @@ void *nq_onBinaryOr(void *this, void *left, void *right);
 void *nq_onBinaryXor(void *this, void *left, void *right);
 void *nq_onBinaryAnd(void *this, void *left, void *right);
 
+void nq_onSafeNavigationStart(void *this, void *expr);
+void nq_onSafeNavigationIdent(void *this, char *ident);
+void *nq_onSafeNavigationEnd(void *this);
+
 void *nq_onLogicalNot(void *this, void *inner);
 void *nq_onBinaryNot(void *this, void *inner);
 void *nq_onUnaryMinus(void *this, void *inner);
@@ -754,43 +758,45 @@ YY_LOCAL(void) yySet(GREG *G, char *text, int count, yythunk *thunk, YY_XTYPE YY
 
 #define YYACCEPT        yyAccept(G, yythunkpos0)
 
-YY_RULE(int) yy_TextInside(GREG *G); /* 220 */
-YY_RULE(int) yy_TextChunk(GREG *G); /* 219 */
-YY_RULE(int) yy_Interpolation(GREG *G); /* 218 */
-YY_RULE(int) yy_StringChunk(GREG *G); /* 217 */
-YY_RULE(int) yy_DOUBLE_QUOTE(GREG *G); /* 216 */
-YY_RULE(int) yy_SINGLE_QUOTE(GREG *G); /* 215 */
-YY_RULE(int) yy_FP_LIT_SUFFIX(GREG *G); /* 214 */
-YY_RULE(int) yy_INT_LIT_SUFFIX(GREG *G); /* 213 */
-YY_RULE(int) yy_CommentMultiLineWithDocs(GREG *G); /* 212 */
-YY_RULE(int) yy_Comment(GREG *G); /* 211 */
-YY_RULE(int) yy_CommentMultiLine(GREG *G); /* 210 */
-YY_RULE(int) yy_CLOS_COMMENT(GREG *G); /* 209 */
-YY_RULE(int) yy_KW(GREG *G); /* 208 */
-YY_RULE(int) yy_FALSE_KW(GREG *G); /* 207 */
-YY_RULE(int) yy_TRUE_KW(GREG *G); /* 206 */
-YY_RULE(int) yy_NULL_KW(GREG *G); /* 205 */
-YY_RULE(int) yy_BOOL_LIT(GREG *G); /* 204 */
-YY_RULE(int) yy_CHAR_LIT(GREG *G); /* 203 */
-YY_RULE(int) yy_STRING_LIT(GREG *G); /* 202 */
-YY_RULE(int) yy_RAW_STRING_LIT(GREG *G); /* 201 */
-YY_RULE(int) yy_FLOAT_LIT(GREG *G); /* 200 */
-YY_RULE(int) yy_BIN_LIT(GREG *G); /* 199 */
-YY_RULE(int) yy_DEC_LIT(GREG *G); /* 198 */
-YY_RULE(int) yy_HEX_LIT(GREG *G); /* 197 */
-YY_RULE(int) yy_OCT_LIT(GREG *G); /* 196 */
-YY_RULE(int) yy_ArrayLiteral(GREG *G); /* 195 */
-YY_RULE(int) yy_ValueCore(GREG *G); /* 194 */
-YY_RULE(int) yy_VariableAccess(GREG *G); /* 193 */
-YY_RULE(int) yy_ACS(GREG *G); /* 192 */
-YY_RULE(int) yy_FunctionCallCore(GREG *G); /* 191 */
-YY_RULE(int) yy_FunctionCallNoname(GREG *G); /* 190 */
-YY_RULE(int) yy_AS_KW(GREG *G); /* 189 */
-YY_RULE(int) yy_CLOS_SQUAR(GREG *G); /* 188 */
-YY_RULE(int) yy_IDENT_CORE(GREG *G); /* 187 */
+YY_RULE(int) yy_TextInside(GREG *G); /* 222 */
+YY_RULE(int) yy_TextChunk(GREG *G); /* 221 */
+YY_RULE(int) yy_Interpolation(GREG *G); /* 220 */
+YY_RULE(int) yy_StringChunk(GREG *G); /* 219 */
+YY_RULE(int) yy_DOUBLE_QUOTE(GREG *G); /* 218 */
+YY_RULE(int) yy_SINGLE_QUOTE(GREG *G); /* 217 */
+YY_RULE(int) yy_FP_LIT_SUFFIX(GREG *G); /* 216 */
+YY_RULE(int) yy_INT_LIT_SUFFIX(GREG *G); /* 215 */
+YY_RULE(int) yy_CommentMultiLineWithDocs(GREG *G); /* 214 */
+YY_RULE(int) yy_Comment(GREG *G); /* 213 */
+YY_RULE(int) yy_CommentMultiLine(GREG *G); /* 212 */
+YY_RULE(int) yy_CLOS_COMMENT(GREG *G); /* 211 */
+YY_RULE(int) yy_KW(GREG *G); /* 210 */
+YY_RULE(int) yy_FALSE_KW(GREG *G); /* 209 */
+YY_RULE(int) yy_TRUE_KW(GREG *G); /* 208 */
+YY_RULE(int) yy_NULL_KW(GREG *G); /* 207 */
+YY_RULE(int) yy_BOOL_LIT(GREG *G); /* 206 */
+YY_RULE(int) yy_CHAR_LIT(GREG *G); /* 205 */
+YY_RULE(int) yy_STRING_LIT(GREG *G); /* 204 */
+YY_RULE(int) yy_RAW_STRING_LIT(GREG *G); /* 203 */
+YY_RULE(int) yy_FLOAT_LIT(GREG *G); /* 202 */
+YY_RULE(int) yy_BIN_LIT(GREG *G); /* 201 */
+YY_RULE(int) yy_DEC_LIT(GREG *G); /* 200 */
+YY_RULE(int) yy_HEX_LIT(GREG *G); /* 199 */
+YY_RULE(int) yy_OCT_LIT(GREG *G); /* 198 */
+YY_RULE(int) yy_ArrayLiteral(GREG *G); /* 197 */
+YY_RULE(int) yy_ValueCore(GREG *G); /* 196 */
+YY_RULE(int) yy_VariableAccess(GREG *G); /* 195 */
+YY_RULE(int) yy_ACS(GREG *G); /* 194 */
+YY_RULE(int) yy_FunctionCallCore(GREG *G); /* 193 */
+YY_RULE(int) yy_FunctionCallNoname(GREG *G); /* 192 */
+YY_RULE(int) yy_AS_KW(GREG *G); /* 191 */
+YY_RULE(int) yy_CLOS_SQUAR(GREG *G); /* 190 */
+YY_RULE(int) yy_IDENT_CORE(GREG *G); /* 189 */
+YY_RULE(int) yy_SAFE_NAV(GREG *G); /* 188 */
+YY_RULE(int) yy_Access(GREG *G); /* 187 */
 YY_RULE(int) yy_SLASH(GREG *G); /* 186 */
 YY_RULE(int) yy_EXP(GREG *G); /* 185 */
-YY_RULE(int) yy_Access(GREG *G); /* 184 */
+YY_RULE(int) yy_SafeNavAccess(GREG *G); /* 184 */
 YY_RULE(int) yy_B_NOT(GREG *G); /* 183 */
 YY_RULE(int) yy_L_NOT(GREG *G); /* 182 */
 YY_RULE(int) yy_ProductCore(GREG *G); /* 181 */
@@ -1996,6 +2002,39 @@ YY_ACTION(void) yy_1_Access(GREG *G, char *yytext, int yyleng, yythunk *thunk, Y
 #undef index
 #undef l
 #undef ident
+}
+YY_ACTION(void) yy_3_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define expr G->val[-2]
+  yyprintf((stderr, "do yy_3_SafeNavAccess"));
+  yyprintfvTcontext(yytext);
+  yyprintf((stderr, "\n  {yy=nq_onSafeNavigationEnd(core->this); }\n"));
+  yy=nq_onSafeNavigationEnd(core->this); ;
+#undef i
+#undef expr
+}
+YY_ACTION(void) yy_2_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define expr G->val[-2]
+  yyprintf((stderr, "do yy_2_SafeNavAccess"));
+  yyprintfvTcontext(yytext);
+  yyprintf((stderr, "\n  {nq_onSafeNavigationIdent(core->this, i); }\n"));
+  nq_onSafeNavigationIdent(core->this, i); ;
+#undef i
+#undef expr
+}
+YY_ACTION(void) yy_1_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define expr G->val[-2]
+  yyprintf((stderr, "do yy_1_SafeNavAccess"));
+  yyprintfvTcontext(yytext);
+  yyprintf((stderr, "\n  {tokenPos; nq_onSafeNavigationStart(core->this, expr); }\n"));
+  tokenPos; nq_onSafeNavigationStart(core->this, expr); ;
+#undef i
+#undef expr
 }
 YY_ACTION(void) yy_6_ProductCore(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
@@ -7680,43 +7719,15 @@ YY_RULE(int) yy_IDENT_CORE(GREG *G)
 
   return 0;
 }
-YY_RULE(int) yy_SLASH(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SLASH"));
-  if (!yymatchChar(G, '/')) goto l193;
-
-  {  int yypos194= G->pos, yythunkpos194= G->thunkpos;  if (!yymatchChar(G, '=')) goto l194;
-  goto l193;
-  l194:;	  G->pos= yypos194; G->thunkpos= yythunkpos194;
-  }
-  {  int yypos195= G->pos, yythunkpos195= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "/*")) goto l195;
-  goto l193;
-  l195:;	  G->pos= yypos195; G->thunkpos= yythunkpos195;
-  }  if (!yy__(G))  goto l193;
-  yyprintf((stderr, "  ok   SLASH"));
+YY_RULE(int) yy_SAFE_NAV(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SAFE_NAV"));
+  if (!yymatchChar(G, '$')) goto l193;
+  yyprintf((stderr, "  ok   SAFE_NAV"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l193:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SLASH"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_EXP(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXP"));
-  if (!yymatchString(G, "**")) goto l196;
-
-  {  int yypos197= G->pos, yythunkpos197= G->thunkpos;  if (!yymatchChar(G, '=')) goto l197;
-  goto l196;
-  l197:;	  G->pos= yypos197; G->thunkpos= yythunkpos197;
-  }  if (!yy__(G))  goto l196;
-  yyprintf((stderr, "  ok   EXP"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l196:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXP"));
+  l193:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SAFE_NAV"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7726,99 +7737,177 @@ YY_RULE(int) yy_Access(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Access"));
 
-  {  int yypos199= G->pos, yythunkpos199= G->thunkpos;  if (!yy_IDENT_CORE(G))  goto l200;
+  {  int yypos195= G->pos, yythunkpos195= G->thunkpos;  if (!yy_IDENT_CORE(G))  goto l196;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_1_Access, G->begin, G->end, "yy_1_Access");
-  if (!yymatchChar(G, '&')) goto l200;
+  if (!yymatchChar(G, '&')) goto l196;
 
-  {  int yypos201= G->pos, yythunkpos201= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l201;
-  goto l200;
-  l201:;	  G->pos= yypos201; G->thunkpos= yythunkpos201;
-  }  if (!yy__(G))  goto l200;
+  {  int yypos197= G->pos, yythunkpos197= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l197;
+  goto l196;
+  l197:;	  G->pos= yypos197; G->thunkpos= yythunkpos197;
+  }  if (!yy__(G))  goto l196;
   yyDo(G, yy_2_Access, G->begin, G->end, "yy_2_Access");
-  goto l199;
-  l200:;	  G->pos= yypos199; G->thunkpos= yythunkpos199;  if (!yy_Value(G))  goto l198;
+  goto l195;
+  l196:;	  G->pos= yypos195; G->thunkpos= yythunkpos195;  if (!yy_Value(G))  goto l194;
   yyDo(G, yySet, -4, 0, "yySet");
 
   }
-  l199:;	
-  l202:;	
-  {  int yypos203= G->pos, yythunkpos203= G->thunkpos;
-  {  int yypos204= G->pos, yythunkpos204= G->thunkpos;  if (!yy__(G))  goto l205;
-  if (!yymatchChar(G, '[')) goto l205;
-  if (!yy__(G))  goto l205;
+  l195:;	
+  l198:;	
+  {  int yypos199= G->pos, yythunkpos199= G->thunkpos;
+  {  int yypos200= G->pos, yythunkpos200= G->thunkpos;  if (!yy__(G))  goto l201;
+  if (!yymatchChar(G, '[')) goto l201;
+  if (!yy__(G))  goto l201;
   yyDo(G, yy_3_Access, G->begin, G->end, "yy_3_Access");
-  if (!yy_Expr(G))  goto l205;
+  if (!yy_Expr(G))  goto l201;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l205;
+  if (!yy__(G))  goto l201;
   yyDo(G, yy_4_Access, G->begin, G->end, "yy_4_Access");
 
-  l206:;	
-  {  int yypos207= G->pos, yythunkpos207= G->thunkpos;  if (!yymatchChar(G, ',')) goto l207;
-  if (!yy_WS(G))  goto l207;
-  if (!yy_Expr(G))  goto l207;
+  l202:;	
+  {  int yypos203= G->pos, yythunkpos203= G->thunkpos;  if (!yymatchChar(G, ',')) goto l203;
+  if (!yy_WS(G))  goto l203;
+  if (!yy_Expr(G))  goto l203;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l207;
+  if (!yy__(G))  goto l203;
   yyDo(G, yy_5_Access, G->begin, G->end, "yy_5_Access");
-  goto l206;
-  l207:;	  G->pos= yypos207; G->thunkpos= yythunkpos207;
-  }  if (!yy__(G))  goto l205;
-  if (!yy_CLOS_SQUAR(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed array access! Expected ']' to end array access.\n"); ; } goto l205; }
-  if (!yy__(G))  goto l205;
+  goto l202;
+  l203:;	  G->pos= yypos203; G->thunkpos= yythunkpos203;
+  }  if (!yy__(G))  goto l201;
+  if (!yy_CLOS_SQUAR(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed array access! Expected ']' to end array access.\n"); ; } goto l201; }
+  if (!yy__(G))  goto l201;
   yyDo(G, yy_6_Access, G->begin, G->end, "yy_6_Access");
-  goto l204;
-  l205:;	  G->pos= yypos204; G->thunkpos= yythunkpos204;  if (!yy__(G))  goto l208;
-  if (!yy_FunctionCall(G))  goto l208;
+  goto l200;
+  l201:;	  G->pos= yypos200; G->thunkpos= yythunkpos200;  if (!yy__(G))  goto l204;
+  if (!yy_FunctionCall(G))  goto l204;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_7_Access, G->begin, G->end, "yy_7_Access");
-  goto l204;
-  l208:;	  G->pos= yypos204; G->thunkpos= yythunkpos204;  if (!yy__(G))  goto l209;
-  if (!yy_IDENT_CORE(G))  goto l209;
+  goto l200;
+  l204:;	  G->pos= yypos200; G->thunkpos= yythunkpos200;  if (!yy__(G))  goto l205;
+  if (!yy_IDENT_CORE(G))  goto l205;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Access, G->begin, G->end, "yy_8_Access");
-  goto l204;
-  l209:;	  G->pos= yypos204; G->thunkpos= yythunkpos204;  if (!yy__(G))  goto l210;
-  if (!yy_AS_KW(G))  goto l210;
+  goto l200;
+  l205:;	  G->pos= yypos200; G->thunkpos= yythunkpos200;  if (!yy__(G))  goto l206;
+  if (!yy_AS_KW(G))  goto l206;
   yyDo(G, yy_9_Access, G->begin, G->end, "yy_9_Access");
-  if (!yy__(G))  goto l210;
-  if (!yy_Type(G))  goto l210;
+  if (!yy__(G))  goto l206;
+  if (!yy_Type(G))  goto l206;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Access, G->begin, G->end, "yy_10_Access");
-  goto l204;
-  l210:;	  G->pos= yypos204; G->thunkpos= yythunkpos204;  if (!yymatchChar(G, '&')) goto l211;
+  goto l200;
+  l206:;	  G->pos= yypos200; G->thunkpos= yythunkpos200;  if (!yymatchChar(G, '&')) goto l207;
 
-  {  int yypos212= G->pos, yythunkpos212= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l212;
-  goto l211;
-  l212:;	  G->pos= yypos212; G->thunkpos= yythunkpos212;
-  }  if (!yy__(G))  goto l211;
+  {  int yypos208= G->pos, yythunkpos208= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l208;
+  goto l207;
+  l208:;	  G->pos= yypos208; G->thunkpos= yythunkpos208;
+  }  if (!yy__(G))  goto l207;
 
-  {  int yypos213= G->pos, yythunkpos213= G->thunkpos;
-  {  int yypos214= G->pos, yythunkpos214= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\046\000\000\001\022\000\010\000\000\000\000\000\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t\\r\\n;,)}")) goto l215;
-  goto l214;
-  l215:;	  G->pos= yypos214; G->thunkpos= yythunkpos214;  if (!yymatchChar(G, ']')) goto l211;
+  {  int yypos209= G->pos, yythunkpos209= G->thunkpos;
+  {  int yypos210= G->pos, yythunkpos210= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\046\000\000\001\022\000\010\000\000\000\000\000\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t\\r\\n;,)}")) goto l211;
+  goto l210;
+  l211:;	  G->pos= yypos210; G->thunkpos= yythunkpos210;  if (!yymatchChar(G, ']')) goto l207;
 
   }
-  l214:;	  G->pos= yypos213; G->thunkpos= yythunkpos213;
+  l210:;	  G->pos= yypos209; G->thunkpos= yythunkpos209;
   }  yyDo(G, yy_11_Access, G->begin, G->end, "yy_11_Access");
-  goto l204;
-  l211:;	  G->pos= yypos204; G->thunkpos= yythunkpos204;  if (!yymatchChar(G, '@')) goto l216;
+  goto l200;
+  l207:;	  G->pos= yypos200; G->thunkpos= yythunkpos200;  if (!yymatchChar(G, '@')) goto l212;
   yyDo(G, yy_12_Access, G->begin, G->end, "yy_12_Access");
-  goto l204;
-  l216:;	  G->pos= yypos204; G->thunkpos= yythunkpos204;  if (!yy__(G))  goto l203;
-  if (!yy_FunctionCallNoname(G))  goto l203;
+  goto l200;
+  l212:;	  G->pos= yypos200; G->thunkpos= yythunkpos200;  if (!yy__(G))  goto l199;
+  if (!yy_FunctionCallNoname(G))  goto l199;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_13_Access, G->begin, G->end, "yy_13_Access");
 
   }
-  l204:;	  goto l202;
-  l203:;	  G->pos= yypos203; G->thunkpos= yythunkpos203;
-  }  if (!yy__(G))  goto l198;
+  l200:;	  goto l198;
+  l199:;	  G->pos= yypos199; G->thunkpos= yythunkpos199;
+  }  if (!yy__(G))  goto l194;
   yyprintf((stderr, "  ok   Access"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l198:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Access"));
+  l194:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Access"));
+  yyprintfvGcontext;
+  yyprintfv((stderr, "\n"));
+
+  return 0;
+}
+YY_RULE(int) yy_SLASH(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SLASH"));
+  if (!yymatchChar(G, '/')) goto l213;
+
+  {  int yypos214= G->pos, yythunkpos214= G->thunkpos;  if (!yymatchChar(G, '=')) goto l214;
+  goto l213;
+  l214:;	  G->pos= yypos214; G->thunkpos= yythunkpos214;
+  }
+  {  int yypos215= G->pos, yythunkpos215= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "/*")) goto l215;
+  goto l213;
+  l215:;	  G->pos= yypos215; G->thunkpos= yythunkpos215;
+  }  if (!yy__(G))  goto l213;
+  yyprintf((stderr, "  ok   SLASH"));
+  yyprintfGcontext;
+  yyprintf((stderr, "\n"));
+
+  return 1;
+  l213:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SLASH"));
+  yyprintfvGcontext;
+  yyprintfv((stderr, "\n"));
+
+  return 0;
+}
+YY_RULE(int) yy_EXP(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXP"));
+  if (!yymatchString(G, "**")) goto l216;
+
+  {  int yypos217= G->pos, yythunkpos217= G->thunkpos;  if (!yymatchChar(G, '=')) goto l217;
+  goto l216;
+  l217:;	  G->pos= yypos217; G->thunkpos= yythunkpos217;
+  }  if (!yy__(G))  goto l216;
+  yyprintf((stderr, "  ok   EXP"));
+  yyprintfGcontext;
+  yyprintf((stderr, "\n"));
+
+  return 1;
+  l216:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXP"));
+  yyprintfvGcontext;
+  yyprintfv((stderr, "\n"));
+
+  return 0;
+}
+YY_RULE(int) yy_SafeNavAccess(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
+  yyprintfv((stderr, "%s\n", "SafeNavAccess"));
+  if (!yy_Access(G))  goto l218;
+  yyDo(G, yySet, -2, 0, "yySet");
+
+  {  int yypos219= G->pos, yythunkpos219= G->thunkpos;  yyDo(G, yy_1_SafeNavAccess, G->begin, G->end, "yy_1_SafeNavAccess");
+  if (!yy_SAFE_NAV(G))  goto l219;
+  if (!yy__(G))  goto l219;
+  if (!yy_IDENT(G))  goto l219;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
+
+  l221:;	
+  {  int yypos222= G->pos, yythunkpos222= G->thunkpos;  if (!yy_SAFE_NAV(G))  goto l222;
+  if (!yy__(G))  goto l222;
+  if (!yy_IDENT(G))  goto l222;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
+  goto l221;
+  l222:;	  G->pos= yypos222; G->thunkpos= yythunkpos222;
+  }  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  goto l220;
+  l219:;	  G->pos= yypos219; G->thunkpos= yythunkpos219;
+  }
+  l220:;	  yyprintf((stderr, "  ok   SafeNavAccess"));
+  yyprintfGcontext;
+  yyprintf((stderr, "\n"));
+  yyDo(G, yyPop, 2, 0, "yyPop");
+  return 1;
+  l218:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SafeNavAccess"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7826,18 +7915,18 @@ YY_RULE(int) yy_Access(GREG *G)
 }
 YY_RULE(int) yy_B_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_NOT"));
-  if (!yymatchChar(G, '~')) goto l217;
+  if (!yymatchChar(G, '~')) goto l223;
 
-  {  int yypos218= G->pos, yythunkpos218= G->thunkpos;  if (!yymatchChar(G, '=')) goto l218;
-  goto l217;
-  l218:;	  G->pos= yypos218; G->thunkpos= yythunkpos218;
-  }  if (!yy__(G))  goto l217;
+  {  int yypos224= G->pos, yythunkpos224= G->thunkpos;  if (!yymatchChar(G, '=')) goto l224;
+  goto l223;
+  l224:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;
+  }  if (!yy__(G))  goto l223;
   yyprintf((stderr, "  ok   B_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l217:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
+  l223:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7845,18 +7934,18 @@ YY_RULE(int) yy_B_NOT(GREG *G)
 }
 YY_RULE(int) yy_L_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_NOT"));
-  if (!yymatchChar(G, '!')) goto l219;
+  if (!yymatchChar(G, '!')) goto l225;
 
-  {  int yypos220= G->pos, yythunkpos220= G->thunkpos;  if (!yymatchChar(G, '=')) goto l220;
-  goto l219;
-  l220:;	  G->pos= yypos220; G->thunkpos= yythunkpos220;
-  }  if (!yy__(G))  goto l219;
+  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;  if (!yymatchChar(G, '=')) goto l226;
+  goto l225;
+  l226:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;
+  }  if (!yy__(G))  goto l225;
   yyprintf((stderr, "  ok   L_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l219:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
+  l225:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7865,41 +7954,41 @@ YY_RULE(int) yy_L_NOT(GREG *G)
 YY_RULE(int) yy_ProductCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductCore"));
-  if (!yy_Access(G))  goto l221;
+  if (!yy_SafeNavAccess(G))  goto l227;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l222:;	
-  {  int yypos223= G->pos, yythunkpos223= G->thunkpos;
-  {  int yypos224= G->pos, yythunkpos224= G->thunkpos;  if (!yy_EXP(G))  goto l225;
+  l228:;	
+  {  int yypos229= G->pos, yythunkpos229= G->thunkpos;
+  {  int yypos230= G->pos, yythunkpos230= G->thunkpos;  if (!yy_EXP(G))  goto l231;
   yyDo(G, yy_1_ProductCore, G->begin, G->end, "yy_1_ProductCore");
-  if (!yy_WS(G))  goto l225;
-  if (!yy_Product(G))  goto l225;
+  if (!yy_WS(G))  goto l231;
+  if (!yy_Product(G))  goto l231;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ProductCore, G->begin, G->end, "yy_2_ProductCore");
-  goto l224;
-  l225:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;  if (!yy_STAR(G))  goto l226;
+  goto l230;
+  l231:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;  if (!yy_STAR(G))  goto l232;
   yyDo(G, yy_3_ProductCore, G->begin, G->end, "yy_3_ProductCore");
-  if (!yy_WS(G))  goto l226;
-  if (!yy_Access(G))  goto l226;
+  if (!yy_WS(G))  goto l232;
+  if (!yy_SafeNavAccess(G))  goto l232;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_ProductCore, G->begin, G->end, "yy_4_ProductCore");
-  goto l224;
-  l226:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;  if (!yy_SLASH(G))  goto l223;
+  goto l230;
+  l232:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;  if (!yy_SLASH(G))  goto l229;
   yyDo(G, yy_5_ProductCore, G->begin, G->end, "yy_5_ProductCore");
-  if (!yy_WS(G))  goto l223;
-  if (!yy_Access(G))  goto l223;
+  if (!yy_WS(G))  goto l229;
+  if (!yy_SafeNavAccess(G))  goto l229;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_ProductCore, G->begin, G->end, "yy_6_ProductCore");
 
   }
-  l224:;	  goto l222;
-  l223:;	  G->pos= yypos223; G->thunkpos= yythunkpos223;
+  l230:;	  goto l228;
+  l229:;	  G->pos= yypos229; G->thunkpos= yythunkpos229;
   }  yyprintf((stderr, "  ok   ProductCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l221:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
+  l227:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7908,19 +7997,19 @@ YY_RULE(int) yy_ProductCore(GREG *G)
 YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductBinaryNot"));
-  if (!yy_B_NOT(G))  goto l227;
+  if (!yy_B_NOT(G))  goto l233;
   yyDo(G, yy_1_ProductBinaryNot, G->begin, G->end, "yy_1_ProductBinaryNot");
-  if (!yy__(G))  goto l227;
-  if (!yy_Product(G))  goto l227;
+  if (!yy__(G))  goto l233;
+  if (!yy_Product(G))  goto l233;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l227;
+  if (!yy__(G))  goto l233;
   yyDo(G, yy_2_ProductBinaryNot, G->begin, G->end, "yy_2_ProductBinaryNot");
   yyprintf((stderr, "  ok   ProductBinaryNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l227:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
+  l233:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7929,19 +8018,19 @@ YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductLogicalNot"));
-  if (!yy_L_NOT(G))  goto l228;
+  if (!yy_L_NOT(G))  goto l234;
   yyDo(G, yy_1_ProductLogicalNot, G->begin, G->end, "yy_1_ProductLogicalNot");
-  if (!yy__(G))  goto l228;
-  if (!yy_Product(G))  goto l228;
+  if (!yy__(G))  goto l234;
+  if (!yy_Product(G))  goto l234;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l228;
+  if (!yy__(G))  goto l234;
   yyDo(G, yy_2_ProductLogicalNot, G->begin, G->end, "yy_2_ProductLogicalNot");
   yyprintf((stderr, "  ok   ProductLogicalNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l228:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
+  l234:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7949,18 +8038,18 @@ YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 }
 YY_RULE(int) yy_PERCENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PERCENT"));
-  if (!yymatchChar(G, '%')) goto l229;
+  if (!yymatchChar(G, '%')) goto l235;
 
-  {  int yypos230= G->pos, yythunkpos230= G->thunkpos;  if (!yymatchChar(G, '=')) goto l230;
-  goto l229;
-  l230:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;
-  }  if (!yy__(G))  goto l229;
+  {  int yypos236= G->pos, yythunkpos236= G->thunkpos;  if (!yymatchChar(G, '=')) goto l236;
+  goto l235;
+  l236:;	  G->pos= yypos236; G->thunkpos= yythunkpos236;
+  }  if (!yy__(G))  goto l235;
   yyprintf((stderr, "  ok   PERCENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l229:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
+  l235:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7968,18 +8057,18 @@ YY_RULE(int) yy_PERCENT(GREG *G)
 }
 YY_RULE(int) yy_MINUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MINUS"));
-  if (!yymatchChar(G, '-')) goto l231;
+  if (!yymatchChar(G, '-')) goto l237;
 
-  {  int yypos232= G->pos, yythunkpos232= G->thunkpos;  if (!yymatchChar(G, '=')) goto l232;
-  goto l231;
-  l232:;	  G->pos= yypos232; G->thunkpos= yythunkpos232;
-  }  if (!yy__(G))  goto l231;
+  {  int yypos238= G->pos, yythunkpos238= G->thunkpos;  if (!yymatchChar(G, '=')) goto l238;
+  goto l237;
+  l238:;	  G->pos= yypos238; G->thunkpos= yythunkpos238;
+  }  if (!yy__(G))  goto l237;
   yyprintf((stderr, "  ok   MINUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l231:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
+  l237:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7988,19 +8077,19 @@ YY_RULE(int) yy_MINUS(GREG *G)
 YY_RULE(int) yy_Product(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Product"));
 
-  {  int yypos234= G->pos, yythunkpos234= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l235;
-  goto l234;
-  l235:;	  G->pos= yypos234; G->thunkpos= yythunkpos234;  if (!yy_ProductBinaryNot(G))  goto l236;
-  goto l234;
-  l236:;	  G->pos= yypos234; G->thunkpos= yythunkpos234;  if (!yy_ProductCore(G))  goto l233;
+  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l241;
+  goto l240;
+  l241:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;  if (!yy_ProductBinaryNot(G))  goto l242;
+  goto l240;
+  l242:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;  if (!yy_ProductCore(G))  goto l239;
 
   }
-  l234:;	  yyprintf((stderr, "  ok   Product"));
+  l240:;	  yyprintf((stderr, "  ok   Product"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l233:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
+  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8008,18 +8097,18 @@ YY_RULE(int) yy_Product(GREG *G)
 }
 YY_RULE(int) yy_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_RSHIFT"));
-  if (!yymatchString(G, ">>")) goto l237;
+  if (!yymatchString(G, ">>")) goto l243;
 
-  {  int yypos238= G->pos, yythunkpos238= G->thunkpos;  if (!yymatchChar(G, '=')) goto l238;
-  goto l237;
-  l238:;	  G->pos= yypos238; G->thunkpos= yythunkpos238;
-  }  if (!yy__(G))  goto l237;
+  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yymatchChar(G, '=')) goto l244;
+  goto l243;
+  l244:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;
+  }  if (!yy__(G))  goto l243;
   yyprintf((stderr, "  ok   B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l237:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
+  l243:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8027,18 +8116,18 @@ YY_RULE(int) yy_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_LSHIFT"));
-  if (!yymatchString(G, "<<")) goto l239;
+  if (!yymatchString(G, "<<")) goto l245;
 
-  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yymatchChar(G, '=')) goto l240;
-  goto l239;
-  l240:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;
-  }  if (!yy__(G))  goto l239;
+  {  int yypos246= G->pos, yythunkpos246= G->thunkpos;  if (!yymatchChar(G, '=')) goto l246;
+  goto l245;
+  l246:;	  G->pos= yypos246; G->thunkpos= yythunkpos246;
+  }  if (!yy__(G))  goto l245;
   yyprintf((stderr, "  ok   B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
+  l245:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8047,41 +8136,41 @@ YY_RULE(int) yy_B_LSHIFT(GREG *G)
 YY_RULE(int) yy_Sum(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Sum"));
-  if (!yy_Product(G))  goto l241;
+  if (!yy_Product(G))  goto l247;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l242:;	
-  {  int yypos243= G->pos, yythunkpos243= G->thunkpos;
-  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yy_PLUS(G))  goto l245;
+  l248:;	
+  {  int yypos249= G->pos, yythunkpos249= G->thunkpos;
+  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;  if (!yy_PLUS(G))  goto l251;
   yyDo(G, yy_1_Sum, G->begin, G->end, "yy_1_Sum");
-  if (!yy_WS(G))  goto l245;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l245; }
+  if (!yy_WS(G))  goto l251;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l251; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Sum, G->begin, G->end, "yy_2_Sum");
-  goto l244;
-  l245:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_MINUS(G))  goto l246;
+  goto l250;
+  l251:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;  if (!yy_MINUS(G))  goto l252;
   yyDo(G, yy_3_Sum, G->begin, G->end, "yy_3_Sum");
-  if (!yy_WS(G))  goto l246;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l246; }
+  if (!yy_WS(G))  goto l252;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l252; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Sum, G->begin, G->end, "yy_4_Sum");
-  goto l244;
-  l246:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_PERCENT(G))  goto l243;
+  goto l250;
+  l252:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;  if (!yy_PERCENT(G))  goto l249;
   yyDo(G, yy_5_Sum, G->begin, G->end, "yy_5_Sum");
-  if (!yy_WS(G))  goto l243;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l243; }
+  if (!yy_WS(G))  goto l249;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l249; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Sum, G->begin, G->end, "yy_6_Sum");
 
   }
-  l244:;	  goto l242;
-  l243:;	  G->pos= yypos243; G->thunkpos= yythunkpos243;
+  l250:;	  goto l248;
+  l249:;	  G->pos= yypos249; G->thunkpos= yythunkpos249;
   }  yyprintf((stderr, "  ok   Sum"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l241:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
+  l247:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8089,14 +8178,14 @@ YY_RULE(int) yy_Sum(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_DOT"));
-  if (!yymatchString(G, "..")) goto l247;
-  if (!yy__(G))  goto l247;
+  if (!yymatchString(G, "..")) goto l253;
+  if (!yy__(G))  goto l253;
   yyprintf((stderr, "  ok   DOUBLE_DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l247:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
+  l253:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8105,34 +8194,34 @@ YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 YY_RULE(int) yy_Shift(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Shift"));
-  if (!yy_Sum(G))  goto l248;
+  if (!yy_Sum(G))  goto l254;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l249:;	
-  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;
-  {  int yypos251= G->pos, yythunkpos251= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l252;
+  l255:;	
+  {  int yypos256= G->pos, yythunkpos256= G->thunkpos;
+  {  int yypos257= G->pos, yythunkpos257= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l258;
   yyDo(G, yy_1_Shift, G->begin, G->end, "yy_1_Shift");
-  if (!yy_WS(G))  goto l252;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l252; }
+  if (!yy_WS(G))  goto l258;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l258; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Shift, G->begin, G->end, "yy_2_Shift");
-  goto l251;
-  l252:;	  G->pos= yypos251; G->thunkpos= yythunkpos251;  if (!yy_B_RSHIFT(G))  goto l250;
+  goto l257;
+  l258:;	  G->pos= yypos257; G->thunkpos= yythunkpos257;  if (!yy_B_RSHIFT(G))  goto l256;
   yyDo(G, yy_3_Shift, G->begin, G->end, "yy_3_Shift");
-  if (!yy_WS(G))  goto l250;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l250; }
+  if (!yy_WS(G))  goto l256;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l256; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Shift, G->begin, G->end, "yy_4_Shift");
 
   }
-  l251:;	  goto l249;
-  l250:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;
+  l257:;	  goto l255;
+  l256:;	  G->pos= yypos256; G->thunkpos= yythunkpos256;
   }  yyprintf((stderr, "  ok   Shift"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l248:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
+  l254:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8140,14 +8229,14 @@ YY_RULE(int) yy_Shift(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN_EQ"));
-  if (!yymatchString(G, ">=")) goto l253;
-  if (!yy__(G))  goto l253;
+  if (!yymatchString(G, ">=")) goto l259;
+  if (!yy__(G))  goto l259;
   yyprintf((stderr, "  ok   MORETHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l253:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
+  l259:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8155,14 +8244,14 @@ YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN_EQ"));
-  if (!yymatchString(G, "<=")) goto l254;
-  if (!yy__(G))  goto l254;
+  if (!yymatchString(G, "<=")) goto l260;
+  if (!yy__(G))  goto l260;
   yyprintf((stderr, "  ok   LESSTHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l254:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
+  l260:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8170,14 +8259,14 @@ YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_CMP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CMP"));
-  if (!yymatchString(G, "<=>")) goto l255;
-  if (!yy__(G))  goto l255;
+  if (!yymatchString(G, "<=>")) goto l261;
+  if (!yy__(G))  goto l261;
   yyprintf((stderr, "  ok   CMP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l255:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
+  l261:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8186,24 +8275,24 @@ YY_RULE(int) yy_CMP(GREG *G)
 YY_RULE(int) yy_Range(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Range"));
-  if (!yy_Shift(G))  goto l256;
+  if (!yy_Shift(G))  goto l262;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l257:;	
-  {  int yypos258= G->pos, yythunkpos258= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l258;
+  l263:;	
+  {  int yypos264= G->pos, yythunkpos264= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l264;
   yyDo(G, yy_1_Range, G->begin, G->end, "yy_1_Range");
-  if (!yy_WS(G))  goto l258;
-  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l258; }
+  if (!yy_WS(G))  goto l264;
+  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l264; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Range, G->begin, G->end, "yy_2_Range");
-  goto l257;
-  l258:;	  G->pos= yypos258; G->thunkpos= yythunkpos258;
+  goto l263;
+  l264:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;
   }  yyprintf((stderr, "  ok   Range"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l256:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
+  l262:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8211,14 +8300,14 @@ YY_RULE(int) yy_Range(GREG *G)
 }
 YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "NOT_EQUALS"));
-  if (!yymatchString(G, "!=")) goto l259;
-  if (!yy__(G))  goto l259;
+  if (!yymatchString(G, "!=")) goto l265;
+  if (!yy__(G))  goto l265;
   yyprintf((stderr, "  ok   NOT_EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l259:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
+  l265:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8226,14 +8315,14 @@ YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 }
 YY_RULE(int) yy_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EQUALS"));
-  if (!yymatchString(G, "==")) goto l260;
-  if (!yy__(G))  goto l260;
+  if (!yymatchString(G, "==")) goto l266;
+  if (!yy__(G))  goto l266;
   yyprintf((stderr, "  ok   EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l260:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
+  l266:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8242,55 +8331,55 @@ YY_RULE(int) yy_EQUALS(GREG *G)
 YY_RULE(int) yy_Inequality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Inequality"));
-  if (!yy_Range(G))  goto l261;
+  if (!yy_Range(G))  goto l267;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l262:;	
-  {  int yypos263= G->pos, yythunkpos263= G->thunkpos;
-  {  int yypos264= G->pos, yythunkpos264= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l265;
+  l268:;	
+  {  int yypos269= G->pos, yythunkpos269= G->thunkpos;
+  {  int yypos270= G->pos, yythunkpos270= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l271;
   yyDo(G, yy_1_Inequality, G->begin, G->end, "yy_1_Inequality");
-  if (!yy_WS(G))  goto l265;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l265; }
+  if (!yy_WS(G))  goto l271;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l271; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Inequality, G->begin, G->end, "yy_2_Inequality");
-  goto l264;
-  l265:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_MORETHAN(G))  goto l266;
+  goto l270;
+  l271:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_MORETHAN(G))  goto l272;
   yyDo(G, yy_3_Inequality, G->begin, G->end, "yy_3_Inequality");
-  if (!yy_WS(G))  goto l266;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l266; }
+  if (!yy_WS(G))  goto l272;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l272; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Inequality, G->begin, G->end, "yy_4_Inequality");
-  goto l264;
-  l266:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_CMP(G))  goto l267;
+  goto l270;
+  l272:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_CMP(G))  goto l273;
   yyDo(G, yy_5_Inequality, G->begin, G->end, "yy_5_Inequality");
-  if (!yy_WS(G))  goto l267;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l267; }
+  if (!yy_WS(G))  goto l273;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l273; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Inequality, G->begin, G->end, "yy_6_Inequality");
-  goto l264;
-  l267:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_LESSTHAN_EQ(G))  goto l268;
+  goto l270;
+  l273:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_LESSTHAN_EQ(G))  goto l274;
   yyDo(G, yy_7_Inequality, G->begin, G->end, "yy_7_Inequality");
-  if (!yy_WS(G))  goto l268;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l268; }
+  if (!yy_WS(G))  goto l274;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l274; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Inequality, G->begin, G->end, "yy_8_Inequality");
-  goto l264;
-  l268:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_MORETHAN_EQ(G))  goto l263;
+  goto l270;
+  l274:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_MORETHAN_EQ(G))  goto l269;
   yyDo(G, yy_9_Inequality, G->begin, G->end, "yy_9_Inequality");
-  if (!yy_WS(G))  goto l263;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l263; }
+  if (!yy_WS(G))  goto l269;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l269; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Inequality, G->begin, G->end, "yy_10_Inequality");
 
   }
-  l264:;	  goto l262;
-  l263:;	  G->pos= yypos263; G->thunkpos= yythunkpos263;
+  l270:;	  goto l268;
+  l269:;	  G->pos= yypos269; G->thunkpos= yythunkpos269;
   }  yyprintf((stderr, "  ok   Inequality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l261:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
+  l267:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8299,21 +8388,21 @@ YY_RULE(int) yy_Inequality(GREG *G)
 YY_RULE(int) yy_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_AND"));
 
-  {  int yypos270= G->pos, yythunkpos270= G->thunkpos;  if (!yy_L_AND(G))  goto l270;
-  goto l269;
-  l270:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;
-  }  if (!yymatchChar(G, '&')) goto l269;
+  {  int yypos276= G->pos, yythunkpos276= G->thunkpos;  if (!yy_L_AND(G))  goto l276;
+  goto l275;
+  l276:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;
+  }  if (!yymatchChar(G, '&')) goto l275;
 
-  {  int yypos271= G->pos, yythunkpos271= G->thunkpos;  if (!yymatchChar(G, '=')) goto l271;
-  goto l269;
-  l271:;	  G->pos= yypos271; G->thunkpos= yythunkpos271;
-  }  if (!yy__(G))  goto l269;
+  {  int yypos277= G->pos, yythunkpos277= G->thunkpos;  if (!yymatchChar(G, '=')) goto l277;
+  goto l275;
+  l277:;	  G->pos= yypos277; G->thunkpos= yythunkpos277;
+  }  if (!yy__(G))  goto l275;
   yyprintf((stderr, "  ok   B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l269:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
+  l275:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8322,34 +8411,34 @@ YY_RULE(int) yy_B_AND(GREG *G)
 YY_RULE(int) yy_Equality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Equality"));
-  if (!yy_Inequality(G))  goto l272;
+  if (!yy_Inequality(G))  goto l278;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l273:;	
-  {  int yypos274= G->pos, yythunkpos274= G->thunkpos;
-  {  int yypos275= G->pos, yythunkpos275= G->thunkpos;  if (!yy_EQUALS(G))  goto l276;
+  l279:;	
+  {  int yypos280= G->pos, yythunkpos280= G->thunkpos;
+  {  int yypos281= G->pos, yythunkpos281= G->thunkpos;  if (!yy_EQUALS(G))  goto l282;
   yyDo(G, yy_1_Equality, G->begin, G->end, "yy_1_Equality");
-  if (!yy_WS(G))  goto l276;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l276; }
+  if (!yy_WS(G))  goto l282;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l282; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Equality, G->begin, G->end, "yy_2_Equality");
-  goto l275;
-  l276:;	  G->pos= yypos275; G->thunkpos= yythunkpos275;  if (!yy_NOT_EQUALS(G))  goto l274;
+  goto l281;
+  l282:;	  G->pos= yypos281; G->thunkpos= yythunkpos281;  if (!yy_NOT_EQUALS(G))  goto l280;
   yyDo(G, yy_3_Equality, G->begin, G->end, "yy_3_Equality");
-  if (!yy_WS(G))  goto l274;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l274; }
+  if (!yy_WS(G))  goto l280;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l280; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Equality, G->begin, G->end, "yy_4_Equality");
 
   }
-  l275:;	  goto l273;
-  l274:;	  G->pos= yypos274; G->thunkpos= yythunkpos274;
+  l281:;	  goto l279;
+  l280:;	  G->pos= yypos280; G->thunkpos= yythunkpos280;
   }  yyprintf((stderr, "  ok   Equality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l272:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
+  l278:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8357,18 +8446,18 @@ YY_RULE(int) yy_Equality(GREG *G)
 }
 YY_RULE(int) yy_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_XOR"));
-  if (!yymatchChar(G, '^')) goto l277;
+  if (!yymatchChar(G, '^')) goto l283;
 
-  {  int yypos278= G->pos, yythunkpos278= G->thunkpos;  if (!yymatchChar(G, '=')) goto l278;
-  goto l277;
-  l278:;	  G->pos= yypos278; G->thunkpos= yythunkpos278;
-  }  if (!yy__(G))  goto l277;
+  {  int yypos284= G->pos, yythunkpos284= G->thunkpos;  if (!yymatchChar(G, '=')) goto l284;
+  goto l283;
+  l284:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;
+  }  if (!yy__(G))  goto l283;
   yyprintf((stderr, "  ok   B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l277:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
+  l283:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8377,24 +8466,24 @@ YY_RULE(int) yy_B_XOR(GREG *G)
 YY_RULE(int) yy_BinaryAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryAnd"));
-  if (!yy_Equality(G))  goto l279;
+  if (!yy_Equality(G))  goto l285;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l280:;	
-  {  int yypos281= G->pos, yythunkpos281= G->thunkpos;  if (!yy_B_AND(G))  goto l281;
+  l286:;	
+  {  int yypos287= G->pos, yythunkpos287= G->thunkpos;  if (!yy_B_AND(G))  goto l287;
   yyDo(G, yy_1_BinaryAnd, G->begin, G->end, "yy_1_BinaryAnd");
-  if (!yy_WS(G))  goto l281;
-  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l281; }
+  if (!yy_WS(G))  goto l287;
+  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l287; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryAnd, G->begin, G->end, "yy_2_BinaryAnd");
-  goto l280;
-  l281:;	  G->pos= yypos281; G->thunkpos= yythunkpos281;
+  goto l286;
+  l287:;	  G->pos= yypos287; G->thunkpos= yythunkpos287;
   }  yyprintf((stderr, "  ok   BinaryAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l279:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
+  l285:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8403,21 +8492,21 @@ YY_RULE(int) yy_BinaryAnd(GREG *G)
 YY_RULE(int) yy_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_OR"));
 
-  {  int yypos283= G->pos, yythunkpos283= G->thunkpos;  if (!yy_L_OR(G))  goto l283;
-  goto l282;
-  l283:;	  G->pos= yypos283; G->thunkpos= yythunkpos283;
-  }  if (!yymatchChar(G, '|')) goto l282;
+  {  int yypos289= G->pos, yythunkpos289= G->thunkpos;  if (!yy_L_OR(G))  goto l289;
+  goto l288;
+  l289:;	  G->pos= yypos289; G->thunkpos= yythunkpos289;
+  }  if (!yymatchChar(G, '|')) goto l288;
 
-  {  int yypos284= G->pos, yythunkpos284= G->thunkpos;  if (!yymatchChar(G, '=')) goto l284;
-  goto l282;
-  l284:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;
-  }  if (!yy__(G))  goto l282;
+  {  int yypos290= G->pos, yythunkpos290= G->thunkpos;  if (!yymatchChar(G, '=')) goto l290;
+  goto l288;
+  l290:;	  G->pos= yypos290; G->thunkpos= yythunkpos290;
+  }  if (!yy__(G))  goto l288;
   yyprintf((stderr, "  ok   B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l282:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
+  l288:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8426,24 +8515,24 @@ YY_RULE(int) yy_B_OR(GREG *G)
 YY_RULE(int) yy_BinaryXor(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryXor"));
-  if (!yy_BinaryAnd(G))  goto l285;
+  if (!yy_BinaryAnd(G))  goto l291;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l286:;	
-  {  int yypos287= G->pos, yythunkpos287= G->thunkpos;  if (!yy_B_XOR(G))  goto l287;
+  l292:;	
+  {  int yypos293= G->pos, yythunkpos293= G->thunkpos;  if (!yy_B_XOR(G))  goto l293;
   yyDo(G, yy_1_BinaryXor, G->begin, G->end, "yy_1_BinaryXor");
-  if (!yy_WS(G))  goto l287;
-  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l287; }
+  if (!yy_WS(G))  goto l293;
+  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l293; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryXor, G->begin, G->end, "yy_2_BinaryXor");
-  goto l286;
-  l287:;	  G->pos= yypos287; G->thunkpos= yythunkpos287;
+  goto l292;
+  l293:;	  G->pos= yypos293; G->thunkpos= yythunkpos293;
   }  yyprintf((stderr, "  ok   BinaryXor"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l285:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
+  l291:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8451,14 +8540,14 @@ YY_RULE(int) yy_BinaryXor(GREG *G)
 }
 YY_RULE(int) yy_L_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_AND"));
-  if (!yymatchString(G, "&&")) goto l288;
-  if (!yy__(G))  goto l288;
+  if (!yymatchString(G, "&&")) goto l294;
+  if (!yy__(G))  goto l294;
   yyprintf((stderr, "  ok   L_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l288:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
+  l294:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8467,24 +8556,24 @@ YY_RULE(int) yy_L_AND(GREG *G)
 YY_RULE(int) yy_BinaryOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryOr"));
-  if (!yy_BinaryXor(G))  goto l289;
+  if (!yy_BinaryXor(G))  goto l295;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l290:;	
-  {  int yypos291= G->pos, yythunkpos291= G->thunkpos;  if (!yy_B_OR(G))  goto l291;
+  l296:;	
+  {  int yypos297= G->pos, yythunkpos297= G->thunkpos;  if (!yy_B_OR(G))  goto l297;
   yyDo(G, yy_1_BinaryOr, G->begin, G->end, "yy_1_BinaryOr");
-  if (!yy_WS(G))  goto l291;
-  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l291; }
+  if (!yy_WS(G))  goto l297;
+  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l297; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryOr, G->begin, G->end, "yy_2_BinaryOr");
-  goto l290;
-  l291:;	  G->pos= yypos291; G->thunkpos= yythunkpos291;
+  goto l296;
+  l297:;	  G->pos= yypos297; G->thunkpos= yythunkpos297;
   }  yyprintf((stderr, "  ok   BinaryOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l289:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
+  l295:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8492,14 +8581,14 @@ YY_RULE(int) yy_BinaryOr(GREG *G)
 }
 YY_RULE(int) yy_L_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_OR"));
-  if (!yymatchString(G, "||")) goto l292;
-  if (!yy__(G))  goto l292;
+  if (!yymatchString(G, "||")) goto l298;
+  if (!yy__(G))  goto l298;
   yyprintf((stderr, "  ok   L_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l292:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
+  l298:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8508,24 +8597,24 @@ YY_RULE(int) yy_L_OR(GREG *G)
 YY_RULE(int) yy_LogicalAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalAnd"));
-  if (!yy_BinaryOr(G))  goto l293;
+  if (!yy_BinaryOr(G))  goto l299;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l294:;	
-  {  int yypos295= G->pos, yythunkpos295= G->thunkpos;  if (!yy_L_AND(G))  goto l295;
+  l300:;	
+  {  int yypos301= G->pos, yythunkpos301= G->thunkpos;  if (!yy_L_AND(G))  goto l301;
   yyDo(G, yy_1_LogicalAnd, G->begin, G->end, "yy_1_LogicalAnd");
-  if (!yy_WS(G))  goto l295;
-  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l295; }
+  if (!yy_WS(G))  goto l301;
+  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l301; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalAnd, G->begin, G->end, "yy_2_LogicalAnd");
-  goto l294;
-  l295:;	  G->pos= yypos295; G->thunkpos= yythunkpos295;
+  goto l300;
+  l301:;	  G->pos= yypos301; G->thunkpos= yythunkpos301;
   }  yyprintf((stderr, "  ok   LogicalAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l293:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
+  l299:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8533,14 +8622,14 @@ YY_RULE(int) yy_LogicalAnd(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_QUEST"));
-  if (!yymatchString(G, "??")) goto l296;
-  if (!yy__(G))  goto l296;
+  if (!yymatchString(G, "??")) goto l302;
+  if (!yy__(G))  goto l302;
   yyprintf((stderr, "  ok   DOUBLE_QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l296:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
+  l302:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8549,24 +8638,24 @@ YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 YY_RULE(int) yy_LogicalOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalOr"));
-  if (!yy_LogicalAnd(G))  goto l297;
+  if (!yy_LogicalAnd(G))  goto l303;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l298:;	
-  {  int yypos299= G->pos, yythunkpos299= G->thunkpos;  if (!yy_L_OR(G))  goto l299;
+  l304:;	
+  {  int yypos305= G->pos, yythunkpos305= G->thunkpos;  if (!yy_L_OR(G))  goto l305;
   yyDo(G, yy_1_LogicalOr, G->begin, G->end, "yy_1_LogicalOr");
-  if (!yy_WS(G))  goto l299;
-  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l299; }
+  if (!yy_WS(G))  goto l305;
+  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l305; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalOr, G->begin, G->end, "yy_2_LogicalOr");
-  goto l298;
-  l299:;	  G->pos= yypos299; G->thunkpos= yythunkpos299;
+  goto l304;
+  l305:;	  G->pos= yypos305; G->thunkpos= yythunkpos305;
   }  yyprintf((stderr, "  ok   LogicalOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l297:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
+  l303:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8574,14 +8663,14 @@ YY_RULE(int) yy_LogicalOr(GREG *G)
 }
 YY_RULE(int) yy_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "QUEST"));
-  if (!yymatchChar(G, '?')) goto l300;
-  if (!yy__(G))  goto l300;
+  if (!yymatchChar(G, '?')) goto l306;
+  if (!yy__(G))  goto l306;
   yyprintf((stderr, "  ok   QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l300:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
+  l306:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8590,24 +8679,24 @@ YY_RULE(int) yy_QUEST(GREG *G)
 YY_RULE(int) yy_NullCoalescing(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "NullCoalescing"));
-  if (!yy_LogicalOr(G))  goto l301;
+  if (!yy_LogicalOr(G))  goto l307;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos302= G->pos, yythunkpos302= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l302;
+  {  int yypos308= G->pos, yythunkpos308= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l308;
   yyDo(G, yy_1_NullCoalescing, G->begin, G->end, "yy_1_NullCoalescing");
-  if (!yy_WS(G))  goto l302;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l302; }
+  if (!yy_WS(G))  goto l308;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l308; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_NullCoalescing, G->begin, G->end, "yy_2_NullCoalescing");
-  goto l303;
-  l302:;	  G->pos= yypos302; G->thunkpos= yythunkpos302;
+  goto l309;
+  l308:;	  G->pos= yypos308; G->thunkpos= yythunkpos308;
   }
-  l303:;	  yyprintf((stderr, "  ok   NullCoalescing"));
+  l309:;	  yyprintf((stderr, "  ok   NullCoalescing"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l301:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
+  l307:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8615,14 +8704,14 @@ YY_RULE(int) yy_NullCoalescing(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_AND"));
-  if (!yymatchString(G, "&=")) goto l304;
-  if (!yy__(G))  goto l304;
+  if (!yymatchString(G, "&=")) goto l310;
+  if (!yy__(G))  goto l310;
   yyprintf((stderr, "  ok   ASS_B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l304:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
+  l310:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8630,14 +8719,14 @@ YY_RULE(int) yy_ASS_B_AND(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_OR"));
-  if (!yymatchString(G, "|=")) goto l305;
-  if (!yy__(G))  goto l305;
+  if (!yymatchString(G, "|=")) goto l311;
+  if (!yy__(G))  goto l311;
   yyprintf((stderr, "  ok   ASS_B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l305:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
+  l311:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8645,14 +8734,14 @@ YY_RULE(int) yy_ASS_B_OR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_XOR"));
-  if (!yymatchString(G, "^=")) goto l306;
-  if (!yy__(G))  goto l306;
+  if (!yymatchString(G, "^=")) goto l312;
+  if (!yy__(G))  goto l312;
   yyprintf((stderr, "  ok   ASS_B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l306:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
+  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8660,14 +8749,14 @@ YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_RSHIFT"));
-  if (!yymatchString(G, ">>=")) goto l307;
-  if (!yy__(G))  goto l307;
+  if (!yymatchString(G, ">>=")) goto l313;
+  if (!yy__(G))  goto l313;
   yyprintf((stderr, "  ok   ASS_B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l307:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
+  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8675,14 +8764,14 @@ YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_LSHIFT"));
-  if (!yymatchString(G, "<<=")) goto l308;
-  if (!yy__(G))  goto l308;
+  if (!yymatchString(G, "<<=")) goto l314;
+  if (!yy__(G))  goto l314;
   yyprintf((stderr, "  ok   ASS_B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l308:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
+  l314:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8690,14 +8779,14 @@ YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_DIV(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DIV"));
-  if (!yymatchString(G, "/=")) goto l309;
-  if (!yy__(G))  goto l309;
+  if (!yymatchString(G, "/=")) goto l315;
+  if (!yy__(G))  goto l315;
   yyprintf((stderr, "  ok   ASS_DIV"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l309:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
+  l315:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8705,14 +8794,14 @@ YY_RULE(int) yy_ASS_DIV(GREG *G)
 }
 YY_RULE(int) yy_ASS_EXP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_EXP"));
-  if (!yymatchString(G, "**=")) goto l310;
-  if (!yy__(G))  goto l310;
+  if (!yymatchString(G, "**=")) goto l316;
+  if (!yy__(G))  goto l316;
   yyprintf((stderr, "  ok   ASS_EXP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l310:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
+  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8720,14 +8809,14 @@ YY_RULE(int) yy_ASS_EXP(GREG *G)
 }
 YY_RULE(int) yy_ASS_MUL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MUL"));
-  if (!yymatchString(G, "*=")) goto l311;
-  if (!yy__(G))  goto l311;
+  if (!yymatchString(G, "*=")) goto l317;
+  if (!yy__(G))  goto l317;
   yyprintf((stderr, "  ok   ASS_MUL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l311:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
+  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8735,14 +8824,14 @@ YY_RULE(int) yy_ASS_MUL(GREG *G)
 }
 YY_RULE(int) yy_ASS_SUB(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_SUB"));
-  if (!yymatchString(G, "-=")) goto l312;
-  if (!yy__(G))  goto l312;
+  if (!yymatchString(G, "-=")) goto l318;
+  if (!yy__(G))  goto l318;
   yyprintf((stderr, "  ok   ASS_SUB"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
+  l318:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8750,14 +8839,14 @@ YY_RULE(int) yy_ASS_SUB(GREG *G)
 }
 YY_RULE(int) yy_ASS_MOD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MOD"));
-  if (!yymatchString(G, "%=")) goto l313;
-  if (!yy__(G))  goto l313;
+  if (!yymatchString(G, "%=")) goto l319;
+  if (!yy__(G))  goto l319;
   yyprintf((stderr, "  ok   ASS_MOD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
+  l319:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8765,14 +8854,14 @@ YY_RULE(int) yy_ASS_MOD(GREG *G)
 }
 YY_RULE(int) yy_ASS_ADD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_ADD"));
-  if (!yymatchString(G, "+=")) goto l314;
-  if (!yy__(G))  goto l314;
+  if (!yymatchString(G, "+=")) goto l320;
+  if (!yy__(G))  goto l320;
   yyprintf((stderr, "  ok   ASS_ADD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l314:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
+  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8781,30 +8870,30 @@ YY_RULE(int) yy_ASS_ADD(GREG *G)
 YY_RULE(int) yy_Ternary(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Ternary"));
-  if (!yy_NullCoalescing(G))  goto l315;
+  if (!yy_NullCoalescing(G))  goto l321;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos316= G->pos, yythunkpos316= G->thunkpos;  if (!yy__(G))  goto l316;
-  if (!yy_QUEST(G))  goto l316;
+  {  int yypos322= G->pos, yythunkpos322= G->thunkpos;  if (!yy__(G))  goto l322;
+  if (!yy_QUEST(G))  goto l322;
   yyDo(G, yy_1_Ternary, G->begin, G->end, "yy_1_Ternary");
-  if (!yy_WS(G))  goto l316;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l316; }
+  if (!yy_WS(G))  goto l322;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l322; }
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l316;
-  if (!yy_COLON(G))  goto l316;
-  if (!yy_WS(G))  goto l316;
-  if (!yy_NullCoalescing(G))  goto l316;
+  if (!yy__(G))  goto l322;
+  if (!yy_COLON(G))  goto l322;
+  if (!yy_WS(G))  goto l322;
+  if (!yy_NullCoalescing(G))  goto l322;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Ternary, G->begin, G->end, "yy_2_Ternary");
-  goto l317;
-  l316:;	  G->pos= yypos316; G->thunkpos= yythunkpos316;
+  goto l323;
+  l322:;	  G->pos= yypos322; G->thunkpos= yythunkpos322;
   }
-  l317:;	  yyprintf((stderr, "  ok   Ternary"));
+  l323:;	  yyprintf((stderr, "  ok   Ternary"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l315:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
+  l321:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8813,111 +8902,111 @@ YY_RULE(int) yy_Ternary(GREG *G)
 YY_RULE(int) yy_Assignment(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Assignment"));
-  if (!yy_Ternary(G))  goto l318;
+  if (!yy_Ternary(G))  goto l324;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l319:;	
-  {  int yypos320= G->pos, yythunkpos320= G->thunkpos;
-  {  int yypos321= G->pos, yythunkpos321= G->thunkpos;  if (!yy_ASS(G))  goto l322;
+  l325:;	
+  {  int yypos326= G->pos, yythunkpos326= G->thunkpos;
+  {  int yypos327= G->pos, yythunkpos327= G->thunkpos;  if (!yy_ASS(G))  goto l328;
   yyDo(G, yy_1_Assignment, G->begin, G->end, "yy_1_Assignment");
-  if (!yy_WS(G))  goto l322;
-  if (!yy_Ternary(G))  goto l322;
+  if (!yy_WS(G))  goto l328;
+  if (!yy_Ternary(G))  goto l328;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Assignment, G->begin, G->end, "yy_2_Assignment");
-  goto l321;
-  l322:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS(G))  goto l323;
+  goto l327;
+  l328:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS(G))  goto l329;
   yyDo(G, yy_3_Assignment, G->begin, G->end, "yy_3_Assignment");
-  if (!yy_WS(G))  goto l323;
-  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l323; }
+  if (!yy_WS(G))  goto l329;
+  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l329; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Assignment, G->begin, G->end, "yy_4_Assignment");
-  goto l321;
-  l323:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_ADD(G))  goto l324;
+  goto l327;
+  l329:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_ADD(G))  goto l330;
   yyDo(G, yy_5_Assignment, G->begin, G->end, "yy_5_Assignment");
-  if (!yy_WS(G))  goto l324;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l324; }
+  if (!yy_WS(G))  goto l330;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l330; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Assignment, G->begin, G->end, "yy_6_Assignment");
-  goto l321;
-  l324:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_MOD(G))  goto l325;
+  goto l327;
+  l330:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_MOD(G))  goto l331;
   yyDo(G, yy_7_Assignment, G->begin, G->end, "yy_7_Assignment");
-  if (!yy_WS(G))  goto l325;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l325; }
+  if (!yy_WS(G))  goto l331;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l331; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Assignment, G->begin, G->end, "yy_8_Assignment");
-  goto l321;
-  l325:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_SUB(G))  goto l326;
+  goto l327;
+  l331:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_SUB(G))  goto l332;
   yyDo(G, yy_9_Assignment, G->begin, G->end, "yy_9_Assignment");
-  if (!yy_WS(G))  goto l326;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l326; }
+  if (!yy_WS(G))  goto l332;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l332; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Assignment, G->begin, G->end, "yy_10_Assignment");
-  goto l321;
-  l326:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_MUL(G))  goto l327;
+  goto l327;
+  l332:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_MUL(G))  goto l333;
   yyDo(G, yy_11_Assignment, G->begin, G->end, "yy_11_Assignment");
-  if (!yy_WS(G))  goto l327;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l327; }
+  if (!yy_WS(G))  goto l333;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l333; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_12_Assignment, G->begin, G->end, "yy_12_Assignment");
-  goto l321;
-  l327:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_EXP(G))  goto l328;
+  goto l327;
+  l333:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_EXP(G))  goto l334;
   yyDo(G, yy_13_Assignment, G->begin, G->end, "yy_13_Assignment");
-  if (!yy_WS(G))  goto l328;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l328; }
+  if (!yy_WS(G))  goto l334;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l334; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_14_Assignment, G->begin, G->end, "yy_14_Assignment");
-  goto l321;
-  l328:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_DIV(G))  goto l329;
+  goto l327;
+  l334:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_DIV(G))  goto l335;
   yyDo(G, yy_15_Assignment, G->begin, G->end, "yy_15_Assignment");
-  if (!yy_WS(G))  goto l329;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l329; }
+  if (!yy_WS(G))  goto l335;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l335; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_16_Assignment, G->begin, G->end, "yy_16_Assignment");
-  goto l321;
-  l329:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_B_LSHIFT(G))  goto l330;
+  goto l327;
+  l335:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_LSHIFT(G))  goto l336;
   yyDo(G, yy_17_Assignment, G->begin, G->end, "yy_17_Assignment");
-  if (!yy_WS(G))  goto l330;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l330; }
+  if (!yy_WS(G))  goto l336;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l336; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_18_Assignment, G->begin, G->end, "yy_18_Assignment");
-  goto l321;
-  l330:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_B_RSHIFT(G))  goto l331;
+  goto l327;
+  l336:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_RSHIFT(G))  goto l337;
   yyDo(G, yy_19_Assignment, G->begin, G->end, "yy_19_Assignment");
-  if (!yy_WS(G))  goto l331;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l331; }
+  if (!yy_WS(G))  goto l337;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l337; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_20_Assignment, G->begin, G->end, "yy_20_Assignment");
-  goto l321;
-  l331:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_B_XOR(G))  goto l332;
+  goto l327;
+  l337:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_XOR(G))  goto l338;
   yyDo(G, yy_21_Assignment, G->begin, G->end, "yy_21_Assignment");
-  if (!yy_WS(G))  goto l332;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l332; }
+  if (!yy_WS(G))  goto l338;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l338; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_22_Assignment, G->begin, G->end, "yy_22_Assignment");
-  goto l321;
-  l332:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_B_OR(G))  goto l333;
+  goto l327;
+  l338:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_OR(G))  goto l339;
   yyDo(G, yy_23_Assignment, G->begin, G->end, "yy_23_Assignment");
-  if (!yy_WS(G))  goto l333;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l333; }
+  if (!yy_WS(G))  goto l339;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l339; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_24_Assignment, G->begin, G->end, "yy_24_Assignment");
-  goto l321;
-  l333:;	  G->pos= yypos321; G->thunkpos= yythunkpos321;  if (!yy_ASS_B_AND(G))  goto l320;
+  goto l327;
+  l339:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_AND(G))  goto l326;
   yyDo(G, yy_25_Assignment, G->begin, G->end, "yy_25_Assignment");
-  if (!yy_WS(G))  goto l320;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l320; }
+  if (!yy_WS(G))  goto l326;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l326; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_26_Assignment, G->begin, G->end, "yy_26_Assignment");
 
   }
-  l321:;	  goto l319;
-  l320:;	  G->pos= yypos320; G->thunkpos= yythunkpos320;
+  l327:;	  goto l325;
+  l326:;	  G->pos= yypos326; G->thunkpos= yythunkpos326;
   }  yyprintf((stderr, "  ok   Assignment"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l318:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
+  l324:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8926,17 +9015,17 @@ YY_RULE(int) yy_Assignment(GREG *G)
 YY_RULE(int) yy_FunctionCall(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionCall"));
-  if (!yy_IDENT(G))  goto l334;
+  if (!yy_IDENT(G))  goto l340;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_FunctionCall, G->begin, G->end, "yy_1_FunctionCall");
-  if (!yy_FunctionCallCore(G))  goto l334;
+  if (!yy_FunctionCallCore(G))  goto l340;
   yyDo(G, yy_2_FunctionCall, G->begin, G->end, "yy_2_FunctionCall");
   yyprintf((stderr, "  ok   FunctionCall"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l334:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
+  l340:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8944,13 +9033,13 @@ YY_RULE(int) yy_FunctionCall(GREG *G)
 }
 YY_RULE(int) yy_BinaryOperation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BinaryOperation"));
-  if (!yy_Assignment(G))  goto l335;
+  if (!yy_Assignment(G))  goto l341;
   yyprintf((stderr, "  ok   BinaryOperation"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l335:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
+  l341:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8959,12 +9048,12 @@ YY_RULE(int) yy_BinaryOperation(GREG *G)
 YY_RULE(int) yy_DoubleArrow(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "DoubleArrow"));
-  if (!yy_Assignment(G))  goto l336;
+  if (!yy_Assignment(G))  goto l342;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DOUBLE_ARROW(G))  goto l336;
+  if (!yy_DOUBLE_ARROW(G))  goto l342;
   yyDo(G, yy_1_DoubleArrow, G->begin, G->end, "yy_1_DoubleArrow");
-  if (!yy_WS(G))  goto l336;
-  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l336; }
+  if (!yy_WS(G))  goto l342;
+  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l342; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_DoubleArrow, G->begin, G->end, "yy_2_DoubleArrow");
   yyprintf((stderr, "  ok   DoubleArrow"));
@@ -8972,7 +9061,7 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l336:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
+  l342:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8980,13 +9069,13 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
 }
 YY_RULE(int) yy_RETURN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "RETURN_KW"));
-  if (!yymatchString(G, "return")) goto l337;
+  if (!yymatchString(G, "return")) goto l343;
   yyprintf((stderr, "  ok   RETURN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l337:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
+  l343:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8994,13 +9083,13 @@ YY_RULE(int) yy_RETURN_KW(GREG *G)
 }
 YY_RULE(int) yy_WHILE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "WHILE_KW"));
-  if (!yymatchString(G, "while")) goto l338;
+  if (!yymatchString(G, "while")) goto l344;
   yyprintf((stderr, "  ok   WHILE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l338:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
+  l344:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9008,13 +9097,13 @@ YY_RULE(int) yy_WHILE_KW(GREG *G)
 }
 YY_RULE(int) yy_IN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IN_KW"));
-  if (!yymatchString(G, "in")) goto l339;
+  if (!yymatchString(G, "in")) goto l345;
   yyprintf((stderr, "  ok   IN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l339:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
+  l345:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9022,13 +9111,13 @@ YY_RULE(int) yy_IN_KW(GREG *G)
 }
 YY_RULE(int) yy_FOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FOR_KW"));
-  if (!yymatchString(G, "for")) goto l340;
+  if (!yymatchString(G, "for")) goto l346;
   yyprintf((stderr, "  ok   FOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l340:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
+  l346:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9038,25 +9127,25 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImplicitDecl"));
 
-  {  int yypos342= G->pos, yythunkpos342= G->thunkpos;  if (!yy_VariableDecl(G))  goto l343;
+  {  int yypos348= G->pos, yythunkpos348= G->thunkpos;  if (!yy_VariableDecl(G))  goto l349;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ImplicitDecl, G->begin, G->end, "yy_1_ImplicitDecl");
-  goto l342;
-  l343:;	  G->pos= yypos342; G->thunkpos= yythunkpos342;  if (!yy_Tuple(G))  goto l344;
+  goto l348;
+  l349:;	  G->pos= yypos348; G->thunkpos= yythunkpos348;  if (!yy_Tuple(G))  goto l350;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_ImplicitDecl, G->begin, G->end, "yy_2_ImplicitDecl");
-  goto l342;
-  l344:;	  G->pos= yypos342; G->thunkpos= yythunkpos342;  if (!yy_IDENT(G))  goto l341;
+  goto l348;
+  l350:;	  G->pos= yypos348; G->thunkpos= yythunkpos348;  if (!yy_IDENT(G))  goto l347;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImplicitDecl, G->begin, G->end, "yy_3_ImplicitDecl");
 
   }
-  l342:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
+  l348:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l341:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
+  l347:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9064,13 +9153,13 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 }
 YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONTINUE_KW"));
-  if (!yymatchString(G, "continue")) goto l345;
+  if (!yymatchString(G, "continue")) goto l351;
   yyprintf((stderr, "  ok   CONTINUE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l345:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
+  l351:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9078,13 +9167,13 @@ YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 }
 YY_RULE(int) yy_BREAK_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BREAK_KW"));
-  if (!yymatchString(G, "break")) goto l346;
+  if (!yymatchString(G, "break")) goto l352;
   yyprintf((stderr, "  ok   BREAK_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l346:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
+  l352:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9092,14 +9181,14 @@ YY_RULE(int) yy_BREAK_KW(GREG *G)
 }
 YY_RULE(int) yy_Continue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Continue"));
-  if (!yy_CONTINUE_KW(G))  goto l347;
+  if (!yy_CONTINUE_KW(G))  goto l353;
   yyDo(G, yy_1_Continue, G->begin, G->end, "yy_1_Continue");
   yyprintf((stderr, "  ok   Continue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l347:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
+  l353:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9107,14 +9196,14 @@ YY_RULE(int) yy_Continue(GREG *G)
 }
 YY_RULE(int) yy_Break(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Break"));
-  if (!yy_BREAK_KW(G))  goto l348;
+  if (!yy_BREAK_KW(G))  goto l354;
   yyDo(G, yy_1_Break, G->begin, G->end, "yy_1_Break");
   yyprintf((stderr, "  ok   Break"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l348:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
+  l354:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9123,27 +9212,27 @@ YY_RULE(int) yy_Break(GREG *G)
 YY_RULE(int) yy_While(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "While"));
-  if (!yy_WHILE_KW(G))  goto l349;
+  if (!yy_WHILE_KW(G))  goto l355;
   yyDo(G, yy_1_While, G->begin, G->end, "yy_1_While");
-  if (!yy_WS(G))  goto l349;
-  if (!yymatchChar(G, '(')) goto l349;
-  if (!yy_WS(G))  goto l349;
-  if (!yy__(G))  goto l349;
-  if (!yy_Expr(G))  goto l349;
+  if (!yy_WS(G))  goto l355;
+  if (!yymatchChar(G, '(')) goto l355;
+  if (!yy_WS(G))  goto l355;
+  if (!yy__(G))  goto l355;
+  if (!yy_Expr(G))  goto l355;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l349;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l349; }
+  if (!yy_WS(G))  goto l355;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l355; }
   yyDo(G, yy_2_While, G->begin, G->end, "yy_2_While");
-  if (!yy__(G))  goto l349;
-  if (!yy_Body(G))  goto l349;
-  if (!yy__(G))  goto l349;
+  if (!yy__(G))  goto l355;
+  if (!yy_Body(G))  goto l355;
+  if (!yy__(G))  goto l355;
   yyDo(G, yy_3_While, G->begin, G->end, "yy_3_While");
   yyprintf((stderr, "  ok   While"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l349:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
+  l355:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9152,32 +9241,32 @@ YY_RULE(int) yy_While(GREG *G)
 YY_RULE(int) yy_Foreach(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Foreach"));
-  if (!yy_FOR_KW(G))  goto l350;
+  if (!yy_FOR_KW(G))  goto l356;
   yyDo(G, yy_1_Foreach, G->begin, G->end, "yy_1_Foreach");
-  if (!yy_WS(G))  goto l350;
-  if (!yymatchChar(G, '(')) goto l350;
-  if (!yy_WS(G))  goto l350;
-  if (!yy__(G))  goto l350;
-  if (!yy_ImplicitDecl(G))  goto l350;
+  if (!yy_WS(G))  goto l356;
+  if (!yymatchChar(G, '(')) goto l356;
+  if (!yy_WS(G))  goto l356;
+  if (!yy__(G))  goto l356;
+  if (!yy_ImplicitDecl(G))  goto l356;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l350;
-  if (!yy_IN_KW(G))  goto l350;
-  if (!yy__(G))  goto l350;
-  if (!yy_Expr(G))  goto l350;
+  if (!yy__(G))  goto l356;
+  if (!yy_IN_KW(G))  goto l356;
+  if (!yy__(G))  goto l356;
+  if (!yy_Expr(G))  goto l356;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l350;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l350; }
+  if (!yy_WS(G))  goto l356;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l356; }
   yyDo(G, yy_2_Foreach, G->begin, G->end, "yy_2_Foreach");
-  if (!yy__(G))  goto l350;
-  if (!yy_Body(G))  goto l350;
-  if (!yy__(G))  goto l350;
+  if (!yy__(G))  goto l356;
+  if (!yy_Body(G))  goto l356;
+  if (!yy__(G))  goto l356;
   yyDo(G, yy_3_Foreach, G->begin, G->end, "yy_3_Foreach");
   yyprintf((stderr, "  ok   Foreach"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l350:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
+  l356:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9185,13 +9274,13 @@ YY_RULE(int) yy_Foreach(GREG *G)
 }
 YY_RULE(int) yy_CATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CATCH_KW"));
-  if (!yymatchString(G, "catch")) goto l351;
+  if (!yymatchString(G, "catch")) goto l357;
   yyprintf((stderr, "  ok   CATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l351:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
+  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9200,36 +9289,36 @@ YY_RULE(int) yy_CATCH_KW(GREG *G)
 YY_RULE(int) yy_Catch(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Catch"));
-  if (!yy_CATCH_KW(G))  goto l352;
+  if (!yy_CATCH_KW(G))  goto l358;
   yyDo(G, yy_1_Catch, G->begin, G->end, "yy_1_Catch");
 
-  {  int yypos353= G->pos, yythunkpos353= G->thunkpos;  if (!yy__(G))  goto l353;
-  if (!yy_Expr(G))  goto l353;
+  {  int yypos359= G->pos, yythunkpos359= G->thunkpos;  if (!yy__(G))  goto l359;
+  if (!yy_Expr(G))  goto l359;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Catch, G->begin, G->end, "yy_2_Catch");
-  goto l354;
-  l353:;	  G->pos= yypos353; G->thunkpos= yythunkpos353;
+  goto l360;
+  l359:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;
   }
-  l354:;	  if (!yy_WS(G))  goto l352;
-  if (!yymatchChar(G, '{')) goto l352;
+  l360:;	  if (!yy_WS(G))  goto l358;
+  if (!yymatchChar(G, '{')) goto l358;
 
-  l355:;	
-  {  int yypos356= G->pos, yythunkpos356= G->thunkpos;  if (!yy_WS(G))  goto l356;
-  if (!yy_Stmt(G))  goto l356;
+  l361:;	
+  {  int yypos362= G->pos, yythunkpos362= G->thunkpos;  if (!yy_WS(G))  goto l362;
+  if (!yy_Stmt(G))  goto l362;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l356;
+  if (!yy_WS(G))  goto l362;
   yyDo(G, yy_3_Catch, G->begin, G->end, "yy_3_Catch");
-  goto l355;
-  l356:;	  G->pos= yypos356; G->thunkpos= yythunkpos356;
-  }  if (!yy_WS(G))  goto l352;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l352; }
+  goto l361;
+  l362:;	  G->pos= yypos362; G->thunkpos= yythunkpos362;
+  }  if (!yy_WS(G))  goto l358;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l358; }
   yyDo(G, yy_4_Catch, G->begin, G->end, "yy_4_Catch");
   yyprintf((stderr, "  ok   Catch"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l352:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
+  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9237,13 +9326,13 @@ YY_RULE(int) yy_Catch(GREG *G)
 }
 YY_RULE(int) yy_TRY_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TRY_KW"));
-  if (!yymatchString(G, "try")) goto l357;
+  if (!yymatchString(G, "try")) goto l363;
   yyprintf((stderr, "  ok   TRY_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
+  l363:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9253,73 +9342,73 @@ YY_RULE(int) yy_Value(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Value"));
 
-  {  int yypos359= G->pos, yythunkpos359= G->thunkpos;  if (!yymatchChar(G, '-')) goto l360;
-  if (!yy__(G))  goto l360;
-  if (!yymatchChar(G, '(')) goto l360;
+  {  int yypos365= G->pos, yythunkpos365= G->thunkpos;  if (!yymatchChar(G, '-')) goto l366;
+  if (!yy__(G))  goto l366;
+  if (!yymatchChar(G, '(')) goto l366;
   yyDo(G, yy_1_Value, G->begin, G->end, "yy_1_Value");
-  if (!yy_WS(G))  goto l360;
-  if (!yy_Expr(G))  goto l360;
+  if (!yy_WS(G))  goto l366;
+  if (!yy_Expr(G))  goto l366;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l360;
-  if (!yymatchChar(G, ')')) goto l360;
+  if (!yy_WS(G))  goto l366;
+  if (!yymatchChar(G, ')')) goto l366;
   yyDo(G, yy_2_Value, G->begin, G->end, "yy_2_Value");
-  if (!yy__(G))  goto l360;
-  goto l359;
-  l360:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;  if (!yymatchChar(G, '+')) goto l361;
-  if (!yy__(G))  goto l361;
-  if (!yymatchChar(G, '(')) goto l361;
+  if (!yy__(G))  goto l366;
+  goto l365;
+  l366:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '+')) goto l367;
+  if (!yy__(G))  goto l367;
+  if (!yymatchChar(G, '(')) goto l367;
   yyDo(G, yy_3_Value, G->begin, G->end, "yy_3_Value");
-  if (!yy_WS(G))  goto l361;
-  if (!yy_Expr(G))  goto l361;
+  if (!yy_WS(G))  goto l367;
+  if (!yy_Expr(G))  goto l367;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l361;
-  if (!yymatchChar(G, ')')) goto l361;
+  if (!yy_WS(G))  goto l367;
+  if (!yymatchChar(G, ')')) goto l367;
   yyDo(G, yy_4_Value, G->begin, G->end, "yy_4_Value");
-  if (!yy__(G))  goto l361;
-  goto l359;
-  l361:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;  if (!yymatchChar(G, '-')) goto l362;
-  if (!yy__(G))  goto l362;
+  if (!yy__(G))  goto l367;
+  goto l365;
+  l367:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '-')) goto l368;
+  if (!yy__(G))  goto l368;
   yyDo(G, yy_5_Value, G->begin, G->end, "yy_5_Value");
-  if (!yy_Access(G))  goto l362;
+  if (!yy_SafeNavAccess(G))  goto l368;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Value, G->begin, G->end, "yy_6_Value");
-  goto l359;
-  l362:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;  if (!yymatchChar(G, '+')) goto l363;
-  if (!yy__(G))  goto l363;
+  goto l365;
+  l368:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '+')) goto l369;
+  if (!yy__(G))  goto l369;
   yyDo(G, yy_7_Value, G->begin, G->end, "yy_7_Value");
-  if (!yy_Access(G))  goto l363;
+  if (!yy_SafeNavAccess(G))  goto l369;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Value, G->begin, G->end, "yy_8_Value");
-  goto l359;
-  l363:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;  if (!yymatchChar(G, '(')) goto l364;
+  goto l365;
+  l369:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '(')) goto l370;
   yyDo(G, yy_9_Value, G->begin, G->end, "yy_9_Value");
-  if (!yy_WS(G))  goto l364;
-  if (!yy_Expr(G))  goto l364;
+  if (!yy_WS(G))  goto l370;
+  if (!yy_Expr(G))  goto l370;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l364;
-  if (!yymatchChar(G, ')')) goto l364;
+  if (!yy_WS(G))  goto l370;
+  if (!yymatchChar(G, ')')) goto l370;
   yyDo(G, yy_10_Value, G->begin, G->end, "yy_10_Value");
 
-  {  int yypos365= G->pos, yythunkpos365= G->thunkpos;  if (!yymatchChar(G, '&')) goto l365;
+  {  int yypos371= G->pos, yythunkpos371= G->thunkpos;  if (!yymatchChar(G, '&')) goto l371;
 
-  {  int yypos367= G->pos, yythunkpos367= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l367;
-  goto l365;
-  l367:;	  G->pos= yypos367; G->thunkpos= yythunkpos367;
+  {  int yypos373= G->pos, yythunkpos373= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l373;
+  goto l371;
+  l373:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;
   }  yyDo(G, yy_11_Value, G->begin, G->end, "yy_11_Value");
-  goto l366;
-  l365:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;
+  goto l372;
+  l371:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;
   }
-  l366:;	  if (!yy__(G))  goto l364;
-  goto l359;
-  l364:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;  if (!yy_ValueCore(G))  goto l358;
+  l372:;	  if (!yy__(G))  goto l370;
+  goto l365;
+  l370:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yy_ValueCore(G))  goto l364;
 
   }
-  l359:;	  yyprintf((stderr, "  ok   Value"));
+  l365:;	  yyprintf((stderr, "  ok   Value"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
+  l364:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9327,13 +9416,13 @@ YY_RULE(int) yy_Value(GREG *G)
 }
 YY_RULE(int) yy_MATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MATCH_KW"));
-  if (!yymatchString(G, "match")) goto l368;
+  if (!yymatchString(G, "match")) goto l374;
   yyprintf((stderr, "  ok   MATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l368:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
+  l374:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9341,13 +9430,13 @@ YY_RULE(int) yy_MATCH_KW(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_ARROW"));
-  if (!yymatchString(G, "=>")) goto l369;
+  if (!yymatchString(G, "=>")) goto l375;
   yyprintf((stderr, "  ok   DOUBLE_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l369:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
+  l375:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9357,40 +9446,40 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CaseExpr"));
 
-  {  int yypos371= G->pos, yythunkpos371= G->thunkpos;  if (!yy_VariableDecl(G))  goto l372;
+  {  int yypos377= G->pos, yythunkpos377= G->thunkpos;  if (!yy_VariableDecl(G))  goto l378;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l372;
-  goto l371;
-  l372:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yy_BinaryOperation(G))  goto l373;
+  if (!yy__(G))  goto l378;
+  goto l377;
+  l378:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;  if (!yy_BinaryOperation(G))  goto l379;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l373;
+  if (!yy__(G))  goto l379;
 
-  l374:;	
-  {  int yypos375= G->pos, yythunkpos375= G->thunkpos;  if (!yy__(G))  goto l375;
-  if (!yymatchChar(G, '.')) goto l375;
+  l380:;	
+  {  int yypos381= G->pos, yythunkpos381= G->thunkpos;  if (!yy__(G))  goto l381;
+  if (!yymatchChar(G, '.')) goto l381;
   yyDo(G, yy_1_CaseExpr, G->begin, G->end, "yy_1_CaseExpr");
-  if (!yy_WS(G))  goto l375;
-  if (!yy_FunctionCall(G))  goto l375;
+  if (!yy_WS(G))  goto l381;
+  if (!yy_FunctionCall(G))  goto l381;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_CaseExpr, G->begin, G->end, "yy_2_CaseExpr");
-  goto l374;
-  l375:;	  G->pos= yypos375; G->thunkpos= yythunkpos375;
-  }  goto l371;
-  l373:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yy_AnonymousFunctionDecl(G))  goto l376;
-  goto l371;
-  l376:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yymatchChar(G, '(')) goto l370;
-  if (!yy__(G))  goto l370;
-  if (!yy_Expr(G))  goto l370;
-  if (!yy__(G))  goto l370;
-  if (!yymatchChar(G, ')')) goto l370;
+  goto l380;
+  l381:;	  G->pos= yypos381; G->thunkpos= yythunkpos381;
+  }  goto l377;
+  l379:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;  if (!yy_AnonymousFunctionDecl(G))  goto l382;
+  goto l377;
+  l382:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;  if (!yymatchChar(G, '(')) goto l376;
+  if (!yy__(G))  goto l376;
+  if (!yy_Expr(G))  goto l376;
+  if (!yy__(G))  goto l376;
+  if (!yymatchChar(G, ')')) goto l376;
 
   }
-  l371:;	  yyprintf((stderr, "  ok   CaseExpr"));
+  l377:;	  yyprintf((stderr, "  ok   CaseExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l370:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
+  l376:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9398,13 +9487,13 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 }
 YY_RULE(int) yy_CASE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CASE_KW"));
-  if (!yymatchString(G, "case")) goto l377;
+  if (!yymatchString(G, "case")) goto l383;
   yyprintf((stderr, "  ok   CASE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l377:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
+  l383:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9413,35 +9502,35 @@ YY_RULE(int) yy_CASE_KW(GREG *G)
 YY_RULE(int) yy_Case(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Case"));
-  if (!yy_CASE_KW(G))  goto l378;
+  if (!yy_CASE_KW(G))  goto l384;
   yyDo(G, yy_1_Case, G->begin, G->end, "yy_1_Case");
 
-  {  int yypos379= G->pos, yythunkpos379= G->thunkpos;  if (!yy__(G))  goto l379;
-  if (!yy_CaseExpr(G))  goto l379;
+  {  int yypos385= G->pos, yythunkpos385= G->thunkpos;  if (!yy__(G))  goto l385;
+  if (!yy_CaseExpr(G))  goto l385;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Case, G->begin, G->end, "yy_2_Case");
-  goto l380;
-  l379:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;
+  goto l386;
+  l385:;	  G->pos= yypos385; G->thunkpos= yythunkpos385;
   }
-  l380:;	  if (!yy_WS(G))  goto l378;
-  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l378; }
+  l386:;	  if (!yy_WS(G))  goto l384;
+  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l384; }
 
-  l381:;	
-  {  int yypos382= G->pos, yythunkpos382= G->thunkpos;  if (!yy_WS(G))  goto l382;
-  if (!yy_Stmt(G))  goto l382;
+  l387:;	
+  {  int yypos388= G->pos, yythunkpos388= G->thunkpos;  if (!yy_WS(G))  goto l388;
+  if (!yy_Stmt(G))  goto l388;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Case, G->begin, G->end, "yy_3_Case");
-  if (!yy_WS(G))  goto l382;
-  goto l381;
-  l382:;	  G->pos= yypos382; G->thunkpos= yythunkpos382;
-  }  if (!yy_WS(G))  goto l378;
+  if (!yy_WS(G))  goto l388;
+  goto l387;
+  l388:;	  G->pos= yypos388; G->thunkpos= yythunkpos388;
+  }  if (!yy_WS(G))  goto l384;
   yyDo(G, yy_4_Case, G->begin, G->end, "yy_4_Case");
   yyprintf((stderr, "  ok   Case"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l378:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
+  l384:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9449,13 +9538,13 @@ YY_RULE(int) yy_Case(GREG *G)
 }
 YY_RULE(int) yy_ELSE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ELSE_KW"));
-  if (!yymatchString(G, "else")) goto l383;
+  if (!yymatchString(G, "else")) goto l389;
   yyprintf((stderr, "  ok   ELSE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l383:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
+  l389:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9465,30 +9554,30 @@ YY_RULE(int) yy_Body(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Body"));
 
-  {  int yypos385= G->pos, yythunkpos385= G->thunkpos;  if (!yymatchChar(G, '{')) goto l386;
+  {  int yypos391= G->pos, yythunkpos391= G->thunkpos;  if (!yymatchChar(G, '{')) goto l392;
 
-  l387:;	
-  {  int yypos388= G->pos, yythunkpos388= G->thunkpos;  if (!yy_WS(G))  goto l388;
-  if (!yy_Stmt(G))  goto l388;
+  l393:;	
+  {  int yypos394= G->pos, yythunkpos394= G->thunkpos;  if (!yy_WS(G))  goto l394;
+  if (!yy_Stmt(G))  goto l394;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Body, G->begin, G->end, "yy_1_Body");
-  if (!yy_WS(G))  goto l388;
-  goto l387;
-  l388:;	  G->pos= yypos388; G->thunkpos= yythunkpos388;
-  }  if (!yy_WS(G))  goto l386;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l386; }
-  goto l385;
-  l386:;	  G->pos= yypos385; G->thunkpos= yythunkpos385;  if (!yy_Stmt(G))  goto l384;
+  if (!yy_WS(G))  goto l394;
+  goto l393;
+  l394:;	  G->pos= yypos394; G->thunkpos= yythunkpos394;
+  }  if (!yy_WS(G))  goto l392;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l392; }
+  goto l391;
+  l392:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yy_Stmt(G))  goto l390;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Body, G->begin, G->end, "yy_2_Body");
 
   }
-  l385:;	  yyprintf((stderr, "  ok   Body"));
+  l391:;	  yyprintf((stderr, "  ok   Body"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l384:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
+  l390:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9496,13 +9585,13 @@ YY_RULE(int) yy_Body(GREG *G)
 }
 YY_RULE(int) yy_IF_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IF_KW"));
-  if (!yymatchString(G, "if")) goto l389;
+  if (!yymatchString(G, "if")) goto l395;
   yyprintf((stderr, "  ok   IF_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l389:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
+  l395:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9510,18 +9599,18 @@ YY_RULE(int) yy_IF_KW(GREG *G)
 }
 YY_RULE(int) yy_Else(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Else"));
-  if (!yy_ELSE_KW(G))  goto l390;
+  if (!yy_ELSE_KW(G))  goto l396;
   yyDo(G, yy_1_Else, G->begin, G->end, "yy_1_Else");
   yyDo(G, yy_2_Else, G->begin, G->end, "yy_2_Else");
-  if (!yy__(G))  goto l390;
-  if (!yy_Body(G))  goto l390;
+  if (!yy__(G))  goto l396;
+  if (!yy_Body(G))  goto l396;
   yyDo(G, yy_3_Else, G->begin, G->end, "yy_3_Else");
   yyprintf((stderr, "  ok   Else"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l390:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
+  l396:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9530,26 +9619,26 @@ YY_RULE(int) yy_Else(GREG *G)
 YY_RULE(int) yy_If(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "If"));
-  if (!yy_IF_KW(G))  goto l391;
+  if (!yy_IF_KW(G))  goto l397;
   yyDo(G, yy_1_If, G->begin, G->end, "yy_1_If");
-  if (!yy_WS(G))  goto l391;
-  if (!yymatchChar(G, '(')) goto l391;
-  if (!yy_WS(G))  goto l391;
-  if (!yy__(G))  goto l391;
-  if (!yy_Expr(G))  goto l391;
+  if (!yy_WS(G))  goto l397;
+  if (!yymatchChar(G, '(')) goto l397;
+  if (!yy_WS(G))  goto l397;
+  if (!yy__(G))  goto l397;
+  if (!yy_Expr(G))  goto l397;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_If, G->begin, G->end, "yy_2_If");
-  if (!yy_WS(G))  goto l391;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l391; }
-  if (!yy__(G))  goto l391;
-  if (!yy_Body(G))  goto l391;
+  if (!yy_WS(G))  goto l397;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l397; }
+  if (!yy__(G))  goto l397;
+  if (!yy_Body(G))  goto l397;
   yyDo(G, yy_3_If, G->begin, G->end, "yy_3_If");
   yyprintf((stderr, "  ok   If"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l391:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
+  l397:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9559,31 +9648,31 @@ YY_RULE(int) yy_Return(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Return"));
 
-  {  int yypos393= G->pos, yythunkpos393= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l394;
+  {  int yypos399= G->pos, yythunkpos399= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l400;
 
-  {  int yypos395= G->pos, yythunkpos395= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l394;
-  G->pos= yypos395; G->thunkpos= yythunkpos395;
+  {  int yypos401= G->pos, yythunkpos401= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l400;
+  G->pos= yypos401; G->thunkpos= yythunkpos401;
   }  yyDo(G, yy_1_Return, G->begin, G->end, "yy_1_Return");
-  if (!yy__(G))  goto l394;
-  if (!yy_Expr(G))  goto l394;
+  if (!yy__(G))  goto l400;
+  if (!yy_Expr(G))  goto l400;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Return, G->begin, G->end, "yy_2_Return");
-  goto l393;
-  l394:;	  G->pos= yypos393; G->thunkpos= yythunkpos393;  if (!yy_RETURN_KW(G))  goto l392;
+  goto l399;
+  l400:;	  G->pos= yypos399; G->thunkpos= yythunkpos399;  if (!yy_RETURN_KW(G))  goto l398;
 
-  {  int yypos396= G->pos, yythunkpos396= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l392;
-  G->pos= yypos396; G->thunkpos= yythunkpos396;
+  {  int yypos402= G->pos, yythunkpos402= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l398;
+  G->pos= yypos402; G->thunkpos= yythunkpos402;
   }  yyDo(G, yy_3_Return, G->begin, G->end, "yy_3_Return");
-  if (!yy__(G))  goto l392;
+  if (!yy__(G))  goto l398;
   yyDo(G, yy_4_Return, G->begin, G->end, "yy_4_Return");
 
   }
-  l393:;	  yyprintf((stderr, "  ok   Return"));
+  l399:;	  yyprintf((stderr, "  ok   Return"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l392:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
+  l398:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9591,24 +9680,24 @@ YY_RULE(int) yy_Return(GREG *G)
 }
 YY_RULE(int) yy_Try(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Try"));
-  if (!yy_TRY_KW(G))  goto l397;
+  if (!yy_TRY_KW(G))  goto l403;
   yyDo(G, yy_1_Try, G->begin, G->end, "yy_1_Try");
-  if (!yy__(G))  goto l397;
-  if (!yy_Body(G))  goto l397;
+  if (!yy__(G))  goto l403;
+  if (!yy_Body(G))  goto l403;
 
-  l398:;	
-  {  int yypos399= G->pos, yythunkpos399= G->thunkpos;  if (!yy_WS(G))  goto l399;
-  if (!yy_Catch(G))  goto l399;
-  if (!yy_WS(G))  goto l399;
-  goto l398;
-  l399:;	  G->pos= yypos399; G->thunkpos= yythunkpos399;
+  l404:;	
+  {  int yypos405= G->pos, yythunkpos405= G->thunkpos;  if (!yy_WS(G))  goto l405;
+  if (!yy_Catch(G))  goto l405;
+  if (!yy_WS(G))  goto l405;
+  goto l404;
+  l405:;	  G->pos= yypos405; G->thunkpos= yythunkpos405;
   }  yyDo(G, yy_2_Try, G->begin, G->end, "yy_2_Try");
   yyprintf((stderr, "  ok   Try"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l397:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
+  l403:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9617,34 +9706,34 @@ YY_RULE(int) yy_Try(GREG *G)
 YY_RULE(int) yy_Match(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Match"));
-  if (!yy_MATCH_KW(G))  goto l400;
+  if (!yy_MATCH_KW(G))  goto l406;
   yyDo(G, yy_1_Match, G->begin, G->end, "yy_1_Match");
 
-  {  int yypos401= G->pos, yythunkpos401= G->thunkpos;  if (!yy__(G))  goto l401;
-  if (!yy_Value(G))  goto l401;
+  {  int yypos407= G->pos, yythunkpos407= G->thunkpos;  if (!yy__(G))  goto l407;
+  if (!yy_Value(G))  goto l407;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Match, G->begin, G->end, "yy_2_Match");
-  goto l402;
-  l401:;	  G->pos= yypos401; G->thunkpos= yythunkpos401;
+  goto l408;
+  l407:;	  G->pos= yypos407; G->thunkpos= yythunkpos407;
   }
-  l402:;	  if (!yy_WS(G))  goto l400;
-  if (!yymatchChar(G, '{')) goto l400;
+  l408:;	  if (!yy_WS(G))  goto l406;
+  if (!yymatchChar(G, '{')) goto l406;
 
-  l403:;	
-  {  int yypos404= G->pos, yythunkpos404= G->thunkpos;  if (!yy_WS(G))  goto l404;
-  if (!yy_Case(G))  goto l404;
-  if (!yy_WS(G))  goto l404;
-  goto l403;
-  l404:;	  G->pos= yypos404; G->thunkpos= yythunkpos404;
-  }  if (!yy_WS(G))  goto l400;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l400; }
+  l409:;	
+  {  int yypos410= G->pos, yythunkpos410= G->thunkpos;  if (!yy_WS(G))  goto l410;
+  if (!yy_Case(G))  goto l410;
+  if (!yy_WS(G))  goto l410;
+  goto l409;
+  l410:;	  G->pos= yypos410; G->thunkpos= yythunkpos410;
+  }  if (!yy_WS(G))  goto l406;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l406; }
   yyDo(G, yy_3_Match, G->begin, G->end, "yy_3_Match");
   yyprintf((stderr, "  ok   Match"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l400:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
+  l406:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9653,21 +9742,21 @@ YY_RULE(int) yy_Match(GREG *G)
 YY_RULE(int) yy_FlowControl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FlowControl"));
 
-  {  int yypos406= G->pos, yythunkpos406= G->thunkpos;  if (!yy_Foreach(G))  goto l407;
-  goto l406;
-  l407:;	  G->pos= yypos406; G->thunkpos= yythunkpos406;  if (!yy_While(G))  goto l408;
-  goto l406;
-  l408:;	  G->pos= yypos406; G->thunkpos= yythunkpos406;  if (!yy_Break(G))  goto l409;
-  goto l406;
-  l409:;	  G->pos= yypos406; G->thunkpos= yythunkpos406;  if (!yy_Continue(G))  goto l405;
+  {  int yypos412= G->pos, yythunkpos412= G->thunkpos;  if (!yy_Foreach(G))  goto l413;
+  goto l412;
+  l413:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;  if (!yy_While(G))  goto l414;
+  goto l412;
+  l414:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;  if (!yy_Break(G))  goto l415;
+  goto l412;
+  l415:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;  if (!yy_Continue(G))  goto l411;
 
   }
-  l406:;	  yyprintf((stderr, "  ok   FlowControl"));
+  l412:;	  yyprintf((stderr, "  ok   FlowControl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l405:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
+  l411:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9676,26 +9765,26 @@ YY_RULE(int) yy_FlowControl(GREG *G)
 YY_RULE(int) yy_Block(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Block"));
-  if (!yymatchChar(G, '{')) goto l410;
+  if (!yymatchChar(G, '{')) goto l416;
   yyDo(G, yy_1_Block, G->begin, G->end, "yy_1_Block");
 
-  l411:;	
-  {  int yypos412= G->pos, yythunkpos412= G->thunkpos;  if (!yy_WS(G))  goto l412;
-  if (!yy_Stmt(G))  goto l412;
+  l417:;	
+  {  int yypos418= G->pos, yythunkpos418= G->thunkpos;  if (!yy_WS(G))  goto l418;
+  if (!yy_Stmt(G))  goto l418;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Block, G->begin, G->end, "yy_2_Block");
-  if (!yy_WS(G))  goto l412;
-  goto l411;
-  l412:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;
-  }  if (!yy_WS(G))  goto l410;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l410; }
+  if (!yy_WS(G))  goto l418;
+  goto l417;
+  l418:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;
+  }  if (!yy_WS(G))  goto l416;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l416; }
   yyDo(G, yy_3_Block, G->begin, G->end, "yy_3_Block");
   yyprintf((stderr, "  ok   Block"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l410:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
+  l416:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9704,22 +9793,22 @@ YY_RULE(int) yy_Block(GREG *G)
 YY_RULE(int) yy_Conditional(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Conditional"));
-  if (!yy_If(G))  goto l413;
+  if (!yy_If(G))  goto l419;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos414= G->pos, yythunkpos414= G->thunkpos;  if (!yy_WS(G))  goto l414;
-  if (!yy_Else(G))  goto l414;
+  {  int yypos420= G->pos, yythunkpos420= G->thunkpos;  if (!yy_WS(G))  goto l420;
+  if (!yy_Else(G))  goto l420;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Conditional, G->begin, G->end, "yy_1_Conditional");
-  goto l415;
-  l414:;	  G->pos= yypos414; G->thunkpos= yythunkpos414;
+  goto l421;
+  l420:;	  G->pos= yypos420; G->thunkpos= yythunkpos420;
   }
-  l415:;	  yyprintf((stderr, "  ok   Conditional"));
+  l421:;	  yyprintf((stderr, "  ok   Conditional"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l413:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
+  l419:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9727,22 +9816,22 @@ YY_RULE(int) yy_Conditional(GREG *G)
 }
 YY_RULE(int) yy_CommentLine(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CommentLine"));
-  if (!yymatchString(G, "//")) goto l416;
+  if (!yymatchString(G, "//")) goto l422;
 
-  l417:;	
-  {  int yypos418= G->pos, yythunkpos418= G->thunkpos;
-  {  int yypos419= G->pos, yythunkpos419= G->thunkpos;  if (!yy_EOL(G))  goto l419;
-  goto l418;
-  l419:;	  G->pos= yypos419; G->thunkpos= yythunkpos419;
-  }  if (!yymatchDot(G)) goto l418;  goto l417;
-  l418:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;
-  }  if (!yy_EOL(G))  goto l416;
+  l423:;	
+  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;
+  {  int yypos425= G->pos, yythunkpos425= G->thunkpos;  if (!yy_EOL(G))  goto l425;
+  goto l424;
+  l425:;	  G->pos= yypos425; G->thunkpos= yythunkpos425;
+  }  if (!yymatchDot(G)) goto l424;  goto l423;
+  l424:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;
+  }  if (!yy_EOL(G))  goto l422;
   yyprintf((stderr, "  ok   CommentLine"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l416:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CommentLine"));
+  l422:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CommentLine"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9751,22 +9840,22 @@ YY_RULE(int) yy_CommentLine(GREG *G)
 YY_RULE(int) yy_EoledStatement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EoledStatement"));
 
-  {  int yypos421= G->pos, yythunkpos421= G->thunkpos;  if (!yy_WS(G))  goto l422;
-  if (!yy_Return(G))  goto l422;
-  goto l421;
-  l422:;	  G->pos= yypos421; G->thunkpos= yythunkpos421;  if (!yy_WS(G))  goto l423;
-  if (!yy_VariableDecl(G))  goto l423;
-  goto l421;
-  l423:;	  G->pos= yypos421; G->thunkpos= yythunkpos421;  if (!yy_WS(G))  goto l420;
-  if (!yy_Expr(G))  goto l420;
+  {  int yypos427= G->pos, yythunkpos427= G->thunkpos;  if (!yy_WS(G))  goto l428;
+  if (!yy_Return(G))  goto l428;
+  goto l427;
+  l428:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l429;
+  if (!yy_VariableDecl(G))  goto l429;
+  goto l427;
+  l429:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l426;
+  if (!yy_Expr(G))  goto l426;
 
   }
-  l421:;	  yyprintf((stderr, "  ok   EoledStatement"));
+  l427:;	  yyprintf((stderr, "  ok   EoledStatement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l420:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EoledStatement"));
+  l426:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EoledStatement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9776,72 +9865,72 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "StmtCore"));
 
-  {  int yypos425= G->pos, yythunkpos425= G->thunkpos;  if (!yy_EoledStatement(G))  goto l426;
+  {  int yypos431= G->pos, yythunkpos431= G->thunkpos;  if (!yy_EoledStatement(G))  goto l432;
   yyDo(G, yySet, 0, 0, "yySet");
 
-  {  int yypos427= G->pos, yythunkpos427= G->thunkpos;  if (!yy_Terminator(G))  goto l428;
+  {  int yypos433= G->pos, yythunkpos433= G->thunkpos;  if (!yy_Terminator(G))  goto l434;
 
-  l429:;	
-  {  int yypos430= G->pos, yythunkpos430= G->thunkpos;  if (!yy_Terminator(G))  goto l430;
-  goto l429;
-  l430:;	  G->pos= yypos430; G->thunkpos= yythunkpos430;
-  }  goto l427;
-  l428:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l431;
+  l435:;	
+  {  int yypos436= G->pos, yythunkpos436= G->thunkpos;  if (!yy_Terminator(G))  goto l436;
+  goto l435;
+  l436:;	  G->pos= yypos436; G->thunkpos= yythunkpos436;
+  }  goto l433;
+  l434:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;  if (!yy_WS(G))  goto l437;
 
-  {  int yypos432= G->pos, yythunkpos432= G->thunkpos;  if (!yymatchChar(G, '}')) goto l431;
-  G->pos= yypos432; G->thunkpos= yythunkpos432;
-  }  goto l427;
-  l431:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l433;
+  {  int yypos438= G->pos, yythunkpos438= G->thunkpos;  if (!yymatchChar(G, '}')) goto l437;
+  G->pos= yypos438; G->thunkpos= yythunkpos438;
+  }  goto l433;
+  l437:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;  if (!yy_WS(G))  goto l439;
 
-  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;  if (!yymatchChar(G, ')')) goto l433;
-  G->pos= yypos434; G->thunkpos= yythunkpos434;
-  }  goto l427;
-  l433:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l435;
+  {  int yypos440= G->pos, yythunkpos440= G->thunkpos;  if (!yymatchChar(G, ')')) goto l439;
+  G->pos= yypos440; G->thunkpos= yythunkpos440;
+  }  goto l433;
+  l439:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;  if (!yy_WS(G))  goto l441;
 
-  {  int yypos436= G->pos, yythunkpos436= G->thunkpos;  if (!yymatchChar(G, ',')) goto l435;
-  G->pos= yypos436; G->thunkpos= yythunkpos436;
-  }  goto l427;
-  l435:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;
-  {  int yypos437= G->pos, yythunkpos437= G->thunkpos;  if (!yy_CommentLine(G))  goto l426;
-  G->pos= yypos437; G->thunkpos= yythunkpos437;
+  {  int yypos442= G->pos, yythunkpos442= G->thunkpos;  if (!yymatchChar(G, ',')) goto l441;
+  G->pos= yypos442; G->thunkpos= yythunkpos442;
+  }  goto l433;
+  l441:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;
+  {  int yypos443= G->pos, yythunkpos443= G->thunkpos;  if (!yy_CommentLine(G))  goto l432;
+  G->pos= yypos443; G->thunkpos= yythunkpos443;
   }
   }
-  l427:;	  goto l425;
-  l426:;	  G->pos= yypos425; G->thunkpos= yythunkpos425;
-  {  int yypos438= G->pos, yythunkpos438= G->thunkpos;  if (!yy_WS(G))  goto l439;
-  if (!yy_Conditional(G))  goto l439;
+  l433:;	  goto l431;
+  l432:;	  G->pos= yypos431; G->thunkpos= yythunkpos431;
+  {  int yypos444= G->pos, yythunkpos444= G->thunkpos;  if (!yy_WS(G))  goto l445;
+  if (!yy_Conditional(G))  goto l445;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l438;
-  l439:;	  G->pos= yypos438; G->thunkpos= yythunkpos438;  if (!yy_WS(G))  goto l440;
-  if (!yy_Block(G))  goto l440;
+  goto l444;
+  l445:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l446;
+  if (!yy_Block(G))  goto l446;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l438;
-  l440:;	  G->pos= yypos438; G->thunkpos= yythunkpos438;  if (!yy_WS(G))  goto l441;
-  if (!yy_FlowControl(G))  goto l441;
+  goto l444;
+  l446:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l447;
+  if (!yy_FlowControl(G))  goto l447;
   yyDo(G, yySet, 0, 0, "yySet");
 
-  l442:;	
-  {  int yypos443= G->pos, yythunkpos443= G->thunkpos;  if (!yy_Terminator(G))  goto l443;
-  goto l442;
-  l443:;	  G->pos= yypos443; G->thunkpos= yythunkpos443;
-  }  goto l438;
-  l441:;	  G->pos= yypos438; G->thunkpos= yythunkpos438;  if (!yy_WS(G))  goto l444;
-  if (!yy_Match(G))  goto l444;
+  l448:;	
+  {  int yypos449= G->pos, yythunkpos449= G->thunkpos;  if (!yy_Terminator(G))  goto l449;
+  goto l448;
+  l449:;	  G->pos= yypos449; G->thunkpos= yythunkpos449;
+  }  goto l444;
+  l447:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l450;
+  if (!yy_Match(G))  goto l450;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l438;
-  l444:;	  G->pos= yypos438; G->thunkpos= yythunkpos438;  if (!yy_WS(G))  goto l424;
-  if (!yy_Try(G))  goto l424;
+  goto l444;
+  l450:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l430;
+  if (!yy_Try(G))  goto l430;
   yyDo(G, yySet, 0, 0, "yySet");
 
   }
-  l438:;	
+  l444:;	
   }
-  l425:;	  yyprintf((stderr, "  ok   StmtCore"));
+  l431:;	  yyprintf((stderr, "  ok   StmtCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l424:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "StmtCore"));
+  l430:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "StmtCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9849,17 +9938,17 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 }
 YY_RULE(int) yy_FuncTypeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FuncTypeCore"));
-  if (!yymatchString(G, "Func")) goto l445;
+  if (!yymatchString(G, "Func")) goto l451;
 
-  {  int yypos446= G->pos, yythunkpos446= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l445;
-  G->pos= yypos446; G->thunkpos= yythunkpos446;
+  {  int yypos452= G->pos, yythunkpos452= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l451;
+  G->pos= yypos452; G->thunkpos= yythunkpos452;
   }  yyDo(G, yy_1_FuncTypeCore, G->begin, G->end, "yy_1_FuncTypeCore");
   yyprintf((stderr, "  ok   FuncTypeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l445:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
+  l451:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9873,7 +9962,7 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l447:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
+  l453:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9882,32 +9971,32 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
 YY_RULE(int) yy_TypeList(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeList"));
-  if (!yymatchChar(G, '(')) goto l448;
-  if (!yy_WS(G))  goto l448;
-  if (!yy_TypeListCore(G))  goto l448;
+  if (!yymatchChar(G, '(')) goto l454;
+  if (!yy_WS(G))  goto l454;
+  if (!yy_TypeListCore(G))  goto l454;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_Type(G))  goto l448;
+  if (!yy_Type(G))  goto l454;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_TypeList, G->begin, G->end, "yy_1_TypeList");
 
-  l449:;	
-  {  int yypos450= G->pos, yythunkpos450= G->thunkpos;  if (!yy_WS(G))  goto l450;
-  if (!yymatchChar(G, ',')) goto l450;
-  if (!yy_WS(G))  goto l450;
-  if (!yy_Type(G))  goto l450;
+  l455:;	
+  {  int yypos456= G->pos, yythunkpos456= G->thunkpos;  if (!yy_WS(G))  goto l456;
+  if (!yymatchChar(G, ',')) goto l456;
+  if (!yy_WS(G))  goto l456;
+  if (!yy_Type(G))  goto l456;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_TypeList, G->begin, G->end, "yy_2_TypeList");
-  goto l449;
-  l450:;	  G->pos= yypos450; G->thunkpos= yythunkpos450;
-  }  if (!yymatchChar(G, ')')) goto l448;
-  if (!yy__(G))  goto l448;
+  goto l455;
+  l456:;	  G->pos= yypos456; G->thunkpos= yythunkpos456;
+  }  if (!yymatchChar(G, ')')) goto l454;
+  if (!yy__(G))  goto l454;
   yyDo(G, yy_3_TypeList, G->begin, G->end, "yy_3_TypeList");
   yyprintf((stderr, "  ok   TypeList"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l448:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
+  l454:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9921,7 +10010,7 @@ YY_RULE(int) yy_Old(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l451:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
+  l457:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9931,123 +10020,123 @@ YY_RULE(int) yy_GenericType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericType"));
 
-  {  int yypos453= G->pos, yythunkpos453= G->thunkpos;  if (!yy_Old(G))  goto l454;
+  {  int yypos459= G->pos, yythunkpos459= G->thunkpos;  if (!yy_Old(G))  goto l460;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l454;
-  if (!yy_IDENT(G))  goto l454;
+  if (!yy__(G))  goto l460;
+  if (!yy_IDENT(G))  goto l460;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_GenericType, G->begin, G->end, "yy_1_GenericType");
-  if (!yy__(G))  goto l454;
-  if (!yy_TypeBase(G))  goto l454;
+  if (!yy__(G))  goto l460;
+  if (!yy_TypeBase(G))  goto l460;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos455= G->pos, yythunkpos455= G->thunkpos;  if (!yy_FuncType(G))  goto l455;
-  goto l454;
-  l455:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;
+  {  int yypos461= G->pos, yythunkpos461= G->thunkpos;  if (!yy_FuncType(G))  goto l461;
+  goto l460;
+  l461:;	  G->pos= yypos461; G->thunkpos= yythunkpos461;
   }  yyDo(G, yy_2_GenericType, G->begin, G->end, "yy_2_GenericType");
-  if (!yy__(G))  goto l454;
-  if (!yymatchChar(G, '<')) goto l454;
-  if (!yy__(G))  goto l454;
-  if (!yy_Type(G))  goto l454;
+  if (!yy__(G))  goto l460;
+  if (!yymatchChar(G, '<')) goto l460;
+  if (!yy__(G))  goto l460;
+  if (!yy_Type(G))  goto l460;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_GenericType, G->begin, G->end, "yy_3_GenericType");
 
-  l456:;	
-  {  int yypos457= G->pos, yythunkpos457= G->thunkpos;  if (!yy__(G))  goto l457;
-  if (!yymatchChar(G, ',')) goto l457;
-  if (!yy__(G))  goto l457;
-  if (!yy_Type(G))  goto l457;
+  l462:;	
+  {  int yypos463= G->pos, yythunkpos463= G->thunkpos;  if (!yy__(G))  goto l463;
+  if (!yymatchChar(G, ',')) goto l463;
+  if (!yy__(G))  goto l463;
+  if (!yy_Type(G))  goto l463;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_GenericType, G->begin, G->end, "yy_4_GenericType");
-  goto l456;
-  l457:;	  G->pos= yypos457; G->thunkpos= yythunkpos457;
-  }  if (!yy__(G))  goto l454;
-  if (!yymatchChar(G, '>')) goto l454;
-  if (!yy__(G))  goto l454;
-
-  l458:;	
-  {  int yypos459= G->pos, yythunkpos459= G->thunkpos;
-  {  int yypos460= G->pos, yythunkpos460= G->thunkpos;  if (!yymatchChar(G, '*')) goto l461;
-  yyDo(G, yy_5_GenericType, G->begin, G->end, "yy_5_GenericType");
-  goto l460;
-  l461:;	  G->pos= yypos460; G->thunkpos= yythunkpos460;  if (!yymatchChar(G, '@')) goto l462;
-  yyDo(G, yy_6_GenericType, G->begin, G->end, "yy_6_GenericType");
-  goto l460;
-  l462:;	  G->pos= yypos460; G->thunkpos= yythunkpos460;  if (!yymatchChar(G, '[')) goto l459;
-  if (!yy_WS(G))  goto l459;
-  yyDo(G, yy_7_GenericType, G->begin, G->end, "yy_7_GenericType");
-  if (!yy__(G))  goto l459;
-
-  {  int yypos463= G->pos, yythunkpos463= G->thunkpos;  if (!yy_Expr(G))  goto l463;
-  yyDo(G, yySet, -1, 0, "yySet");
-  goto l464;
+  goto l462;
   l463:;	  G->pos= yypos463; G->thunkpos= yythunkpos463;
+  }  if (!yy__(G))  goto l460;
+  if (!yymatchChar(G, '>')) goto l460;
+  if (!yy__(G))  goto l460;
+
+  l464:;	
+  {  int yypos465= G->pos, yythunkpos465= G->thunkpos;
+  {  int yypos466= G->pos, yythunkpos466= G->thunkpos;  if (!yymatchChar(G, '*')) goto l467;
+  yyDo(G, yy_5_GenericType, G->begin, G->end, "yy_5_GenericType");
+  goto l466;
+  l467:;	  G->pos= yypos466; G->thunkpos= yythunkpos466;  if (!yymatchChar(G, '@')) goto l468;
+  yyDo(G, yy_6_GenericType, G->begin, G->end, "yy_6_GenericType");
+  goto l466;
+  l468:;	  G->pos= yypos466; G->thunkpos= yythunkpos466;  if (!yymatchChar(G, '[')) goto l465;
+  if (!yy_WS(G))  goto l465;
+  yyDo(G, yy_7_GenericType, G->begin, G->end, "yy_7_GenericType");
+  if (!yy__(G))  goto l465;
+
+  {  int yypos469= G->pos, yythunkpos469= G->thunkpos;  if (!yy_Expr(G))  goto l469;
+  yyDo(G, yySet, -1, 0, "yySet");
+  goto l470;
+  l469:;	  G->pos= yypos469; G->thunkpos= yythunkpos469;
   }
-  l464:;	  if (!yymatchChar(G, ']')) goto l459;
+  l470:;	  if (!yymatchChar(G, ']')) goto l465;
   yyDo(G, yy_8_GenericType, G->begin, G->end, "yy_8_GenericType");
 
   }
-  l460:;	  goto l458;
-  l459:;	  G->pos= yypos459; G->thunkpos= yythunkpos459;
-  }  if (!yy__(G))  goto l454;
+  l466:;	  goto l464;
+  l465:;	  G->pos= yypos465; G->thunkpos= yythunkpos465;
+  }  if (!yy__(G))  goto l460;
   yyDo(G, yy_9_GenericType, G->begin, G->end, "yy_9_GenericType");
-  goto l453;
-  l454:;	  G->pos= yypos453; G->thunkpos= yythunkpos453;  if (!yy_TypeBase(G))  goto l452;
+  goto l459;
+  l460:;	  G->pos= yypos459; G->thunkpos= yythunkpos459;  if (!yy_TypeBase(G))  goto l458;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l452;
-  if (!yymatchChar(G, '<')) goto l452;
-  if (!yy__(G))  goto l452;
-  if (!yy_Type(G))  goto l452;
+  if (!yy__(G))  goto l458;
+  if (!yymatchChar(G, '<')) goto l458;
+  if (!yy__(G))  goto l458;
+  if (!yy_Type(G))  goto l458;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_10_GenericType, G->begin, G->end, "yy_10_GenericType");
 
-  l465:;	
-  {  int yypos466= G->pos, yythunkpos466= G->thunkpos;  if (!yy__(G))  goto l466;
-  if (!yymatchChar(G, ',')) goto l466;
-  if (!yy__(G))  goto l466;
-  if (!yy_Type(G))  goto l466;
+  l471:;	
+  {  int yypos472= G->pos, yythunkpos472= G->thunkpos;  if (!yy__(G))  goto l472;
+  if (!yymatchChar(G, ',')) goto l472;
+  if (!yy__(G))  goto l472;
+  if (!yy_Type(G))  goto l472;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_11_GenericType, G->begin, G->end, "yy_11_GenericType");
-  goto l465;
-  l466:;	  G->pos= yypos466; G->thunkpos= yythunkpos466;
-  }  if (!yy__(G))  goto l452;
-  if (!yymatchChar(G, '>')) goto l452;
-  if (!yy__(G))  goto l452;
-
-  l467:;	
-  {  int yypos468= G->pos, yythunkpos468= G->thunkpos;
-  {  int yypos469= G->pos, yythunkpos469= G->thunkpos;  if (!yymatchChar(G, '*')) goto l470;
-  yyDo(G, yy_12_GenericType, G->begin, G->end, "yy_12_GenericType");
-  goto l469;
-  l470:;	  G->pos= yypos469; G->thunkpos= yythunkpos469;  if (!yymatchChar(G, '@')) goto l471;
-  yyDo(G, yy_13_GenericType, G->begin, G->end, "yy_13_GenericType");
-  goto l469;
-  l471:;	  G->pos= yypos469; G->thunkpos= yythunkpos469;  if (!yymatchChar(G, '[')) goto l468;
-  if (!yy_WS(G))  goto l468;
-  yyDo(G, yy_14_GenericType, G->begin, G->end, "yy_14_GenericType");
-  if (!yy__(G))  goto l468;
-
-  {  int yypos472= G->pos, yythunkpos472= G->thunkpos;  if (!yy_Expr(G))  goto l472;
-  yyDo(G, yySet, -1, 0, "yySet");
-  goto l473;
+  goto l471;
   l472:;	  G->pos= yypos472; G->thunkpos= yythunkpos472;
+  }  if (!yy__(G))  goto l458;
+  if (!yymatchChar(G, '>')) goto l458;
+  if (!yy__(G))  goto l458;
+
+  l473:;	
+  {  int yypos474= G->pos, yythunkpos474= G->thunkpos;
+  {  int yypos475= G->pos, yythunkpos475= G->thunkpos;  if (!yymatchChar(G, '*')) goto l476;
+  yyDo(G, yy_12_GenericType, G->begin, G->end, "yy_12_GenericType");
+  goto l475;
+  l476:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;  if (!yymatchChar(G, '@')) goto l477;
+  yyDo(G, yy_13_GenericType, G->begin, G->end, "yy_13_GenericType");
+  goto l475;
+  l477:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;  if (!yymatchChar(G, '[')) goto l474;
+  if (!yy_WS(G))  goto l474;
+  yyDo(G, yy_14_GenericType, G->begin, G->end, "yy_14_GenericType");
+  if (!yy__(G))  goto l474;
+
+  {  int yypos478= G->pos, yythunkpos478= G->thunkpos;  if (!yy_Expr(G))  goto l478;
+  yyDo(G, yySet, -1, 0, "yySet");
+  goto l479;
+  l478:;	  G->pos= yypos478; G->thunkpos= yythunkpos478;
   }
-  l473:;	  if (!yymatchChar(G, ']')) goto l468;
+  l479:;	  if (!yymatchChar(G, ']')) goto l474;
   yyDo(G, yy_15_GenericType, G->begin, G->end, "yy_15_GenericType");
 
   }
-  l469:;	  goto l467;
-  l468:;	  G->pos= yypos468; G->thunkpos= yythunkpos468;
-  }  if (!yy__(G))  goto l452;
+  l475:;	  goto l473;
+  l474:;	  G->pos= yypos474; G->thunkpos= yythunkpos474;
+  }  if (!yy__(G))  goto l458;
   yyDo(G, yy_16_GenericType, G->begin, G->end, "yy_16_GenericType");
 
   }
-  l453:;	  yyprintf((stderr, "  ok   GenericType"));
+  l459:;	  yyprintf((stderr, "  ok   GenericType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l452:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
+  l458:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10056,79 +10145,79 @@ YY_RULE(int) yy_GenericType(GREG *G)
 YY_RULE(int) yy_FuncType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FuncType"));
-  if (!yy_FuncTypeCore(G))  goto l474;
+  if (!yy_FuncTypeCore(G))  goto l480;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos475= G->pos, yythunkpos475= G->thunkpos;  if (!yy__(G))  goto l475;
-  if (!yymatchChar(G, '<')) goto l475;
-  if (!yy__(G))  goto l475;
-  if (!yy_IDENT(G))  goto l475;
+  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy__(G))  goto l481;
+  if (!yymatchChar(G, '<')) goto l481;
+  if (!yy__(G))  goto l481;
+  if (!yy_IDENT(G))  goto l481;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_FuncType, G->begin, G->end, "yy_1_FuncType");
 
-  l477:;	
-  {  int yypos478= G->pos, yythunkpos478= G->thunkpos;  if (!yy__(G))  goto l478;
-  if (!yymatchChar(G, ',')) goto l478;
-  if (!yy__(G))  goto l478;
-  if (!yy_IDENT(G))  goto l478;
+  l483:;	
+  {  int yypos484= G->pos, yythunkpos484= G->thunkpos;  if (!yy__(G))  goto l484;
+  if (!yymatchChar(G, ',')) goto l484;
+  if (!yy__(G))  goto l484;
+  if (!yy_IDENT(G))  goto l484;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_FuncType, G->begin, G->end, "yy_2_FuncType");
-  goto l477;
-  l478:;	  G->pos= yypos478; G->thunkpos= yythunkpos478;
-  }  if (!yy__(G))  goto l475;
-  if (!yymatchChar(G, '>')) goto l475;
-  goto l476;
-  l475:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;
-  }
-  l476:;	
-  {  int yypos479= G->pos, yythunkpos479= G->thunkpos;  if (!yy__(G))  goto l479;
-  if (!yymatchChar(G, '(')) goto l479;
-
-  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy__(G))  goto l481;
-  if (!yy_Type(G))  goto l481;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
-
-  l483:;	
-  {  int yypos484= G->pos, yythunkpos484= G->thunkpos;  if (!yymatchChar(G, ',')) goto l484;
-  if (!yy__(G))  goto l484;
-  if (!yy_Type(G))  goto l484;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
   goto l483;
   l484:;	  G->pos= yypos484; G->thunkpos= yythunkpos484;
-  }  goto l482;
+  }  if (!yy__(G))  goto l481;
+  if (!yymatchChar(G, '>')) goto l481;
+  goto l482;
   l481:;	  G->pos= yypos481; G->thunkpos= yythunkpos481;
   }
   l482:;	
-  {  int yypos485= G->pos, yythunkpos485= G->thunkpos;  if (!yymatchString(G, "...")) goto l485;
-  if (!yy__(G))  goto l485;
+  {  int yypos485= G->pos, yythunkpos485= G->thunkpos;  if (!yy__(G))  goto l485;
+  if (!yymatchChar(G, '(')) goto l485;
+
+  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yy__(G))  goto l487;
+  if (!yy_Type(G))  goto l487;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
+
+  l489:;	
+  {  int yypos490= G->pos, yythunkpos490= G->thunkpos;  if (!yymatchChar(G, ',')) goto l490;
+  if (!yy__(G))  goto l490;
+  if (!yy_Type(G))  goto l490;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
+  goto l489;
+  l490:;	  G->pos= yypos490; G->thunkpos= yythunkpos490;
+  }  goto l488;
+  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
+  }
+  l488:;	
+  {  int yypos491= G->pos, yythunkpos491= G->thunkpos;  if (!yymatchString(G, "...")) goto l491;
+  if (!yy__(G))  goto l491;
   yyDo(G, yy_5_FuncType, G->begin, G->end, "yy_5_FuncType");
+  goto l492;
+  l491:;	  G->pos= yypos491; G->thunkpos= yythunkpos491;
+  }
+  l492:;	  if (!yy__(G))  goto l485;
+  if (!yymatchChar(G, ')')) goto l485;
   goto l486;
   l485:;	  G->pos= yypos485; G->thunkpos= yythunkpos485;
   }
-  l486:;	  if (!yy__(G))  goto l479;
-  if (!yymatchChar(G, ')')) goto l479;
-  goto l480;
-  l479:;	  G->pos= yypos479; G->thunkpos= yythunkpos479;
-  }
-  l480:;	
-  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yy__(G))  goto l487;
-  if (!yymatchString(G, "->")) goto l487;
-  if (!yy__(G))  goto l487;
-  if (!yy_Type(G))  goto l487;
+  l486:;	
+  {  int yypos493= G->pos, yythunkpos493= G->thunkpos;  if (!yy__(G))  goto l493;
+  if (!yymatchString(G, "->")) goto l493;
+  if (!yy__(G))  goto l493;
+  if (!yy_Type(G))  goto l493;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FuncType, G->begin, G->end, "yy_6_FuncType");
-  goto l488;
-  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
+  goto l494;
+  l493:;	  G->pos= yypos493; G->thunkpos= yythunkpos493;
   }
-  l488:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
+  l494:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
   yyprintf((stderr, "  ok   FuncType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l474:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
+  l480:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10138,65 +10227,65 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeBase"));
 
-  {  int yypos490= G->pos, yythunkpos490= G->thunkpos;  if (!yy_FuncType(G))  goto l491;
-  goto l490;
-  l491:;	  G->pos= yypos490; G->thunkpos= yythunkpos490;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l489;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
-
-  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;  if (!yy_CONST_KW(G))  goto l492;
-  if (!yy__(G))  goto l492;
-  goto l493;
-  l492:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;
-  }
-  l493:;	
-  l494:;	
-  {  int yypos495= G->pos, yythunkpos495= G->thunkpos;
-  {  int yypos496= G->pos, yythunkpos496= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l497;
-  yyDo(G, yy_2_TypeBase, G->begin, G->end, "yy_2_TypeBase");
-  if (!yy__(G))  goto l497;
+  {  int yypos496= G->pos, yythunkpos496= G->thunkpos;  if (!yy_FuncType(G))  goto l497;
   goto l496;
-  l497:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;  if (!yymatchString(G, "signed")) goto l498;
-  yyDo(G, yy_3_TypeBase, G->begin, G->end, "yy_3_TypeBase");
+  l497:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l495;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
+
+  {  int yypos498= G->pos, yythunkpos498= G->thunkpos;  if (!yy_CONST_KW(G))  goto l498;
   if (!yy__(G))  goto l498;
-  goto l496;
-  l498:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;  if (!yymatchString(G, "long")) goto l499;
-
-  {  int yypos500= G->pos, yythunkpos500= G->thunkpos;  if (!yy__(G))  goto l499;
-
-  {  int yypos501= G->pos, yythunkpos501= G->thunkpos;  if (!yymatchString(G, "long")) goto l502;
-  goto l501;
-  l502:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;  if (!yymatchString(G, "double")) goto l503;
-  goto l501;
-  l503:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;  if (!yymatchString(G, "int")) goto l499;
-
+  goto l499;
+  l498:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;
   }
-  l501:;	  G->pos= yypos500; G->thunkpos= yythunkpos500;
-  }  yyDo(G, yy_4_TypeBase, G->begin, G->end, "yy_4_TypeBase");
-  if (!yy__(G))  goto l499;
-  goto l496;
-  l499:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;  if (!yymatchString(G, "struct")) goto l504;
-  yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
+  l499:;	
+  l500:;	
+  {  int yypos501= G->pos, yythunkpos501= G->thunkpos;
+  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l503;
+  yyDo(G, yy_2_TypeBase, G->begin, G->end, "yy_2_TypeBase");
+  if (!yy__(G))  goto l503;
+  goto l502;
+  l503:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "signed")) goto l504;
+  yyDo(G, yy_3_TypeBase, G->begin, G->end, "yy_3_TypeBase");
   if (!yy__(G))  goto l504;
-  goto l496;
-  l504:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;  if (!yymatchString(G, "union")) goto l495;
-  yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
-  if (!yy__(G))  goto l495;
+  goto l502;
+  l504:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "long")) goto l505;
+
+  {  int yypos506= G->pos, yythunkpos506= G->thunkpos;  if (!yy__(G))  goto l505;
+
+  {  int yypos507= G->pos, yythunkpos507= G->thunkpos;  if (!yymatchString(G, "long")) goto l508;
+  goto l507;
+  l508:;	  G->pos= yypos507; G->thunkpos= yythunkpos507;  if (!yymatchString(G, "double")) goto l509;
+  goto l507;
+  l509:;	  G->pos= yypos507; G->thunkpos= yythunkpos507;  if (!yymatchString(G, "int")) goto l505;
 
   }
-  l496:;	  if (!yy__(G))  goto l495;
-  goto l494;
-  l495:;	  G->pos= yypos495; G->thunkpos= yythunkpos495;
-  }  if (!yy_IDENT(G))  goto l489;
+  l507:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;
+  }  yyDo(G, yy_4_TypeBase, G->begin, G->end, "yy_4_TypeBase");
+  if (!yy__(G))  goto l505;
+  goto l502;
+  l505:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "struct")) goto l510;
+  yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
+  if (!yy__(G))  goto l510;
+  goto l502;
+  l510:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "union")) goto l501;
+  yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
+  if (!yy__(G))  goto l501;
+
+  }
+  l502:;	  if (!yy__(G))  goto l501;
+  goto l500;
+  l501:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;
+  }  if (!yy_IDENT(G))  goto l495;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_7_TypeBase, G->begin, G->end, "yy_7_TypeBase");
-  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l489;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
+  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l495;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
 
   }
-  l490:;	  yyprintf((stderr, "  ok   TypeBase"));
+  l496:;	  yyprintf((stderr, "  ok   TypeBase"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l489:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
+  l495:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10204,13 +10293,13 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 }
 YY_RULE(int) yy_SET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SET_KW"));
-  if (!yymatchString(G, "set")) goto l505;
+  if (!yymatchString(G, "set")) goto l511;
   yyprintf((stderr, "  ok   SET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l505:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
+  l511:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10218,13 +10307,13 @@ YY_RULE(int) yy_SET_KW(GREG *G)
 }
 YY_RULE(int) yy_GET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "GET_KW"));
-  if (!yymatchString(G, "get")) goto l506;
+  if (!yymatchString(G, "get")) goto l512;
   yyprintf((stderr, "  ok   GET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l506:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
+  l512:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10233,59 +10322,59 @@ YY_RULE(int) yy_GET_KW(GREG *G)
 YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclSetter"));
-  if (!yy_OocDoc(G))  goto l507;
+  if (!yy_OocDoc(G))  goto l513;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclSetter, G->begin, G->end, "yy_1_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l507;
-  if (!yy_SET_KW(G))  goto l507;
-  if (!yy_WS(G))  goto l507;
+  if (!yy_WS(G))  goto l513;
+  if (!yy_SET_KW(G))  goto l513;
+  if (!yy_WS(G))  goto l513;
 
-  {  int yypos508= G->pos, yythunkpos508= G->thunkpos;  if (!yy_COLON(G))  goto l508;
-  if (!yy_WS(G))  goto l508;
-  if (!yy_ExternName(G))  goto l508;
+  {  int yypos514= G->pos, yythunkpos514= G->thunkpos;  if (!yy_COLON(G))  goto l514;
+  if (!yy_WS(G))  goto l514;
+  if (!yy_ExternName(G))  goto l514;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclSetter, G->begin, G->end, "yy_2_PropertyDeclSetter");
-  goto l509;
-  l508:;	  G->pos= yypos508; G->thunkpos= yythunkpos508;
+  goto l515;
+  l514:;	  G->pos= yypos514; G->thunkpos= yythunkpos514;
   }
-  l509:;	
-  {  int yypos510= G->pos, yythunkpos510= G->thunkpos;  if (!yymatchChar(G, '(')) goto l510;
-  if (!yy_WS(G))  goto l510;
+  l515:;	
+  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;  if (!yymatchChar(G, '(')) goto l516;
+  if (!yy_WS(G))  goto l516;
 
-  {  int yypos512= G->pos, yythunkpos512= G->thunkpos;  if (!yy_IDENT(G))  goto l513;
+  {  int yypos518= G->pos, yythunkpos518= G->thunkpos;  if (!yy_IDENT(G))  goto l519;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclSetter, G->begin, G->end, "yy_3_PropertyDeclSetter");
-  goto l512;
-  l513:;	  G->pos= yypos512; G->thunkpos= yythunkpos512;  if (!yy_ASS(G))  goto l510;
-  if (!yy_IDENT(G))  goto l510;
+  goto l518;
+  l519:;	  G->pos= yypos518; G->thunkpos= yythunkpos518;  if (!yy_ASS(G))  goto l516;
+  if (!yy_IDENT(G))  goto l516;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l510;
+  if (!yy__(G))  goto l516;
   yyDo(G, yy_4_PropertyDeclSetter, G->begin, G->end, "yy_4_PropertyDeclSetter");
 
   }
-  l512:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l510; }
-  if (!yy_WS(G))  goto l510;
-  if (!yymatchChar(G, '{')) goto l510;
+  l518:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l516; }
+  if (!yy_WS(G))  goto l516;
+  if (!yymatchChar(G, '{')) goto l516;
 
-  l514:;	
-  {  int yypos515= G->pos, yythunkpos515= G->thunkpos;  if (!yy_WS(G))  goto l515;
-  if (!yy_Stmt(G))  goto l515;
+  l520:;	
+  {  int yypos521= G->pos, yythunkpos521= G->thunkpos;  if (!yy_WS(G))  goto l521;
+  if (!yy_Stmt(G))  goto l521;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_PropertyDeclSetter, G->begin, G->end, "yy_5_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l515;
-  goto l514;
-  l515:;	  G->pos= yypos515; G->thunkpos= yythunkpos515;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l510; }
-  goto l511;
-  l510:;	  G->pos= yypos510; G->thunkpos= yythunkpos510;
+  if (!yy_WS(G))  goto l521;
+  goto l520;
+  l521:;	  G->pos= yypos521; G->thunkpos= yythunkpos521;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l516; }
+  goto l517;
+  l516:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;
   }
-  l511:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
+  l517:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
   yyprintf((stderr, "  ok   PropertyDeclSetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l507:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
+  l513:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10294,43 +10383,43 @@ YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclGetter"));
-  if (!yy_OocDoc(G))  goto l516;
+  if (!yy_OocDoc(G))  goto l522;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclGetter, G->begin, G->end, "yy_1_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l516;
-  if (!yy_GET_KW(G))  goto l516;
-  if (!yy_WS(G))  goto l516;
+  if (!yy_WS(G))  goto l522;
+  if (!yy_GET_KW(G))  goto l522;
+  if (!yy_WS(G))  goto l522;
 
-  {  int yypos517= G->pos, yythunkpos517= G->thunkpos;  if (!yy_COLON(G))  goto l517;
-  if (!yy_WS(G))  goto l517;
-  if (!yy_ExternName(G))  goto l517;
+  {  int yypos523= G->pos, yythunkpos523= G->thunkpos;  if (!yy_COLON(G))  goto l523;
+  if (!yy_WS(G))  goto l523;
+  if (!yy_ExternName(G))  goto l523;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclGetter, G->begin, G->end, "yy_2_PropertyDeclGetter");
-  goto l518;
-  l517:;	  G->pos= yypos517; G->thunkpos= yythunkpos517;
+  goto l524;
+  l523:;	  G->pos= yypos523; G->thunkpos= yythunkpos523;
   }
-  l518:;	
-  {  int yypos519= G->pos, yythunkpos519= G->thunkpos;  if (!yymatchChar(G, '{')) goto l519;
+  l524:;	
+  {  int yypos525= G->pos, yythunkpos525= G->thunkpos;  if (!yymatchChar(G, '{')) goto l525;
 
-  l521:;	
-  {  int yypos522= G->pos, yythunkpos522= G->thunkpos;  if (!yy_WS(G))  goto l522;
-  if (!yy_Stmt(G))  goto l522;
+  l527:;	
+  {  int yypos528= G->pos, yythunkpos528= G->thunkpos;  if (!yy_WS(G))  goto l528;
+  if (!yy_Stmt(G))  goto l528;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclGetter, G->begin, G->end, "yy_3_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l522;
-  goto l521;
-  l522:;	  G->pos= yypos522; G->thunkpos= yythunkpos522;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l519; }
-  goto l520;
-  l519:;	  G->pos= yypos519; G->thunkpos= yythunkpos519;
+  if (!yy_WS(G))  goto l528;
+  goto l527;
+  l528:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l525; }
+  goto l526;
+  l525:;	  G->pos= yypos525; G->thunkpos= yythunkpos525;
   }
-  l520:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
+  l526:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
   yyprintf((stderr, "  ok   PropertyDeclGetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l516:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
+  l522:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10338,14 +10427,14 @@ YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 }
 YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROPASS_DECL"));
-  if (!yymatchString(G, "::=")) goto l523;
-  if (!yy__(G))  goto l523;
+  if (!yymatchString(G, "::=")) goto l529;
+  if (!yy__(G))  goto l529;
   yyprintf((stderr, "  ok   PROPASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l523:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
+  l529:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10354,15 +10443,15 @@ YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 {  yyprintfv((stderr, "%s\n", "PropertyDeclCore"));
 
-  l525:;	
-  {  int yypos526= G->pos, yythunkpos526= G->thunkpos;
-  {  int yypos527= G->pos, yythunkpos527= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l528;
-  goto l527;
-  l528:;	  G->pos= yypos527; G->thunkpos= yythunkpos527;  if (!yy_PropertyDeclSetter(G))  goto l526;
+  l531:;	
+  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;
+  {  int yypos533= G->pos, yythunkpos533= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l534;
+  goto l533;
+  l534:;	  G->pos= yypos533; G->thunkpos= yythunkpos533;  if (!yy_PropertyDeclSetter(G))  goto l532;
 
   }
-  l527:;	  goto l525;
-  l526:;	  G->pos= yypos526; G->thunkpos= yythunkpos526;
+  l533:;	  goto l531;
+  l532:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;
   }  yyprintf((stderr, "  ok   PropertyDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -10372,37 +10461,37 @@ YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalPropertyDecl"));
-  if (!yy_OocDoc(G))  goto l529;
+  if (!yy_OocDoc(G))  goto l535;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_IDENT(G))  goto l529;
+  if (!yy_IDENT(G))  goto l535;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_ConventionalPropertyDecl, G->begin, G->end, "yy_1_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l529;
-  if (!yy_COLON(G))  goto l529;
-  if (!yy_WS(G))  goto l529;
+  if (!yy_WS(G))  goto l535;
+  if (!yy_COLON(G))  goto l535;
+  if (!yy_WS(G))  goto l535;
 
-  {  int yypos530= G->pos, yythunkpos530= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l530;
+  {  int yypos536= G->pos, yythunkpos536= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l536;
   yyDo(G, yy_2_ConventionalPropertyDecl, G->begin, G->end, "yy_2_ConventionalPropertyDecl");
-  goto l531;
-  l530:;	  G->pos= yypos530; G->thunkpos= yythunkpos530;
+  goto l537;
+  l536:;	  G->pos= yypos536; G->thunkpos= yythunkpos536;
   }
-  l531:;	  if (!yy_WS(G))  goto l529;
-  if (!yy_Type(G))  goto l529;
+  l537:;	  if (!yy_WS(G))  goto l535;
+  if (!yy_Type(G))  goto l535;
   yyDo(G, yy_3_ConventionalPropertyDecl, G->begin, G->end, "yy_3_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l529;
-  if (!yymatchChar(G, '{')) goto l529;
-  if (!yy_WS(G))  goto l529;
-  if (!yy_PropertyDeclCore(G))  goto l529;
-  if (!yy_WS(G))  goto l529;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l529; }
-  if (!yy_WS(G))  goto l529;
+  if (!yy_WS(G))  goto l535;
+  if (!yymatchChar(G, '{')) goto l535;
+  if (!yy_WS(G))  goto l535;
+  if (!yy_PropertyDeclCore(G))  goto l535;
+  if (!yy_WS(G))  goto l535;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l535; }
+  if (!yy_WS(G))  goto l535;
   yyDo(G, yy_4_ConventionalPropertyDecl, G->begin, G->end, "yy_4_ConventionalPropertyDecl");
   yyprintf((stderr, "  ok   ConventionalPropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l529:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
+  l535:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10411,35 +10500,35 @@ YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 YY_RULE(int) yy_PropertyDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l532;
+  if (!yy_OocDoc(G))  goto l538;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_IDENT(G))  goto l532;
+  if (!yy_IDENT(G))  goto l538;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclFromExpr, G->begin, G->end, "yy_1_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l532;
-  if (!yy_PROPASS_DECL(G))  goto l532;
+  if (!yy__(G))  goto l538;
+  if (!yy_PROPASS_DECL(G))  goto l538;
 
-  l533:;	
-  {  int yypos534= G->pos, yythunkpos534= G->thunkpos;  if (!yy__(G))  goto l534;
-  if (!yy_STATIC_KW(G))  goto l534;
+  l539:;	
+  {  int yypos540= G->pos, yythunkpos540= G->thunkpos;  if (!yy__(G))  goto l540;
+  if (!yy_STATIC_KW(G))  goto l540;
   yyDo(G, yy_2_PropertyDeclFromExpr, G->begin, G->end, "yy_2_PropertyDeclFromExpr");
 
-  {  int yypos535= G->pos, yythunkpos535= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l534;
-  G->pos= yypos535; G->thunkpos= yythunkpos535;
-  }  goto l533;
-  l534:;	  G->pos= yypos534; G->thunkpos= yythunkpos534;
-  }  if (!yy__(G))  goto l532;
-  if (!yy_Expr(G))  goto l532;
+  {  int yypos541= G->pos, yythunkpos541= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l540;
+  G->pos= yypos541; G->thunkpos= yythunkpos541;
+  }  goto l539;
+  l540:;	  G->pos= yypos540; G->thunkpos= yythunkpos540;
+  }  if (!yy__(G))  goto l538;
+  if (!yy_Expr(G))  goto l538;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclFromExpr, G->begin, G->end, "yy_3_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l532;
+  if (!yy__(G))  goto l538;
   yyDo(G, yy_4_PropertyDeclFromExpr, G->begin, G->end, "yy_4_PropertyDeclFromExpr");
   yyprintf((stderr, "  ok   PropertyDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l532:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
+  l538:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10449,88 +10538,88 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalVarDecl"));
   yyDo(G, yy_1_ConventionalVarDecl, G->begin, G->end, "yy_1_ConventionalVarDecl");
-  if (!yy_OocDoc(G))  goto l536;
+  if (!yy_OocDoc(G))  goto l542;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l536;
+  if (!yy_IDENT(G))  goto l542;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end, "yy_2_ConventionalVarDecl");
 
-  {  int yypos537= G->pos, yythunkpos537= G->thunkpos;  if (!yy__(G))  goto l537;
-  if (!yy_ASS(G))  goto l537;
-  if (!yy__(G))  goto l537;
-  if (!yy_Expr(G))  goto l537;
+  {  int yypos543= G->pos, yythunkpos543= G->thunkpos;  if (!yy__(G))  goto l543;
+  if (!yy_ASS(G))  goto l543;
+  if (!yy__(G))  goto l543;
+  if (!yy_Expr(G))  goto l543;
   yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end, "yy_3_ConventionalVarDecl");
-  goto l538;
-  l537:;	  G->pos= yypos537; G->thunkpos= yythunkpos537;
+  goto l544;
+  l543:;	  G->pos= yypos543; G->thunkpos= yythunkpos543;
   }
-  l538:;	
-  l539:;	
-  {  int yypos540= G->pos, yythunkpos540= G->thunkpos;  if (!yy__(G))  goto l540;
-  if (!yymatchChar(G, ',')) goto l540;
-  if (!yy_OocDoc(G))  goto l540;
+  l544:;	
+  l545:;	
+  {  int yypos546= G->pos, yythunkpos546= G->thunkpos;  if (!yy__(G))  goto l546;
+  if (!yymatchChar(G, ',')) goto l546;
+  if (!yy_OocDoc(G))  goto l546;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_WS(G))  goto l540;
-  if (!yy_IDENT(G))  goto l540;
+  if (!yy_WS(G))  goto l546;
+  if (!yy_IDENT(G))  goto l546;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end, "yy_4_ConventionalVarDecl");
 
-  {  int yypos541= G->pos, yythunkpos541= G->thunkpos;  if (!yy__(G))  goto l541;
-  if (!yy_ASS(G))  goto l541;
-  if (!yy__(G))  goto l541;
-  if (!yy_Expr(G))  goto l541;
+  {  int yypos547= G->pos, yythunkpos547= G->thunkpos;  if (!yy__(G))  goto l547;
+  if (!yy_ASS(G))  goto l547;
+  if (!yy__(G))  goto l547;
+  if (!yy_Expr(G))  goto l547;
   yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end, "yy_5_ConventionalVarDecl");
-  goto l542;
-  l541:;	  G->pos= yypos541; G->thunkpos= yythunkpos541;
+  goto l548;
+  l547:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;
   }
-  l542:;	  if (!yy__(G))  goto l540;
-  goto l539;
-  l540:;	  G->pos= yypos540; G->thunkpos= yythunkpos540;
-  }  if (!yy_WS(G))  goto l536;
-  if (!yy_COLON(G))  goto l536;
-  if (!yy_WS(G))  goto l536;
+  l548:;	  if (!yy__(G))  goto l546;
+  goto l545;
+  l546:;	  G->pos= yypos546; G->thunkpos= yythunkpos546;
+  }  if (!yy_WS(G))  goto l542;
+  if (!yy_COLON(G))  goto l542;
+  if (!yy_WS(G))  goto l542;
 
-  l543:;	
-  {  int yypos544= G->pos, yythunkpos544= G->thunkpos;  if (!yy__(G))  goto l544;
+  l549:;	
+  {  int yypos550= G->pos, yythunkpos550= G->thunkpos;  if (!yy__(G))  goto l550;
 
-  {  int yypos545= G->pos, yythunkpos545= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l546;
+  {  int yypos551= G->pos, yythunkpos551= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l552;
   yyDo(G, yy_6_ConventionalVarDecl, G->begin, G->end, "yy_6_ConventionalVarDecl");
-  goto l545;
-  l546:;	  G->pos= yypos545; G->thunkpos= yythunkpos545;  if (!yy_CONST_KW(G))  goto l547;
+  goto l551;
+  l552:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_CONST_KW(G))  goto l553;
   yyDo(G, yy_7_ConventionalVarDecl, G->begin, G->end, "yy_7_ConventionalVarDecl");
-  goto l545;
-  l547:;	  G->pos= yypos545; G->thunkpos= yythunkpos545;  if (!yy_PROTO_KW(G))  goto l548;
+  goto l551;
+  l553:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_PROTO_KW(G))  goto l554;
   yyDo(G, yy_8_ConventionalVarDecl, G->begin, G->end, "yy_8_ConventionalVarDecl");
-  goto l545;
-  l548:;	  G->pos= yypos545; G->thunkpos= yythunkpos545;  if (!yy_ExternName(G))  goto l549;
+  goto l551;
+  l554:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_ExternName(G))  goto l555;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_9_ConventionalVarDecl, G->begin, G->end, "yy_9_ConventionalVarDecl");
-  goto l545;
-  l549:;	  G->pos= yypos545; G->thunkpos= yythunkpos545;  if (!yy_UnmangledName(G))  goto l544;
+  goto l551;
+  l555:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_UnmangledName(G))  goto l550;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ConventionalVarDecl, G->begin, G->end, "yy_10_ConventionalVarDecl");
 
   }
-  l545:;	  goto l543;
-  l544:;	  G->pos= yypos544; G->thunkpos= yythunkpos544;
-  }  if (!yy_WS(G))  goto l536;
-  if (!yy_Type(G))  goto l536;
+  l551:;	  goto l549;
+  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
+  }  if (!yy_WS(G))  goto l542;
+  if (!yy_Type(G))  goto l542;
   yyDo(G, yy_11_ConventionalVarDecl, G->begin, G->end, "yy_11_ConventionalVarDecl");
 
-  {  int yypos550= G->pos, yythunkpos550= G->thunkpos;  if (!yy__(G))  goto l550;
-  if (!yy_ASS(G))  goto l550;
-  if (!yy__(G))  goto l550;
-  if (!yy_Expr(G))  goto l550;
+  {  int yypos556= G->pos, yythunkpos556= G->thunkpos;  if (!yy__(G))  goto l556;
+  if (!yy_ASS(G))  goto l556;
+  if (!yy__(G))  goto l556;
+  if (!yy_Expr(G))  goto l556;
   yyDo(G, yy_12_ConventionalVarDecl, G->begin, G->end, "yy_12_ConventionalVarDecl");
-  goto l551;
-  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
+  goto l557;
+  l556:;	  G->pos= yypos556; G->thunkpos= yythunkpos556;
   }
-  l551:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
+  l557:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
   yyprintf((stderr, "  ok   ConventionalVarDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l536:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
+  l542:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10538,13 +10627,13 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 }
 YY_RULE(int) yy_CONST_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONST_KW"));
-  if (!yymatchString(G, "const")) goto l552;
+  if (!yymatchString(G, "const")) goto l558;
   yyprintf((stderr, "  ok   CONST_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l552:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
+  l558:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10552,14 +10641,14 @@ YY_RULE(int) yy_CONST_KW(GREG *G)
 }
 YY_RULE(int) yy_ASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DECL"));
-  if (!yymatchString(G, ":=")) goto l553;
-  if (!yy__(G))  goto l553;
+  if (!yymatchString(G, ":=")) goto l559;
+  if (!yy__(G))  goto l559;
   yyprintf((stderr, "  ok   ASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l553:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
+  l559:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10568,41 +10657,41 @@ YY_RULE(int) yy_ASS_DECL(GREG *G)
 YY_RULE(int) yy_Tuple(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Tuple"));
-  if (!yymatchChar(G, '(')) goto l554;
+  if (!yymatchChar(G, '(')) goto l560;
   yyDo(G, yy_1_Tuple, G->begin, G->end, "yy_1_Tuple");
-  if (!yy_WS(G))  goto l554;
+  if (!yy_WS(G))  goto l560;
   yyDo(G, yy_2_Tuple, G->begin, G->end, "yy_2_Tuple");
 
-  {  int yypos555= G->pos, yythunkpos555= G->thunkpos;  if (!yy_Expr(G))  goto l555;
+  {  int yypos561= G->pos, yythunkpos561= G->thunkpos;  if (!yy_Expr(G))  goto l561;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Tuple, G->begin, G->end, "yy_3_Tuple");
 
-  l557:;	
-  {  int yypos558= G->pos, yythunkpos558= G->thunkpos;
-  {  int yypos559= G->pos, yythunkpos559= G->thunkpos;  if (!yy_WS(G))  goto l560;
-  if (!yymatchChar(G, ',')) goto l560;
-  goto l559;
-  l560:;	  G->pos= yypos559; G->thunkpos= yythunkpos559;  if (!yy_EOL(G))  goto l558;
+  l563:;	
+  {  int yypos564= G->pos, yythunkpos564= G->thunkpos;
+  {  int yypos565= G->pos, yythunkpos565= G->thunkpos;  if (!yy_WS(G))  goto l566;
+  if (!yymatchChar(G, ',')) goto l566;
+  goto l565;
+  l566:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_EOL(G))  goto l564;
 
   }
-  l559:;	  if (!yy_WS(G))  goto l558;
-  if (!yy_Expr(G))  goto l558;
+  l565:;	  if (!yy_WS(G))  goto l564;
+  if (!yy_Expr(G))  goto l564;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Tuple, G->begin, G->end, "yy_4_Tuple");
-  goto l557;
-  l558:;	  G->pos= yypos558; G->thunkpos= yythunkpos558;
-  }  goto l556;
-  l555:;	  G->pos= yypos555; G->thunkpos= yythunkpos555;
+  goto l563;
+  l564:;	  G->pos= yypos564; G->thunkpos= yythunkpos564;
+  }  goto l562;
+  l561:;	  G->pos= yypos561; G->thunkpos= yythunkpos561;
   }
-  l556:;	  if (!yy_WS(G))  goto l554;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l554; }
+  l562:;	  if (!yy_WS(G))  goto l560;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l560; }
   yyDo(G, yy_5_Tuple, G->begin, G->end, "yy_5_Tuple");
   yyprintf((stderr, "  ok   Tuple"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l554:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
+  l560:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10611,51 +10700,51 @@ YY_RULE(int) yy_Tuple(GREG *G)
 YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VarDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l561;
+  if (!yy_OocDoc(G))  goto l567;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos562= G->pos, yythunkpos562= G->thunkpos;  if (!yy_IDENT(G))  goto l563;
+  {  int yypos568= G->pos, yythunkpos568= G->thunkpos;  if (!yy_IDENT(G))  goto l569;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_VarDeclFromExpr, G->begin, G->end, "yy_1_VarDeclFromExpr");
-  goto l562;
-  l563:;	  G->pos= yypos562; G->thunkpos= yythunkpos562;  if (!yy_Tuple(G))  goto l561;
+  goto l568;
+  l569:;	  G->pos= yypos568; G->thunkpos= yythunkpos568;  if (!yy_Tuple(G))  goto l567;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_VarDeclFromExpr, G->begin, G->end, "yy_2_VarDeclFromExpr");
 
   }
-  l562:;	  if (!yy__(G))  goto l561;
-  if (!yy_ASS_DECL(G))  goto l561;
+  l568:;	  if (!yy__(G))  goto l567;
+  if (!yy_ASS_DECL(G))  goto l567;
 
-  l564:;	
-  {  int yypos565= G->pos, yythunkpos565= G->thunkpos;  if (!yy__(G))  goto l565;
+  l570:;	
+  {  int yypos571= G->pos, yythunkpos571= G->thunkpos;  if (!yy__(G))  goto l571;
 
-  {  int yypos566= G->pos, yythunkpos566= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l567;
+  {  int yypos572= G->pos, yythunkpos572= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l573;
   yyDo(G, yy_3_VarDeclFromExpr, G->begin, G->end, "yy_3_VarDeclFromExpr");
-  goto l566;
-  l567:;	  G->pos= yypos566; G->thunkpos= yythunkpos566;  if (!yy_CONST_KW(G))  goto l568;
+  goto l572;
+  l573:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;  if (!yy_CONST_KW(G))  goto l574;
   yyDo(G, yy_4_VarDeclFromExpr, G->begin, G->end, "yy_4_VarDeclFromExpr");
-  goto l566;
-  l568:;	  G->pos= yypos566; G->thunkpos= yythunkpos566;  if (!yy_PROTO_KW(G))  goto l565;
+  goto l572;
+  l574:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;  if (!yy_PROTO_KW(G))  goto l571;
   yyDo(G, yy_5_VarDeclFromExpr, G->begin, G->end, "yy_5_VarDeclFromExpr");
 
   }
-  l566:;	
-  {  int yypos569= G->pos, yythunkpos569= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l565;
-  G->pos= yypos569; G->thunkpos= yythunkpos569;
-  }  goto l564;
-  l565:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;
-  }  if (!yy__(G))  goto l561;
-  if (!yy_Expr(G))  goto l561;
+  l572:;	
+  {  int yypos575= G->pos, yythunkpos575= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l571;
+  G->pos= yypos575; G->thunkpos= yythunkpos575;
+  }  goto l570;
+  l571:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;
+  }  if (!yy__(G))  goto l567;
+  if (!yy_Expr(G))  goto l567;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end, "yy_6_VarDeclFromExpr");
-  if (!yy__(G))  goto l561;
+  if (!yy__(G))  goto l567;
   yyDo(G, yy_7_VarDeclFromExpr, G->begin, G->end, "yy_7_VarDeclFromExpr");
   yyprintf((stderr, "  ok   VarDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l561:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
+  l567:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10663,13 +10752,13 @@ YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 }
 YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UNMANGLED_KW"));
-  if (!yymatchString(G, "unmangled")) goto l570;
+  if (!yymatchString(G, "unmangled")) goto l576;
   yyprintf((stderr, "  ok   UNMANGLED_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l570:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
+  l576:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10677,13 +10766,13 @@ YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTERN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTERN_KW"));
-  if (!yymatchString(G, "extern")) goto l571;
+  if (!yymatchString(G, "extern")) goto l577;
   yyprintf((stderr, "  ok   EXTERN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l571:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
+  l577:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10691,13 +10780,13 @@ YY_RULE(int) yy_EXTERN_KW(GREG *G)
 }
 YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTERFACE_KW"));
-  if (!yymatchString(G, "interface")) goto l572;
+  if (!yymatchString(G, "interface")) goto l578;
   yyprintf((stderr, "  ok   INTERFACE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l572:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
+  l578:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10705,13 +10794,13 @@ YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 }
 YY_RULE(int) yy_COVER_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COVER_KW"));
-  if (!yymatchString(G, "cover")) goto l573;
+  if (!yymatchString(G, "cover")) goto l579;
   yyprintf((stderr, "  ok   COVER_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l573:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
+  l579:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10719,18 +10808,18 @@ YY_RULE(int) yy_COVER_KW(GREG *G)
 }
 YY_RULE(int) yy_PLUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PLUS"));
-  if (!yymatchChar(G, '+')) goto l574;
+  if (!yymatchChar(G, '+')) goto l580;
 
-  {  int yypos575= G->pos, yythunkpos575= G->thunkpos;  if (!yymatchChar(G, '=')) goto l575;
-  goto l574;
-  l575:;	  G->pos= yypos575; G->thunkpos= yythunkpos575;
-  }  if (!yy__(G))  goto l574;
+  {  int yypos581= G->pos, yythunkpos581= G->thunkpos;  if (!yymatchChar(G, '=')) goto l581;
+  goto l580;
+  l581:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;
+  }  if (!yy__(G))  goto l580;
   yyprintf((stderr, "  ok   PLUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l574:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
+  l580:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10738,18 +10827,18 @@ YY_RULE(int) yy_PLUS(GREG *G)
 }
 YY_RULE(int) yy_STAR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STAR"));
-  if (!yymatchChar(G, '*')) goto l576;
+  if (!yymatchChar(G, '*')) goto l582;
 
-  {  int yypos577= G->pos, yythunkpos577= G->thunkpos;  if (!yymatchChar(G, '=')) goto l577;
-  goto l576;
-  l577:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;
-  }  if (!yy__(G))  goto l576;
+  {  int yypos583= G->pos, yythunkpos583= G->thunkpos;  if (!yymatchChar(G, '=')) goto l583;
+  goto l582;
+  l583:;	  G->pos= yypos583; G->thunkpos= yythunkpos583;
+  }  if (!yy__(G))  goto l582;
   yyprintf((stderr, "  ok   STAR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l576:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
+  l582:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10759,38 +10848,38 @@ YY_RULE(int) yy_Expr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Expr"));
 
-  {  int yypos579= G->pos, yythunkpos579= G->thunkpos;  if (!yy_VariableDecl(G))  goto l580;
+  {  int yypos585= G->pos, yythunkpos585= G->thunkpos;  if (!yy_VariableDecl(G))  goto l586;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l580;
-  goto l579;
-  l580:;	  G->pos= yypos579; G->thunkpos= yythunkpos579;  if (!yy_DoubleArrow(G))  goto l581;
+  if (!yy__(G))  goto l586;
+  goto l585;
+  l586:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_DoubleArrow(G))  goto l587;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l581;
-  goto l579;
-  l581:;	  G->pos= yypos579; G->thunkpos= yythunkpos579;  if (!yy_BinaryOperation(G))  goto l582;
+  if (!yy__(G))  goto l587;
+  goto l585;
+  l587:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_BinaryOperation(G))  goto l588;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l582;
+  if (!yy__(G))  goto l588;
 
-  l583:;	
-  {  int yypos584= G->pos, yythunkpos584= G->thunkpos;  if (!yy__(G))  goto l584;
-  if (!yymatchChar(G, '.')) goto l584;
+  l589:;	
+  {  int yypos590= G->pos, yythunkpos590= G->thunkpos;  if (!yy__(G))  goto l590;
+  if (!yymatchChar(G, '.')) goto l590;
   yyDo(G, yy_1_Expr, G->begin, G->end, "yy_1_Expr");
-  if (!yy_WS(G))  goto l584;
-  if (!yy_FunctionCall(G))  goto l584;
+  if (!yy_WS(G))  goto l590;
+  if (!yy_FunctionCall(G))  goto l590;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Expr, G->begin, G->end, "yy_2_Expr");
-  goto l583;
-  l584:;	  G->pos= yypos584; G->thunkpos= yythunkpos584;
-  }  goto l579;
-  l582:;	  G->pos= yypos579; G->thunkpos= yythunkpos579;  if (!yy_AnonymousFunctionDecl(G))  goto l578;
+  goto l589;
+  l590:;	  G->pos= yypos590; G->thunkpos= yythunkpos590;
+  }  goto l585;
+  l588:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_AnonymousFunctionDecl(G))  goto l584;
 
   }
-  l579:;	  yyprintf((stderr, "  ok   Expr"));
+  l585:;	  yyprintf((stderr, "  ok   Expr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l578:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
+  l584:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10799,36 +10888,36 @@ YY_RULE(int) yy_Expr(GREG *G)
 YY_RULE(int) yy_EnumElement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumElement"));
-  if (!yy_OocDoc(G))  goto l585;
+  if (!yy_OocDoc(G))  goto l591;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l585;
+  if (!yy_IDENT(G))  goto l591;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_EnumElement, G->begin, G->end, "yy_1_EnumElement");
-  if (!yy__(G))  goto l585;
+  if (!yy__(G))  goto l591;
 
-  {  int yypos586= G->pos, yythunkpos586= G->thunkpos;
-  {  int yypos588= G->pos, yythunkpos588= G->thunkpos;  if (!yy_ASS(G))  goto l589;
-  if (!yy_Expr(G))  goto l589;
+  {  int yypos592= G->pos, yythunkpos592= G->thunkpos;
+  {  int yypos594= G->pos, yythunkpos594= G->thunkpos;  if (!yy_ASS(G))  goto l595;
+  if (!yy_Expr(G))  goto l595;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_EnumElement, G->begin, G->end, "yy_2_EnumElement");
-  goto l588;
-  l589:;	  G->pos= yypos588; G->thunkpos= yythunkpos588;  if (!yy_COLON(G))  goto l586;
-  if (!yy__(G))  goto l586;
-  if (!yy_ExternName(G))  goto l586;
+  goto l594;
+  l595:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yy_COLON(G))  goto l592;
+  if (!yy__(G))  goto l592;
+  if (!yy_ExternName(G))  goto l592;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumElement, G->begin, G->end, "yy_3_EnumElement");
 
   }
-  l588:;	  goto l587;
-  l586:;	  G->pos= yypos586; G->thunkpos= yythunkpos586;
+  l594:;	  goto l593;
+  l592:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;
   }
-  l587:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
+  l593:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
   yyprintf((stderr, "  ok   EnumElement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l585:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
+  l591:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10838,28 +10927,28 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IntLiteral"));
 
-  {  int yypos591= G->pos, yythunkpos591= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l592;
+  {  int yypos597= G->pos, yythunkpos597= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l598;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l592;
+  if (!yy__(G))  goto l598;
   yyDo(G, yy_1_IntLiteral, G->begin, G->end, "yy_1_IntLiteral");
-  goto l591;
-  l592:;	  G->pos= yypos591; G->thunkpos= yythunkpos591;  if (!yy_HEX_LIT(G))  goto l593;
+  goto l597;
+  l598:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  if (!yy_HEX_LIT(G))  goto l599;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l593;
+  if (!yy__(G))  goto l599;
   yyDo(G, yy_2_IntLiteral, G->begin, G->end, "yy_2_IntLiteral");
-  goto l591;
-  l593:;	  G->pos= yypos591; G->thunkpos= yythunkpos591;  if (!yy_DEC_LIT(G))  goto l590;
+  goto l597;
+  l599:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  if (!yy_DEC_LIT(G))  goto l596;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l590;
+  if (!yy__(G))  goto l596;
   yyDo(G, yy_3_IntLiteral, G->begin, G->end, "yy_3_IntLiteral");
 
   }
-  l591:;	  yyprintf((stderr, "  ok   IntLiteral"));
+  l597:;	  yyprintf((stderr, "  ok   IntLiteral"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l590:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
+  l596:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10868,19 +10957,19 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EnumIncrementOper"));
 
-  {  int yypos595= G->pos, yythunkpos595= G->thunkpos;  if (!yy_STAR(G))  goto l596;
+  {  int yypos601= G->pos, yythunkpos601= G->thunkpos;  if (!yy_STAR(G))  goto l602;
   yyDo(G, yy_1_EnumIncrementOper, G->begin, G->end, "yy_1_EnumIncrementOper");
-  goto l595;
-  l596:;	  G->pos= yypos595; G->thunkpos= yythunkpos595;  if (!yy_PLUS(G))  goto l594;
+  goto l601;
+  l602:;	  G->pos= yypos601; G->thunkpos= yythunkpos601;  if (!yy_PLUS(G))  goto l600;
   yyDo(G, yy_2_EnumIncrementOper, G->begin, G->end, "yy_2_EnumIncrementOper");
 
   }
-  l595:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
+  l601:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l594:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
+  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10888,13 +10977,13 @@ YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 }
 YY_RULE(int) yy_FROM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FROM_KW"));
-  if (!yymatchString(G, "from")) goto l597;
+  if (!yymatchString(G, "from")) goto l603;
   yyprintf((stderr, "  ok   FROM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l597:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
+  l603:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10902,13 +10991,13 @@ YY_RULE(int) yy_FROM_KW(GREG *G)
 }
 YY_RULE(int) yy_ENUM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ENUM_KW"));
-  if (!yymatchString(G, "enum")) goto l598;
+  if (!yymatchString(G, "enum")) goto l604;
   yyprintf((stderr, "  ok   ENUM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l598:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
+  l604:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10916,13 +11005,13 @@ YY_RULE(int) yy_ENUM_KW(GREG *G)
 }
 YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPLEMENTS_KW"));
-  if (!yymatchString(G, "implements")) goto l599;
+  if (!yymatchString(G, "implements")) goto l605;
   yyprintf((stderr, "  ok   IMPLEMENTS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l599:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
+  l605:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10930,13 +11019,13 @@ YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTENDS_KW"));
-  if (!yymatchString(G, "extends")) goto l600;
+  if (!yymatchString(G, "extends")) goto l606;
   yyprintf((stderr, "  ok   EXTENDS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
+  l606:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10944,13 +11033,13 @@ YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 }
 YY_RULE(int) yy_CLASS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLASS_KW"));
-  if (!yymatchString(G, "class")) goto l601;
+  if (!yymatchString(G, "class")) goto l607;
   yyprintf((stderr, "  ok   CLASS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l601:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
+  l607:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10959,17 +11048,17 @@ YY_RULE(int) yy_CLASS_KW(GREG *G)
 YY_RULE(int) yy_ASS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS"));
 
-  {  int yypos603= G->pos, yythunkpos603= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l603;
-  goto l602;
-  l603:;	  G->pos= yypos603; G->thunkpos= yythunkpos603;
-  }  if (!yymatchChar(G, '=')) goto l602;
-  if (!yy__(G))  goto l602;
+  {  int yypos609= G->pos, yythunkpos609= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l609;
+  goto l608;
+  l609:;	  G->pos= yypos609; G->thunkpos= yythunkpos609;
+  }  if (!yymatchChar(G, '=')) goto l608;
+  if (!yy__(G))  goto l608;
   yyprintf((stderr, "  ok   ASS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l602:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
+  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10978,16 +11067,16 @@ YY_RULE(int) yy_ASS(GREG *G)
 YY_RULE(int) yy_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOT"));
 
-  {  int yypos605= G->pos, yythunkpos605= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l605;
-  goto l604;
-  l605:;	  G->pos= yypos605; G->thunkpos= yythunkpos605;
-  }  if (!yymatchChar(G, '.')) goto l604;
+  {  int yypos611= G->pos, yythunkpos611= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l611;
+  goto l610;
+  l611:;	  G->pos= yypos611; G->thunkpos= yythunkpos611;
+  }  if (!yymatchChar(G, '.')) goto l610;
   yyprintf((stderr, "  ok   DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l604:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
+  l610:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10997,137 +11086,137 @@ YY_RULE(int) yy_Type(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Type"));
 
-  {  int yypos607= G->pos, yythunkpos607= G->thunkpos;  if (!yy_TypeList(G))  goto l608;
+  {  int yypos613= G->pos, yythunkpos613= G->thunkpos;  if (!yy_TypeList(G))  goto l614;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_1_Type, G->begin, G->end, "yy_1_Type");
-  goto l607;
-  l608:;	  G->pos= yypos607; G->thunkpos= yythunkpos607;  if (!yy_TypeBase(G))  goto l609;
+  goto l613;
+  l614:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;  if (!yy_TypeBase(G))  goto l615;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos610= G->pos, yythunkpos610= G->thunkpos;  if (!yy__(G))  goto l610;
-  if (!yymatchChar(G, '<')) goto l610;
-  if (!yy__(G))  goto l610;
-  if (!yy_Type(G))  goto l610;
+  {  int yypos616= G->pos, yythunkpos616= G->thunkpos;  if (!yy__(G))  goto l616;
+  if (!yymatchChar(G, '<')) goto l616;
+  if (!yy__(G))  goto l616;
+  if (!yy_Type(G))  goto l616;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_Type, G->begin, G->end, "yy_2_Type");
 
-  l612:;	
-  {  int yypos613= G->pos, yythunkpos613= G->thunkpos;  if (!yy__(G))  goto l613;
-  if (!yymatchChar(G, ',')) goto l613;
-  if (!yy__(G))  goto l613;
-  if (!yy_Type(G))  goto l613;
+  l618:;	
+  {  int yypos619= G->pos, yythunkpos619= G->thunkpos;  if (!yy__(G))  goto l619;
+  if (!yymatchChar(G, ',')) goto l619;
+  if (!yy__(G))  goto l619;
+  if (!yy_Type(G))  goto l619;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_3_Type, G->begin, G->end, "yy_3_Type");
-  goto l612;
-  l613:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;
-  }  if (!yy__(G))  goto l610;
-  if (!yymatchChar(G, '>')) goto l610;
-  goto l611;
-  l610:;	  G->pos= yypos610; G->thunkpos= yythunkpos610;
-  }
-  l611:;	  if (!yy__(G))  goto l609;
-
-  l614:;	
-  {  int yypos615= G->pos, yythunkpos615= G->thunkpos;
-  {  int yypos616= G->pos, yythunkpos616= G->thunkpos;  if (!yy_STAR(G))  goto l617;
-  yyDo(G, yy_4_Type, G->begin, G->end, "yy_4_Type");
-  goto l616;
-  l617:;	  G->pos= yypos616; G->thunkpos= yythunkpos616;  if (!yymatchChar(G, '@')) goto l618;
-  yyDo(G, yy_5_Type, G->begin, G->end, "yy_5_Type");
-  goto l616;
-  l618:;	  G->pos= yypos616; G->thunkpos= yythunkpos616;  if (!yymatchChar(G, '[')) goto l615;
-  if (!yy_WS(G))  goto l615;
-  yyDo(G, yy_6_Type, G->begin, G->end, "yy_6_Type");
-  if (!yy__(G))  goto l615;
-
-  {  int yypos619= G->pos, yythunkpos619= G->thunkpos;  if (!yy_Expr(G))  goto l619;
-  yyDo(G, yySet, -3, 0, "yySet");
-  goto l620;
+  goto l618;
   l619:;	  G->pos= yypos619; G->thunkpos= yythunkpos619;
+  }  if (!yy__(G))  goto l616;
+  if (!yymatchChar(G, '>')) goto l616;
+  goto l617;
+  l616:;	  G->pos= yypos616; G->thunkpos= yythunkpos616;
   }
-  l620:;	  if (!yymatchChar(G, ']')) goto l615;
+  l617:;	  if (!yy__(G))  goto l615;
+
+  l620:;	
+  {  int yypos621= G->pos, yythunkpos621= G->thunkpos;
+  {  int yypos622= G->pos, yythunkpos622= G->thunkpos;  if (!yy_STAR(G))  goto l623;
+  yyDo(G, yy_4_Type, G->begin, G->end, "yy_4_Type");
+  goto l622;
+  l623:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;  if (!yymatchChar(G, '@')) goto l624;
+  yyDo(G, yy_5_Type, G->begin, G->end, "yy_5_Type");
+  goto l622;
+  l624:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;  if (!yymatchChar(G, '[')) goto l621;
+  if (!yy_WS(G))  goto l621;
+  yyDo(G, yy_6_Type, G->begin, G->end, "yy_6_Type");
+  if (!yy__(G))  goto l621;
+
+  {  int yypos625= G->pos, yythunkpos625= G->thunkpos;  if (!yy_Expr(G))  goto l625;
+  yyDo(G, yySet, -3, 0, "yySet");
+  goto l626;
+  l625:;	  G->pos= yypos625; G->thunkpos= yythunkpos625;
+  }
+  l626:;	  if (!yymatchChar(G, ']')) goto l621;
   yyDo(G, yy_7_Type, G->begin, G->end, "yy_7_Type");
 
   }
-  l616:;	  goto l614;
-  l615:;	  G->pos= yypos615; G->thunkpos= yythunkpos615;
-  }  if (!yy__(G))  goto l609;
+  l622:;	  goto l620;
+  l621:;	  G->pos= yypos621; G->thunkpos= yythunkpos621;
+  }  if (!yy__(G))  goto l615;
   yyDo(G, yy_8_Type, G->begin, G->end, "yy_8_Type");
-  goto l607;
-  l609:;	  G->pos= yypos607; G->thunkpos= yythunkpos607;  if (!yymatchChar(G, '(')) goto l606;
-  if (!yy_Old(G))  goto l606;
+  goto l613;
+  l615:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;  if (!yymatchChar(G, '(')) goto l612;
+  if (!yy_Old(G))  goto l612;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l606;
-  if (!yy_IDENT(G))  goto l606;
+  if (!yy__(G))  goto l612;
+  if (!yy_IDENT(G))  goto l612;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_Type, G->begin, G->end, "yy_9_Type");
-  if (!yy__(G))  goto l606;
-  if (!yy_TypeBase(G))  goto l606;
+  if (!yy__(G))  goto l612;
+  if (!yy_TypeBase(G))  goto l612;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos621= G->pos, yythunkpos621= G->thunkpos;  if (!yy_FuncType(G))  goto l621;
-  goto l606;
-  l621:;	  G->pos= yypos621; G->thunkpos= yythunkpos621;
+  {  int yypos627= G->pos, yythunkpos627= G->thunkpos;  if (!yy_FuncType(G))  goto l627;
+  goto l612;
+  l627:;	  G->pos= yypos627; G->thunkpos= yythunkpos627;
   }  yyDo(G, yy_10_Type, G->begin, G->end, "yy_10_Type");
 
-  {  int yypos622= G->pos, yythunkpos622= G->thunkpos;  if (!yy__(G))  goto l622;
-  if (!yymatchChar(G, '<')) goto l622;
-  if (!yy__(G))  goto l622;
-  if (!yy_Type(G))  goto l622;
+  {  int yypos628= G->pos, yythunkpos628= G->thunkpos;  if (!yy__(G))  goto l628;
+  if (!yymatchChar(G, '<')) goto l628;
+  if (!yy__(G))  goto l628;
+  if (!yy_Type(G))  goto l628;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_11_Type, G->begin, G->end, "yy_11_Type");
 
-  l624:;	
-  {  int yypos625= G->pos, yythunkpos625= G->thunkpos;  if (!yy__(G))  goto l625;
-  if (!yymatchChar(G, ',')) goto l625;
-  if (!yy__(G))  goto l625;
-  if (!yy_Type(G))  goto l625;
+  l630:;	
+  {  int yypos631= G->pos, yythunkpos631= G->thunkpos;  if (!yy__(G))  goto l631;
+  if (!yymatchChar(G, ',')) goto l631;
+  if (!yy__(G))  goto l631;
+  if (!yy_Type(G))  goto l631;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_12_Type, G->begin, G->end, "yy_12_Type");
-  goto l624;
-  l625:;	  G->pos= yypos625; G->thunkpos= yythunkpos625;
-  }  if (!yy__(G))  goto l622;
-  if (!yymatchChar(G, '>')) goto l622;
-  goto l623;
-  l622:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;
-  }
-  l623:;	  if (!yy__(G))  goto l606;
-
-  l626:;	
-  {  int yypos627= G->pos, yythunkpos627= G->thunkpos;
-  {  int yypos628= G->pos, yythunkpos628= G->thunkpos;  if (!yy_STAR(G))  goto l629;
-  yyDo(G, yy_13_Type, G->begin, G->end, "yy_13_Type");
-  goto l628;
-  l629:;	  G->pos= yypos628; G->thunkpos= yythunkpos628;  if (!yymatchChar(G, '@')) goto l630;
-  yyDo(G, yy_14_Type, G->begin, G->end, "yy_14_Type");
-  goto l628;
-  l630:;	  G->pos= yypos628; G->thunkpos= yythunkpos628;  if (!yymatchChar(G, '[')) goto l627;
-  if (!yy_WS(G))  goto l627;
-  yyDo(G, yy_15_Type, G->begin, G->end, "yy_15_Type");
-  if (!yy__(G))  goto l627;
-
-  {  int yypos631= G->pos, yythunkpos631= G->thunkpos;  if (!yy_Expr(G))  goto l631;
-  yyDo(G, yySet, -3, 0, "yySet");
-  goto l632;
+  goto l630;
   l631:;	  G->pos= yypos631; G->thunkpos= yythunkpos631;
+  }  if (!yy__(G))  goto l628;
+  if (!yymatchChar(G, '>')) goto l628;
+  goto l629;
+  l628:;	  G->pos= yypos628; G->thunkpos= yythunkpos628;
   }
-  l632:;	  if (!yymatchChar(G, ']')) goto l627;
+  l629:;	  if (!yy__(G))  goto l612;
+
+  l632:;	
+  {  int yypos633= G->pos, yythunkpos633= G->thunkpos;
+  {  int yypos634= G->pos, yythunkpos634= G->thunkpos;  if (!yy_STAR(G))  goto l635;
+  yyDo(G, yy_13_Type, G->begin, G->end, "yy_13_Type");
+  goto l634;
+  l635:;	  G->pos= yypos634; G->thunkpos= yythunkpos634;  if (!yymatchChar(G, '@')) goto l636;
+  yyDo(G, yy_14_Type, G->begin, G->end, "yy_14_Type");
+  goto l634;
+  l636:;	  G->pos= yypos634; G->thunkpos= yythunkpos634;  if (!yymatchChar(G, '[')) goto l633;
+  if (!yy_WS(G))  goto l633;
+  yyDo(G, yy_15_Type, G->begin, G->end, "yy_15_Type");
+  if (!yy__(G))  goto l633;
+
+  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;  if (!yy_Expr(G))  goto l637;
+  yyDo(G, yySet, -3, 0, "yySet");
+  goto l638;
+  l637:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;
+  }
+  l638:;	  if (!yymatchChar(G, ']')) goto l633;
   yyDo(G, yy_16_Type, G->begin, G->end, "yy_16_Type");
 
   }
-  l628:;	  goto l626;
-  l627:;	  G->pos= yypos627; G->thunkpos= yythunkpos627;
-  }  if (!yy__(G))  goto l606;
+  l634:;	  goto l632;
+  l633:;	  G->pos= yypos633; G->thunkpos= yythunkpos633;
+  }  if (!yy__(G))  goto l612;
   yyDo(G, yy_17_Type, G->begin, G->end, "yy_17_Type");
-  if (!yymatchChar(G, ')')) goto l606;
+  if (!yymatchChar(G, ')')) goto l612;
 
   }
-  l607:;	  yyprintf((stderr, "  ok   Type"));
+  l613:;	  yyprintf((stderr, "  ok   Type"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l606:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
+  l612:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11135,13 +11224,13 @@ YY_RULE(int) yy_Type(GREG *G)
 }
 YY_RULE(int) yy_R_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "R_ARROW"));
-  if (!yymatchString(G, "->")) goto l633;
+  if (!yymatchString(G, "->")) goto l639;
   yyprintf((stderr, "  ok   R_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l633:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
+  l639:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11151,45 +11240,45 @@ YY_RULE(int) yy_Argument(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Argument"));
 
-  {  int yypos635= G->pos, yythunkpos635= G->thunkpos;  if (!yy_DOT(G))  goto l636;
-  if (!yy_IDENT(G))  goto l636;
+  {  int yypos641= G->pos, yythunkpos641= G->thunkpos;  if (!yy_DOT(G))  goto l642;
+  if (!yy_IDENT(G))  goto l642;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l636;
+  if (!yy__(G))  goto l642;
   yyDo(G, yy_1_Argument, G->begin, G->end, "yy_1_Argument");
-  goto l635;
-  l636:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;  if (!yy_ASS(G))  goto l637;
-  if (!yy_IDENT(G))  goto l637;
+  goto l641;
+  l642:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_ASS(G))  goto l643;
+  if (!yy_IDENT(G))  goto l643;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l637;
+  if (!yy__(G))  goto l643;
   yyDo(G, yy_2_Argument, G->begin, G->end, "yy_2_Argument");
-  goto l635;
-  l637:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;  if (!yy_VariableDecl(G))  goto l638;
+  goto l641;
+  l643:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_VariableDecl(G))  goto l644;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_Argument, G->begin, G->end, "yy_3_Argument");
-  goto l635;
-  l638:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;  if (!yy_IDENT(G))  goto l639;
+  goto l641;
+  l644:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_IDENT(G))  goto l645;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l639;
-  if (!yymatchChar(G, ':')) goto l639;
-  if (!yy__(G))  goto l639;
-  if (!yymatchString(G, "...")) goto l639;
-  if (!yy__(G))  goto l639;
+  if (!yy__(G))  goto l645;
+  if (!yymatchChar(G, ':')) goto l645;
+  if (!yy__(G))  goto l645;
+  if (!yymatchString(G, "...")) goto l645;
+  if (!yy__(G))  goto l645;
   yyDo(G, yy_4_Argument, G->begin, G->end, "yy_4_Argument");
-  goto l635;
-  l639:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;  if (!yy_Type(G))  goto l640;
+  goto l641;
+  l645:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_Type(G))  goto l646;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_Argument, G->begin, G->end, "yy_5_Argument");
-  goto l635;
-  l640:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;  if (!yymatchString(G, "...")) goto l634;
+  goto l641;
+  l646:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yymatchString(G, "...")) goto l640;
   yyDo(G, yy_6_Argument, G->begin, G->end, "yy_6_Argument");
 
   }
-  l635:;	  yyprintf((stderr, "  ok   Argument"));
+  l641:;	  yyprintf((stderr, "  ok   Argument"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l634:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
+  l640:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11198,13 +11287,13 @@ YY_RULE(int) yy_Argument(GREG *G)
 YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "AnonymousFunctionDecl"));
   yyDo(G, yy_1_AnonymousFunctionDecl, G->begin, G->end, "yy_1_AnonymousFunctionDecl");
-  if (!yy_FunctionDeclCore(G))  goto l641;
+  if (!yy_FunctionDeclCore(G))  goto l647;
   yyprintf((stderr, "  ok   AnonymousFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l641:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
+  l647:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11213,30 +11302,30 @@ YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclCore"));
-  if (!yy__(G))  goto l642;
-  if (!yy_FUNC_KW(G))  goto l642;
+  if (!yy__(G))  goto l648;
+  if (!yy_FUNC_KW(G))  goto l648;
 
-  {  int yypos643= G->pos, yythunkpos643= G->thunkpos;  if (!yymatchChar(G, '@')) goto l643;
+  {  int yypos649= G->pos, yythunkpos649= G->thunkpos;  if (!yymatchChar(G, '@')) goto l649;
   yyDo(G, yy_1_FunctionDeclCore, G->begin, G->end, "yy_1_FunctionDeclCore");
-  goto l644;
-  l643:;	  G->pos= yypos643; G->thunkpos= yythunkpos643;
+  goto l650;
+  l649:;	  G->pos= yypos649; G->thunkpos= yythunkpos649;
   }
-  l644:;	
-  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yy__(G))  goto l645;
-  if (!yymatchChar(G, '~')) goto l645;
-  if (!yy_IDENT(G))  goto l645;
+  l650:;	
+  {  int yypos651= G->pos, yythunkpos651= G->thunkpos;  if (!yy__(G))  goto l651;
+  if (!yymatchChar(G, '~')) goto l651;
+  if (!yy_IDENT(G))  goto l651;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_FunctionDeclCore, G->begin, G->end, "yy_2_FunctionDeclCore");
-  goto l646;
-  l645:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;
+  goto l652;
+  l651:;	  G->pos= yypos651; G->thunkpos= yythunkpos651;
   }
-  l646:;	  if (!yy_FunctionDeclBody(G))  goto l642;
+  l652:;	  if (!yy_FunctionDeclBody(G))  goto l648;
   yyprintf((stderr, "  ok   FunctionDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l642:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
+  l648:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11244,13 +11333,13 @@ YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 }
 YY_RULE(int) yy_PROTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROTO_KW"));
-  if (!yymatchString(G, "proto")) goto l647;
+  if (!yymatchString(G, "proto")) goto l653;
   yyprintf((stderr, "  ok   PROTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l647:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
+  l653:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11258,13 +11347,13 @@ YY_RULE(int) yy_PROTO_KW(GREG *G)
 }
 YY_RULE(int) yy_FINAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FINAL_KW"));
-  if (!yymatchString(G, "final")) goto l648;
+  if (!yymatchString(G, "final")) goto l654;
   yyprintf((stderr, "  ok   FINAL_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l648:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
+  l654:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11272,13 +11361,13 @@ YY_RULE(int) yy_FINAL_KW(GREG *G)
 }
 YY_RULE(int) yy_INLINE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INLINE_KW"));
-  if (!yymatchString(G, "inline")) goto l649;
+  if (!yymatchString(G, "inline")) goto l655;
   yyprintf((stderr, "  ok   INLINE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l649:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
+  l655:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11286,13 +11375,13 @@ YY_RULE(int) yy_INLINE_KW(GREG *G)
 }
 YY_RULE(int) yy_STATIC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STATIC_KW"));
-  if (!yymatchString(G, "static")) goto l650;
+  if (!yymatchString(G, "static")) goto l656;
   yyprintf((stderr, "  ok   STATIC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l650:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
+  l656:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11301,26 +11390,26 @@ YY_RULE(int) yy_STATIC_KW(GREG *G)
 YY_RULE(int) yy_UnmangledName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "UnmangledName"));
-  if (!yy_UNMANGLED_KW(G))  goto l651;
+  if (!yy_UNMANGLED_KW(G))  goto l657;
   yyDo(G, yy_1_UnmangledName, G->begin, G->end, "yy_1_UnmangledName");
 
-  {  int yypos652= G->pos, yythunkpos652= G->thunkpos;  if (!yy__(G))  goto l652;
-  if (!yymatchChar(G, '(')) goto l652;
-  if (!yy__(G))  goto l652;
-  if (!yy_IDENT(G))  goto l652;
+  {  int yypos658= G->pos, yythunkpos658= G->thunkpos;  if (!yy__(G))  goto l658;
+  if (!yymatchChar(G, '(')) goto l658;
+  if (!yy__(G))  goto l658;
+  if (!yy_IDENT(G))  goto l658;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_UnmangledName, G->begin, G->end, "yy_2_UnmangledName");
-  if (!yy__(G))  goto l652;
-  if (!yymatchChar(G, ')')) goto l652;
-  goto l653;
-  l652:;	  G->pos= yypos652; G->thunkpos= yythunkpos652;
+  if (!yy__(G))  goto l658;
+  if (!yymatchChar(G, ')')) goto l658;
+  goto l659;
+  l658:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;
   }
-  l653:;	  yyprintf((stderr, "  ok   UnmangledName"));
+  l659:;	  yyprintf((stderr, "  ok   UnmangledName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l651:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
+  l657:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11328,30 +11417,30 @@ YY_RULE(int) yy_UnmangledName(GREG *G)
 }
 YY_RULE(int) yy_ExternName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ExternName"));
-  if (!yy_EXTERN_KW(G))  goto l654;
+  if (!yy_EXTERN_KW(G))  goto l660;
   yyDo(G, yy_1_ExternName, G->begin, G->end, "yy_1_ExternName");
 
-  {  int yypos655= G->pos, yythunkpos655= G->thunkpos;  if (!yy__(G))  goto l655;
-  if (!yymatchChar(G, '(')) goto l655;
-  if (!yy__(G))  goto l655;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l655;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l655;
+  {  int yypos661= G->pos, yythunkpos661= G->thunkpos;  if (!yy__(G))  goto l661;
+  if (!yymatchChar(G, '(')) goto l661;
+  if (!yy__(G))  goto l661;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l661;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l661;
 
-  l657:;	
-  {  int yypos658= G->pos, yythunkpos658= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l658;
-  goto l657;
-  l658:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l655;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
-  if (!yy__(G))  goto l655;
-  if (!yymatchChar(G, ')')) goto l655;
-  goto l656;
-  l655:;	  G->pos= yypos655; G->thunkpos= yythunkpos655;
+  l663:;	
+  {  int yypos664= G->pos, yythunkpos664= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l664;
+  goto l663;
+  l664:;	  G->pos= yypos664; G->thunkpos= yythunkpos664;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l661;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
+  if (!yy__(G))  goto l661;
+  if (!yymatchChar(G, ')')) goto l661;
+  goto l662;
+  l661:;	  G->pos= yypos661; G->thunkpos= yythunkpos661;
   }
-  l656:;	  yyprintf((stderr, "  ok   ExternName"));
+  l662:;	  yyprintf((stderr, "  ok   ExternName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l654:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
+  l660:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11360,17 +11449,17 @@ YY_RULE(int) yy_ExternName(GREG *G)
 YY_RULE(int) yy_OocDoc(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDoc"));
 
-  {  int yypos660= G->pos, yythunkpos660= G->thunkpos;  if (!yy_OocDocCore(G))  goto l661;
-  goto l660;
-  l661:;	  G->pos= yypos660; G->thunkpos= yythunkpos660;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
+  {  int yypos666= G->pos, yythunkpos666= G->thunkpos;  if (!yy_OocDocCore(G))  goto l667;
+  goto l666;
+  l667:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
 
   }
-  l660:;	  yyprintf((stderr, "  ok   OocDoc"));
+  l666:;	  yyprintf((stderr, "  ok   OocDoc"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l659:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
+  l665:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11378,13 +11467,13 @@ YY_RULE(int) yy_OocDoc(GREG *G)
 }
 YY_RULE(int) yy_FUNC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FUNC_KW"));
-  if (!yymatchString(G, "func")) goto l662;
+  if (!yymatchString(G, "func")) goto l668;
   yyprintf((stderr, "  ok   FUNC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l662:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
+  l668:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11393,20 +11482,20 @@ YY_RULE(int) yy_FUNC_KW(GREG *G)
 YY_RULE(int) yy_COLON(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COLON"));
 
-  {  int yypos664= G->pos, yythunkpos664= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l664;
-  goto l663;
-  l664:;	  G->pos= yypos664; G->thunkpos= yythunkpos664;
+  {  int yypos670= G->pos, yythunkpos670= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l670;
+  goto l669;
+  l670:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;
   }
-  {  int yypos665= G->pos, yythunkpos665= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l665;
-  goto l663;
-  l665:;	  G->pos= yypos665; G->thunkpos= yythunkpos665;
-  }  if (!yymatchChar(G, ':')) goto l663;
+  {  int yypos671= G->pos, yythunkpos671= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l671;
+  goto l669;
+  l671:;	  G->pos= yypos671; G->thunkpos= yythunkpos671;
+  }  if (!yymatchChar(G, ':')) goto l669;
   yyprintf((stderr, "  ok   COLON"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l663:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
+  l669:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11415,50 +11504,50 @@ YY_RULE(int) yy_COLON(GREG *G)
 YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "RegularFunctionDecl"));
-  if (!yy_OocDoc(G))  goto l666;
+  if (!yy_OocDoc(G))  goto l672;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l666;
+  if (!yy_IDENT(G))  goto l672;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_RegularFunctionDecl, G->begin, G->end, "yy_1_RegularFunctionDecl");
-  if (!yy__(G))  goto l666;
-  if (!yy_COLON(G))  goto l666;
+  if (!yy__(G))  goto l672;
+  if (!yy_COLON(G))  goto l672;
 
-  l667:;	
-  {  int yypos668= G->pos, yythunkpos668= G->thunkpos;  if (!yy__(G))  goto l668;
+  l673:;	
+  {  int yypos674= G->pos, yythunkpos674= G->thunkpos;  if (!yy__(G))  goto l674;
 
-  {  int yypos669= G->pos, yythunkpos669= G->thunkpos;  if (!yy_ExternName(G))  goto l670;
+  {  int yypos675= G->pos, yythunkpos675= G->thunkpos;  if (!yy_ExternName(G))  goto l676;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_RegularFunctionDecl, G->begin, G->end, "yy_2_RegularFunctionDecl");
-  goto l669;
-  l670:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;  if (!yy_UnmangledName(G))  goto l671;
+  goto l675;
+  l676:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_UnmangledName(G))  goto l677;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_RegularFunctionDecl, G->begin, G->end, "yy_3_RegularFunctionDecl");
-  goto l669;
-  l671:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;  if (!yy_ABSTRACT_KW(G))  goto l672;
+  goto l675;
+  l677:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_ABSTRACT_KW(G))  goto l678;
   yyDo(G, yy_4_RegularFunctionDecl, G->begin, G->end, "yy_4_RegularFunctionDecl");
-  goto l669;
-  l672:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;  if (!yy_STATIC_KW(G))  goto l673;
+  goto l675;
+  l678:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_STATIC_KW(G))  goto l679;
   yyDo(G, yy_5_RegularFunctionDecl, G->begin, G->end, "yy_5_RegularFunctionDecl");
-  goto l669;
-  l673:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;  if (!yy_INLINE_KW(G))  goto l674;
+  goto l675;
+  l679:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_INLINE_KW(G))  goto l680;
   yyDo(G, yy_6_RegularFunctionDecl, G->begin, G->end, "yy_6_RegularFunctionDecl");
-  goto l669;
-  l674:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;  if (!yy_FINAL_KW(G))  goto l675;
+  goto l675;
+  l680:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_FINAL_KW(G))  goto l681;
   yyDo(G, yy_7_RegularFunctionDecl, G->begin, G->end, "yy_7_RegularFunctionDecl");
-  goto l669;
-  l675:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;  if (!yy_PROTO_KW(G))  goto l668;
+  goto l675;
+  l681:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_PROTO_KW(G))  goto l674;
   yyDo(G, yy_8_RegularFunctionDecl, G->begin, G->end, "yy_8_RegularFunctionDecl");
 
   }
-  l669:;	  goto l667;
-  l668:;	  G->pos= yypos668; G->thunkpos= yythunkpos668;
-  }  if (!yy_FunctionDeclCore(G))  goto l666;
+  l675:;	  goto l673;
+  l674:;	  G->pos= yypos674; G->thunkpos= yythunkpos674;
+  }  if (!yy_FunctionDeclCore(G))  goto l672;
   yyprintf((stderr, "  ok   RegularFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l666:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
+  l672:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11467,32 +11556,32 @@ YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 YY_RULE(int) yy_SuperFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "SuperFunctionDecl"));
-  if (!yy_IDENT(G))  goto l676;
+  if (!yy_IDENT(G))  goto l682;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l676;
-  if (!yy_COLON(G))  goto l676;
-  if (!yy__(G))  goto l676;
-  if (!yymatchString(G, "super")) goto l676;
-  if (!yy__(G))  goto l676;
-  if (!yy_FUNC_KW(G))  goto l676;
-  if (!yy__(G))  goto l676;
+  if (!yy__(G))  goto l682;
+  if (!yy_COLON(G))  goto l682;
+  if (!yy__(G))  goto l682;
+  if (!yymatchString(G, "super")) goto l682;
+  if (!yy__(G))  goto l682;
+  if (!yy_FUNC_KW(G))  goto l682;
+  if (!yy__(G))  goto l682;
   yyDo(G, yy_1_SuperFunctionDecl, G->begin, G->end, "yy_1_SuperFunctionDecl");
 
-  {  int yypos677= G->pos, yythunkpos677= G->thunkpos;  if (!yy__(G))  goto l677;
-  if (!yymatchChar(G, '~')) goto l677;
-  if (!yy_IDENT(G))  goto l677;
+  {  int yypos683= G->pos, yythunkpos683= G->thunkpos;  if (!yy__(G))  goto l683;
+  if (!yymatchChar(G, '~')) goto l683;
+  if (!yy_IDENT(G))  goto l683;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_SuperFunctionDecl, G->begin, G->end, "yy_2_SuperFunctionDecl");
-  goto l678;
-  l677:;	  G->pos= yypos677; G->thunkpos= yythunkpos677;
+  goto l684;
+  l683:;	  G->pos= yypos683; G->thunkpos= yythunkpos683;
   }
-  l678:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
+  l684:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
   yyprintf((stderr, "  ok   SuperFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l676:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
+  l682:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11502,87 +11591,87 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclBody"));
 
-  {  int yypos680= G->pos, yythunkpos680= G->thunkpos;  if (!yy_GenericArguments(G))  goto l680;
-  goto l681;
-  l680:;	  G->pos= yypos680; G->thunkpos= yythunkpos680;
+  {  int yypos686= G->pos, yythunkpos686= G->thunkpos;  if (!yy_GenericArguments(G))  goto l686;
+  goto l687;
+  l686:;	  G->pos= yypos686; G->thunkpos= yythunkpos686;
   }
-  l681:;	
-  {  int yypos682= G->pos, yythunkpos682= G->thunkpos;  if (!yy_WS(G))  goto l682;
-  if (!yymatchChar(G, '(')) goto l682;
+  l687:;	
+  {  int yypos688= G->pos, yythunkpos688= G->thunkpos;  if (!yy_WS(G))  goto l688;
+  if (!yymatchChar(G, '(')) goto l688;
   yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end, "yy_1_FunctionDeclBody");
 
-  {  int yypos684= G->pos, yythunkpos684= G->thunkpos;  if (!yy_WS(G))  goto l684;
-  if (!yy_Argument(G))  goto l684;
-  if (!yy_WS(G))  goto l684;
+  {  int yypos690= G->pos, yythunkpos690= G->thunkpos;  if (!yy_WS(G))  goto l690;
+  if (!yy_Argument(G))  goto l690;
+  if (!yy_WS(G))  goto l690;
 
-  l686:;	
-  {  int yypos687= G->pos, yythunkpos687= G->thunkpos;  if (!yymatchChar(G, ',')) goto l687;
-  if (!yy_WS(G))  goto l687;
-  if (!yy_Argument(G))  goto l687;
-  if (!yy_WS(G))  goto l687;
-  goto l686;
-  l687:;	  G->pos= yypos687; G->thunkpos= yythunkpos687;
-  }  goto l685;
-  l684:;	  G->pos= yypos684; G->thunkpos= yythunkpos684;
+  l692:;	
+  {  int yypos693= G->pos, yythunkpos693= G->thunkpos;  if (!yymatchChar(G, ',')) goto l693;
+  if (!yy_WS(G))  goto l693;
+  if (!yy_Argument(G))  goto l693;
+  if (!yy_WS(G))  goto l693;
+  goto l692;
+  l693:;	  G->pos= yypos693; G->thunkpos= yythunkpos693;
+  }  goto l691;
+  l690:;	  G->pos= yypos690; G->thunkpos= yythunkpos690;
   }
-  l685:;	  if (!yy_WS(G))  goto l682;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l682; }
+  l691:;	  if (!yy_WS(G))  goto l688;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l688; }
   yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end, "yy_2_FunctionDeclBody");
-  goto l683;
-  l682:;	  G->pos= yypos682; G->thunkpos= yythunkpos682;
-  }
-  l683:;	
-  {  int yypos688= G->pos, yythunkpos688= G->thunkpos;  if (!yy__(G))  goto l688;
-  if (!yymatchChar(G, '~')) goto l688;
-  if (!yy_IDENT(G))  goto l688;
-  yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end, "yy_3_FunctionDeclBody");
   goto l689;
   l688:;	  G->pos= yypos688; G->thunkpos= yythunkpos688;
   }
   l689:;	
-  {  int yypos690= G->pos, yythunkpos690= G->thunkpos;  if (!yy__(G))  goto l690;
-  if (!yy_R_ARROW(G))  goto l690;
-  if (!yy__(G))  goto l690;
-  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l690; }
+  {  int yypos694= G->pos, yythunkpos694= G->thunkpos;  if (!yy__(G))  goto l694;
+  if (!yymatchChar(G, '~')) goto l694;
+  if (!yy_IDENT(G))  goto l694;
+  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end, "yy_3_FunctionDeclBody");
+  goto l695;
+  l694:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;
+  }
+  l695:;	
+  {  int yypos696= G->pos, yythunkpos696= G->thunkpos;  if (!yy__(G))  goto l696;
+  if (!yy_R_ARROW(G))  goto l696;
+  if (!yy__(G))  goto l696;
+  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l696; }
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end, "yy_4_FunctionDeclBody");
-  goto l691;
-  l690:;	  G->pos= yypos690; G->thunkpos= yythunkpos690;
+  goto l697;
+  l696:;	  G->pos= yypos696; G->thunkpos= yythunkpos696;
   }
-  l691:;	
-  {  int yypos692= G->pos, yythunkpos692= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
-  if (!yy_WS(G))  goto l692;
-  if (!yymatchChar(G, '{')) goto l692;
-  if (!yy_WS(G))  goto l692;
+  l697:;	
+  {  int yypos698= G->pos, yythunkpos698= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
+  if (!yy_WS(G))  goto l698;
+  if (!yymatchChar(G, '{')) goto l698;
+  if (!yy_WS(G))  goto l698;
 
-  l694:;	
-  {  int yypos695= G->pos, yythunkpos695= G->thunkpos;  if (!yy_WS(G))  goto l695;
+  l700:;	
+  {  int yypos701= G->pos, yythunkpos701= G->thunkpos;  if (!yy_WS(G))  goto l701;
 
-  {  int yypos696= G->pos, yythunkpos696= G->thunkpos;  if (!yy_Stmt(G))  goto l697;
+  {  int yypos702= G->pos, yythunkpos702= G->thunkpos;  if (!yy_Stmt(G))  goto l703;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end, "yy_6_FunctionDeclBody");
-  goto l696;
-  l697:;	  G->pos= yypos696; G->thunkpos= yythunkpos696;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
-  if (!yy_OocDocCore(G))  goto l695;
+  goto l702;
+  l703:;	  G->pos= yypos702; G->thunkpos= yythunkpos702;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
+  if (!yy_OocDocCore(G))  goto l701;
   yyDo(G, yy_8_FunctionDeclBody, G->begin, G->end, "yy_8_FunctionDeclBody");
 
   }
-  l696:;	  if (!yy_WS(G))  goto l695;
-  goto l694;
-  l695:;	  G->pos= yypos695; G->thunkpos= yythunkpos695;
-  }  if (!yy_WS(G))  goto l692;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l692; }
-  goto l693;
-  l692:;	  G->pos= yypos692; G->thunkpos= yythunkpos692;
+  l702:;	  if (!yy_WS(G))  goto l701;
+  goto l700;
+  l701:;	  G->pos= yypos701; G->thunkpos= yythunkpos701;
+  }  if (!yy_WS(G))  goto l698;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l698; }
+  goto l699;
+  l698:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;
   }
-  l693:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
+  l699:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
   yyprintf((stderr, "  ok   FunctionDeclBody"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l679:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
+  l685:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11590,13 +11679,13 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 }
 YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ABSTRACT_KW"));
-  if (!yymatchString(G, "abstract")) goto l698;
+  if (!yymatchString(G, "abstract")) goto l704;
   yyprintf((stderr, "  ok   ABSTRACT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l698:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
+  l704:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11604,13 +11693,13 @@ YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 }
 YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OPERATOR_KW"));
-  if (!yymatchString(G, "operator")) goto l699;
+  if (!yymatchString(G, "operator")) goto l705;
   yyprintf((stderr, "  ok   OPERATOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l699:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
+  l705:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11618,18 +11707,18 @@ YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 }
 YY_RULE(int) yy_TemplateDef(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TemplateDef"));
-  if (!yy_WS(G))  goto l700;
-  if (!yymatchString(G, "template")) goto l700;
-  if (!yy_WS(G))  goto l700;
+  if (!yy_WS(G))  goto l706;
+  if (!yymatchString(G, "template")) goto l706;
+  if (!yy_WS(G))  goto l706;
   yyDo(G, yy_1_TemplateDef, G->begin, G->end, "yy_1_TemplateDef");
-  if (!yy_GenericArguments(G))  goto l700;
+  if (!yy_GenericArguments(G))  goto l706;
   yyDo(G, yy_2_TemplateDef, G->begin, G->end, "yy_2_TemplateDef");
   yyprintf((stderr, "  ok   TemplateDef"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l700:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
+  l706:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11637,23 +11726,23 @@ YY_RULE(int) yy_TemplateDef(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN"));
-  if (!yymatchChar(G, '>')) goto l701;
+  if (!yymatchChar(G, '>')) goto l707;
 
-  {  int yypos702= G->pos, yythunkpos702= G->thunkpos;
-  {  int yypos703= G->pos, yythunkpos703= G->thunkpos;  if (!yymatchChar(G, '=')) goto l704;
-  goto l703;
-  l704:;	  G->pos= yypos703; G->thunkpos= yythunkpos703;  if (!yymatchChar(G, '>')) goto l702;
+  {  int yypos708= G->pos, yythunkpos708= G->thunkpos;
+  {  int yypos709= G->pos, yythunkpos709= G->thunkpos;  if (!yymatchChar(G, '=')) goto l710;
+  goto l709;
+  l710:;	  G->pos= yypos709; G->thunkpos= yythunkpos709;  if (!yymatchChar(G, '>')) goto l708;
 
   }
-  l703:;	  goto l701;
-  l702:;	  G->pos= yypos702; G->thunkpos= yythunkpos702;
-  }  if (!yy__(G))  goto l701;
+  l709:;	  goto l707;
+  l708:;	  G->pos= yypos708; G->thunkpos= yythunkpos708;
+  }  if (!yy__(G))  goto l707;
   yyprintf((stderr, "  ok   MORETHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l701:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
+  l707:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11661,23 +11750,23 @@ YY_RULE(int) yy_MORETHAN(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN"));
-  if (!yymatchChar(G, '<')) goto l705;
+  if (!yymatchChar(G, '<')) goto l711;
 
-  {  int yypos706= G->pos, yythunkpos706= G->thunkpos;
-  {  int yypos707= G->pos, yythunkpos707= G->thunkpos;  if (!yymatchChar(G, '=')) goto l708;
-  goto l707;
-  l708:;	  G->pos= yypos707; G->thunkpos= yythunkpos707;  if (!yymatchChar(G, '<')) goto l706;
+  {  int yypos712= G->pos, yythunkpos712= G->thunkpos;
+  {  int yypos713= G->pos, yythunkpos713= G->thunkpos;  if (!yymatchChar(G, '=')) goto l714;
+  goto l713;
+  l714:;	  G->pos= yypos713; G->thunkpos= yythunkpos713;  if (!yymatchChar(G, '<')) goto l712;
 
   }
-  l707:;	  goto l705;
-  l706:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;
-  }  if (!yy__(G))  goto l705;
+  l713:;	  goto l711;
+  l712:;	  G->pos= yypos712; G->thunkpos= yythunkpos712;
+  }  if (!yy__(G))  goto l711;
   yyprintf((stderr, "  ok   LESSTHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l705:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
+  l711:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11686,30 +11775,30 @@ YY_RULE(int) yy_LESSTHAN(GREG *G)
 YY_RULE(int) yy_GenericArguments(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericArguments"));
-  if (!yy__(G))  goto l709;
-  if (!yy_LESSTHAN(G))  goto l709;
-  if (!yy__(G))  goto l709;
-  if (!yy_IDENT(G))  goto l709;
+  if (!yy__(G))  goto l715;
+  if (!yy_LESSTHAN(G))  goto l715;
+  if (!yy__(G))  goto l715;
+  if (!yy_IDENT(G))  goto l715;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_GenericArguments, G->begin, G->end, "yy_1_GenericArguments");
 
-  l710:;	
-  {  int yypos711= G->pos, yythunkpos711= G->thunkpos;  if (!yy__(G))  goto l711;
-  if (!yymatchChar(G, ',')) goto l711;
-  if (!yy__(G))  goto l711;
-  if (!yy_IDENT(G))  goto l711;
+  l716:;	
+  {  int yypos717= G->pos, yythunkpos717= G->thunkpos;  if (!yy__(G))  goto l717;
+  if (!yymatchChar(G, ',')) goto l717;
+  if (!yy__(G))  goto l717;
+  if (!yy_IDENT(G))  goto l717;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_GenericArguments, G->begin, G->end, "yy_2_GenericArguments");
-  goto l710;
-  l711:;	  G->pos= yypos711; G->thunkpos= yythunkpos711;
-  }  if (!yy_MORETHAN(G))  goto l709;
-  if (!yy__(G))  goto l709;
+  goto l716;
+  l717:;	  G->pos= yypos717; G->thunkpos= yythunkpos717;
+  }  if (!yy_MORETHAN(G))  goto l715;
+  if (!yy__(G))  goto l715;
   yyprintf((stderr, "  ok   GenericArguments"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l709:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
+  l715:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11718,27 +11807,27 @@ YY_RULE(int) yy_GenericArguments(GREG *G)
 YY_RULE(int) yy_Terminator(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Terminator"));
 
-  {  int yypos713= G->pos, yythunkpos713= G->thunkpos;  if (!yy_CommentLine(G))  goto l714;
-  goto l713;
-  l714:;	  G->pos= yypos713; G->thunkpos= yythunkpos713;
-  {  int yypos715= G->pos, yythunkpos715= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l715;
-  goto l716;
-  l715:;	  G->pos= yypos715; G->thunkpos= yythunkpos715;
+  {  int yypos719= G->pos, yythunkpos719= G->thunkpos;  if (!yy_CommentLine(G))  goto l720;
+  goto l719;
+  l720:;	  G->pos= yypos719; G->thunkpos= yythunkpos719;
+  {  int yypos721= G->pos, yythunkpos721= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l721;
+  goto l722;
+  l721:;	  G->pos= yypos721; G->thunkpos= yythunkpos721;
   }
-  l716:;	
-  {  int yypos717= G->pos, yythunkpos717= G->thunkpos;  if (!yy_EOL(G))  goto l718;
-  goto l717;
-  l718:;	  G->pos= yypos717; G->thunkpos= yythunkpos717;  if (!yymatchChar(G, ';')) goto l712;
+  l722:;	
+  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_EOL(G))  goto l724;
+  goto l723;
+  l724:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;  if (!yymatchChar(G, ';')) goto l718;
 
   }
-  l717:;	
+  l723:;	
   }
-  l713:;	  yyprintf((stderr, "  ok   Terminator"));
+  l719:;	  yyprintf((stderr, "  ok   Terminator"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l712:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
+  l718:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11748,21 +11837,21 @@ YY_RULE(int) yy_VariableDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VariableDecl"));
 
-  {  int yypos720= G->pos, yythunkpos720= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l721;
+  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l727;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_VariableDecl, G->begin, G->end, "yy_1_VariableDecl");
-  goto l720;
-  l721:;	  G->pos= yypos720; G->thunkpos= yythunkpos720;  if (!yy_ConventionalVarDecl(G))  goto l719;
+  goto l726;
+  l727:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;  if (!yy_ConventionalVarDecl(G))  goto l725;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VariableDecl, G->begin, G->end, "yy_2_VariableDecl");
 
   }
-  l720:;	  yyprintf((stderr, "  ok   VariableDecl"));
+  l726:;	  yyprintf((stderr, "  ok   VariableDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l719:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
+  l725:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11772,21 +11861,21 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDecl"));
 
-  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l724;
+  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l730;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_PropertyDecl, G->begin, G->end, "yy_1_PropertyDecl");
-  goto l723;
-  l724:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;  if (!yy_ConventionalPropertyDecl(G))  goto l722;
+  goto l729;
+  l730:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;  if (!yy_ConventionalPropertyDecl(G))  goto l728;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_PropertyDecl, G->begin, G->end, "yy_2_PropertyDecl");
 
   }
-  l723:;	  yyprintf((stderr, "  ok   PropertyDecl"));
+  l729:;	  yyprintf((stderr, "  ok   PropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l722:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
+  l728:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11795,17 +11884,17 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 YY_RULE(int) yy_FunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FunctionDecl"));
 
-  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l727;
-  goto l726;
-  l727:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;  if (!yy_RegularFunctionDecl(G))  goto l725;
+  {  int yypos732= G->pos, yythunkpos732= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l733;
+  goto l732;
+  l733:;	  G->pos= yypos732; G->thunkpos= yythunkpos732;  if (!yy_RegularFunctionDecl(G))  goto l731;
 
   }
-  l726:;	  yyprintf((stderr, "  ok   FunctionDecl"));
+  l732:;	  yyprintf((stderr, "  ok   FunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l725:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
+  l731:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11814,115 +11903,115 @@ YY_RULE(int) yy_FunctionDecl(GREG *G)
 YY_RULE(int) yy_OperatorDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OperatorDecl"));
 
-  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l730;
+  {  int yypos735= G->pos, yythunkpos735= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l736;
   yyDo(G, yy_1_OperatorDecl, G->begin, G->end, "yy_1_OperatorDecl");
-  goto l729;
-  l730:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;  if (!yy_ABSTRACT_KW(G))  goto l728;
-  if (!yy__(G))  goto l728;
-  if (!yy_OPERATOR_KW(G))  goto l728;
+  goto l735;
+  l736:;	  G->pos= yypos735; G->thunkpos= yythunkpos735;  if (!yy_ABSTRACT_KW(G))  goto l734;
+  if (!yy__(G))  goto l734;
+  if (!yy_OPERATOR_KW(G))  goto l734;
   yyDo(G, yy_2_OperatorDecl, G->begin, G->end, "yy_2_OperatorDecl");
 
   }
-  l729:;	  if (!yy__(G))  goto l728;
+  l735:;	  if (!yy__(G))  goto l734;
 
-  {  int yypos731= G->pos, yythunkpos731= G->thunkpos;  if (!yymatchChar(G, '@')) goto l731;
+  {  int yypos737= G->pos, yythunkpos737= G->thunkpos;  if (!yymatchChar(G, '@')) goto l737;
   yyDo(G, yy_3_OperatorDecl, G->begin, G->end, "yy_3_OperatorDecl");
-  goto l732;
-  l731:;	  G->pos= yypos731; G->thunkpos= yythunkpos731;
+  goto l738;
+  l737:;	  G->pos= yypos737; G->thunkpos= yythunkpos737;
   }
-  l732:;	  if (!yy__(G))  goto l728;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l728;
-  {  int yypos733= G->pos, yythunkpos733= G->thunkpos;  if (!yymatchString(G, "=>")) goto l734;
-  goto l733;
-  l734:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "<=>")) goto l735;
-  goto l733;
-  l735:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, ">>=")) goto l736;
-  goto l733;
-  l736:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "<<=")) goto l737;
-  goto l733;
-  l737:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, ">>")) goto l738;
-  goto l733;
-  l738:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "<<")) goto l739;
-  goto l733;
-  l739:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, ">=")) goto l740;
-  goto l733;
-  l740:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "<=")) goto l741;
-  goto l733;
-  l741:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "!=")) goto l742;
-  goto l733;
-  l742:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "==")) goto l743;
-  goto l733;
-  l743:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '>')) goto l744;
-  goto l733;
-  l744:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '<')) goto l745;
-  goto l733;
-  l745:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '!')) goto l746;
-  goto l733;
-  l746:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "??")) goto l747;
-  goto l733;
-  l747:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "+=")) goto l748;
-  goto l733;
-  l748:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "-=")) goto l749;
-  goto l733;
-  l749:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "*=")) goto l750;
-  goto l733;
-  l750:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "**=")) goto l751;
-  goto l733;
-  l751:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "/=")) goto l752;
-  goto l733;
-  l752:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "%=")) goto l753;
-  goto l733;
-  l753:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '+')) goto l754;
-  goto l733;
-  l754:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '-')) goto l755;
-  goto l733;
-  l755:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "**")) goto l756;
-  goto l733;
-  l756:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '/')) goto l757;
-  goto l733;
-  l757:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '*')) goto l758;
-  goto l733;
-  l758:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '=')) goto l759;
-  goto l733;
-  l759:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "[]=")) goto l760;
-  goto l733;
-  l760:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "[]")) goto l761;
-  goto l733;
-  l761:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "&&")) goto l762;
-  goto l733;
-  l762:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "||")) goto l763;
-  goto l733;
-  l763:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '%')) goto l764;
-  goto l733;
-  l764:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "as")) goto l765;
-  goto l733;
-  l765:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "implicit as")) goto l766;
-  goto l733;
-  l766:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "&=")) goto l767;
-  goto l733;
-  l767:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "|=")) goto l768;
-  goto l733;
-  l768:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchString(G, "^=")) goto l769;
-  goto l733;
-  l769:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '&')) goto l770;
-  goto l733;
-  l770:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '|')) goto l771;
-  goto l733;
-  l771:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '^')) goto l772;
-  goto l733;
-  l772:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yymatchChar(G, '~')) goto l728;
+  l738:;	  if (!yy__(G))  goto l734;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l734;
+  {  int yypos739= G->pos, yythunkpos739= G->thunkpos;  if (!yymatchString(G, "=>")) goto l740;
+  goto l739;
+  l740:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<=>")) goto l741;
+  goto l739;
+  l741:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">>=")) goto l742;
+  goto l739;
+  l742:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<<=")) goto l743;
+  goto l739;
+  l743:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">>")) goto l744;
+  goto l739;
+  l744:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<<")) goto l745;
+  goto l739;
+  l745:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">=")) goto l746;
+  goto l739;
+  l746:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<=")) goto l747;
+  goto l739;
+  l747:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "!=")) goto l748;
+  goto l739;
+  l748:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "==")) goto l749;
+  goto l739;
+  l749:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '>')) goto l750;
+  goto l739;
+  l750:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '<')) goto l751;
+  goto l739;
+  l751:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '!')) goto l752;
+  goto l739;
+  l752:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "??")) goto l753;
+  goto l739;
+  l753:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "+=")) goto l754;
+  goto l739;
+  l754:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "-=")) goto l755;
+  goto l739;
+  l755:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "*=")) goto l756;
+  goto l739;
+  l756:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "**=")) goto l757;
+  goto l739;
+  l757:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "/=")) goto l758;
+  goto l739;
+  l758:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "%=")) goto l759;
+  goto l739;
+  l759:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '+')) goto l760;
+  goto l739;
+  l760:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '-')) goto l761;
+  goto l739;
+  l761:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "**")) goto l762;
+  goto l739;
+  l762:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '/')) goto l763;
+  goto l739;
+  l763:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '*')) goto l764;
+  goto l739;
+  l764:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '=')) goto l765;
+  goto l739;
+  l765:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "[]=")) goto l766;
+  goto l739;
+  l766:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "[]")) goto l767;
+  goto l739;
+  l767:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "&&")) goto l768;
+  goto l739;
+  l768:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "||")) goto l769;
+  goto l739;
+  l769:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '%')) goto l770;
+  goto l739;
+  l770:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "as")) goto l771;
+  goto l739;
+  l771:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "implicit as")) goto l772;
+  goto l739;
+  l772:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "&=")) goto l773;
+  goto l739;
+  l773:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "|=")) goto l774;
+  goto l739;
+  l774:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "^=")) goto l775;
+  goto l739;
+  l775:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '&')) goto l776;
+  goto l739;
+  l776:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '|')) goto l777;
+  goto l739;
+  l777:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '^')) goto l778;
+  goto l739;
+  l778:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '~')) goto l734;
 
   }
-  l733:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l728;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
-  if (!yy__(G))  goto l728;
-  if (!yy_FunctionDeclBody(G))  goto l728;
+  l739:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l734;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
+  if (!yy__(G))  goto l734;
+  if (!yy_FunctionDeclBody(G))  goto l734;
   yyDo(G, yy_5_OperatorDecl, G->begin, G->end, "yy_5_OperatorDecl");
   yyprintf((stderr, "  ok   OperatorDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l728:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
+  l734:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11931,70 +12020,70 @@ YY_RULE(int) yy_OperatorDecl(GREG *G)
 YY_RULE(int) yy_InterfaceDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "InterfaceDecl"));
-  if (!yy_OocDoc(G))  goto l773;
+  if (!yy_OocDoc(G))  goto l779;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l773;
+  if (!yy_IDENT(G))  goto l779;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_InterfaceDecl, G->begin, G->end, "yy_1_InterfaceDecl");
-  if (!yy__(G))  goto l773;
-  if (!yy_COLON(G))  goto l773;
-  if (!yy__(G))  goto l773;
-  if (!yy_INTERFACE_KW(G))  goto l773;
+  if (!yy__(G))  goto l779;
+  if (!yy_COLON(G))  goto l779;
+  if (!yy__(G))  goto l779;
+  if (!yy_INTERFACE_KW(G))  goto l779;
 
-  {  int yypos774= G->pos, yythunkpos774= G->thunkpos;  if (!yy_GenericArguments(G))  goto l774;
-  goto l775;
-  l774:;	  G->pos= yypos774; G->thunkpos= yythunkpos774;
+  {  int yypos780= G->pos, yythunkpos780= G->thunkpos;  if (!yy_GenericArguments(G))  goto l780;
+  goto l781;
+  l780:;	  G->pos= yypos780; G->thunkpos= yythunkpos780;
   }
-  l775:;	
-  {  int yypos776= G->pos, yythunkpos776= G->thunkpos;  if (!yy__(G))  goto l776;
-  if (!yy_EXTENDS_KW(G))  goto l776;
-  if (!yy__(G))  goto l776;
-  if (!yy_Type(G))  goto l776;
+  l781:;	
+  {  int yypos782= G->pos, yythunkpos782= G->thunkpos;  if (!yy__(G))  goto l782;
+  if (!yy_EXTENDS_KW(G))  goto l782;
+  if (!yy__(G))  goto l782;
+  if (!yy_Type(G))  goto l782;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_InterfaceDecl, G->begin, G->end, "yy_2_InterfaceDecl");
-  goto l777;
-  l776:;	  G->pos= yypos776; G->thunkpos= yythunkpos776;
+  goto l783;
+  l782:;	  G->pos= yypos782; G->thunkpos= yythunkpos782;
   }
-  l777:;	
-  {  int yypos778= G->pos, yythunkpos778= G->thunkpos;  if (!yy__(G))  goto l778;
-  if (!yy_IMPLEMENTS_KW(G))  goto l778;
-  if (!yy__(G))  goto l778;
-  if (!yy_Type(G))  goto l778;
+  l783:;	
+  {  int yypos784= G->pos, yythunkpos784= G->thunkpos;  if (!yy__(G))  goto l784;
+  if (!yy_IMPLEMENTS_KW(G))  goto l784;
+  if (!yy__(G))  goto l784;
+  if (!yy_Type(G))  goto l784;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_InterfaceDecl, G->begin, G->end, "yy_3_InterfaceDecl");
 
-  l780:;	
-  {  int yypos781= G->pos, yythunkpos781= G->thunkpos;  if (!yy__(G))  goto l781;
-  if (!yymatchChar(G, ',')) goto l781;
-  if (!yy__(G))  goto l781;
-  if (!yy_Type(G))  goto l781;
+  l786:;	
+  {  int yypos787= G->pos, yythunkpos787= G->thunkpos;  if (!yy__(G))  goto l787;
+  if (!yymatchChar(G, ',')) goto l787;
+  if (!yy__(G))  goto l787;
+  if (!yy_Type(G))  goto l787;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_InterfaceDecl, G->begin, G->end, "yy_4_InterfaceDecl");
-  goto l780;
-  l781:;	  G->pos= yypos781; G->thunkpos= yythunkpos781;
-  }  goto l779;
-  l778:;	  G->pos= yypos778; G->thunkpos= yythunkpos778;
+  goto l786;
+  l787:;	  G->pos= yypos787; G->thunkpos= yythunkpos787;
+  }  goto l785;
+  l784:;	  G->pos= yypos784; G->thunkpos= yythunkpos784;
   }
-  l779:;	  if (!yy_WS(G))  goto l773;
-  if (!yymatchChar(G, '{')) goto l773;
-  if (!yy_WS(G))  goto l773;
+  l785:;	  if (!yy_WS(G))  goto l779;
+  if (!yymatchChar(G, '{')) goto l779;
+  if (!yy_WS(G))  goto l779;
 
-  l782:;	
-  {  int yypos783= G->pos, yythunkpos783= G->thunkpos;  if (!yy_WS(G))  goto l783;
-  if (!yy_FunctionDecl(G))  goto l783;
+  l788:;	
+  {  int yypos789= G->pos, yythunkpos789= G->thunkpos;  if (!yy_WS(G))  goto l789;
+  if (!yy_FunctionDecl(G))  goto l789;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l783;
-  goto l782;
-  l783:;	  G->pos= yypos783; G->thunkpos= yythunkpos783;
-  }  if (!yy_WS(G))  goto l773;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l773; }
+  if (!yy_WS(G))  goto l789;
+  goto l788;
+  l789:;	  G->pos= yypos789; G->thunkpos= yythunkpos789;
+  }  if (!yy_WS(G))  goto l779;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l779; }
   yyDo(G, yy_5_InterfaceDecl, G->begin, G->end, "yy_5_InterfaceDecl");
   yyprintf((stderr, "  ok   InterfaceDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l773:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
+  l779:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12003,86 +12092,86 @@ YY_RULE(int) yy_InterfaceDecl(GREG *G)
 YY_RULE(int) yy_EnumDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumDecl"));
-  if (!yy_OocDoc(G))  goto l784;
+  if (!yy_OocDoc(G))  goto l790;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l784;
+  if (!yy_IDENT(G))  goto l790;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_EnumDecl, G->begin, G->end, "yy_1_EnumDecl");
-  if (!yy__(G))  goto l784;
-  if (!yy_COLON(G))  goto l784;
-  if (!yy__(G))  goto l784;
-  if (!yy_ENUM_KW(G))  goto l784;
+  if (!yy__(G))  goto l790;
+  if (!yy_COLON(G))  goto l790;
+  if (!yy__(G))  goto l790;
+  if (!yy_ENUM_KW(G))  goto l790;
 
-  {  int yypos785= G->pos, yythunkpos785= G->thunkpos;  if (!yy__(G))  goto l785;
-  if (!yy_FROM_KW(G))  goto l785;
-  if (!yy__(G))  goto l785;
-  if (!yy_Type(G))  goto l785;
+  {  int yypos791= G->pos, yythunkpos791= G->thunkpos;  if (!yy__(G))  goto l791;
+  if (!yy_FROM_KW(G))  goto l791;
+  if (!yy__(G))  goto l791;
+  if (!yy_Type(G))  goto l791;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_EnumDecl, G->begin, G->end, "yy_2_EnumDecl");
-  goto l786;
-  l785:;	  G->pos= yypos785; G->thunkpos= yythunkpos785;
+  goto l792;
+  l791:;	  G->pos= yypos791; G->thunkpos= yythunkpos791;
   }
-  l786:;	
-  {  int yypos787= G->pos, yythunkpos787= G->thunkpos;  if (!yy__(G))  goto l787;
-  if (!yymatchChar(G, '(')) goto l787;
-  if (!yy__(G))  goto l787;
-  if (!yy_EnumIncrementOper(G))  goto l787;
+  l792:;	
+  {  int yypos793= G->pos, yythunkpos793= G->thunkpos;  if (!yy__(G))  goto l793;
+  if (!yymatchChar(G, '(')) goto l793;
+  if (!yy__(G))  goto l793;
+  if (!yy_EnumIncrementOper(G))  goto l793;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l787;
-  if (!yy_IntLiteral(G))  goto l787;
+  if (!yy_WS(G))  goto l793;
+  if (!yy_IntLiteral(G))  goto l793;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumDecl, G->begin, G->end, "yy_3_EnumDecl");
-  if (!yy__(G))  goto l787;
-  if (!yymatchChar(G, ')')) goto l787;
-  goto l788;
-  l787:;	  G->pos= yypos787; G->thunkpos= yythunkpos787;
+  if (!yy__(G))  goto l793;
+  if (!yymatchChar(G, ')')) goto l793;
+  goto l794;
+  l793:;	  G->pos= yypos793; G->thunkpos= yythunkpos793;
   }
-  l788:;	  if (!yy_WS(G))  goto l784;
-  if (!yymatchChar(G, '{')) goto l784;
-  if (!yy_WS(G))  goto l784;
+  l794:;	  if (!yy_WS(G))  goto l790;
+  if (!yymatchChar(G, '{')) goto l790;
+  if (!yy_WS(G))  goto l790;
 
-  {  int yypos789= G->pos, yythunkpos789= G->thunkpos;  if (!yy_EnumElement(G))  goto l789;
+  {  int yypos795= G->pos, yythunkpos795= G->thunkpos;  if (!yy_EnumElement(G))  goto l795;
 
-  l791:;	
-  {  int yypos792= G->pos, yythunkpos792= G->thunkpos;
-  {  int yypos793= G->pos, yythunkpos793= G->thunkpos;  if (!yy_Terminator(G))  goto l794;
+  l797:;	
+  {  int yypos798= G->pos, yythunkpos798= G->thunkpos;
+  {  int yypos799= G->pos, yythunkpos799= G->thunkpos;  if (!yy_Terminator(G))  goto l800;
 
-  l795:;	
-  {  int yypos796= G->pos, yythunkpos796= G->thunkpos;  if (!yy_Terminator(G))  goto l796;
-  goto l795;
-  l796:;	  G->pos= yypos796; G->thunkpos= yythunkpos796;
-  }  if (!yy_WS(G))  goto l794;
-  if (!yy_FunctionDecl(G))  goto l794;
-  goto l793;
-  l794:;	  G->pos= yypos793; G->thunkpos= yythunkpos793;
-  {  int yypos797= G->pos, yythunkpos797= G->thunkpos;  if (!yymatchChar(G, ',')) goto l798;
-  goto l797;
-  l798:;	  G->pos= yypos797; G->thunkpos= yythunkpos797;  if (!yy_Terminator(G))  goto l792;
-
-  l799:;	
-  {  int yypos800= G->pos, yythunkpos800= G->thunkpos;  if (!yy_Terminator(G))  goto l800;
+  l801:;	
+  {  int yypos802= G->pos, yythunkpos802= G->thunkpos;  if (!yy_Terminator(G))  goto l802;
+  goto l801;
+  l802:;	  G->pos= yypos802; G->thunkpos= yythunkpos802;
+  }  if (!yy_WS(G))  goto l800;
+  if (!yy_FunctionDecl(G))  goto l800;
   goto l799;
-  l800:;	  G->pos= yypos800; G->thunkpos= yythunkpos800;
+  l800:;	  G->pos= yypos799; G->thunkpos= yythunkpos799;
+  {  int yypos803= G->pos, yythunkpos803= G->thunkpos;  if (!yymatchChar(G, ',')) goto l804;
+  goto l803;
+  l804:;	  G->pos= yypos803; G->thunkpos= yythunkpos803;  if (!yy_Terminator(G))  goto l798;
+
+  l805:;	
+  {  int yypos806= G->pos, yythunkpos806= G->thunkpos;  if (!yy_Terminator(G))  goto l806;
+  goto l805;
+  l806:;	  G->pos= yypos806; G->thunkpos= yythunkpos806;
   }
   }
-  l797:;	  if (!yy_WS(G))  goto l792;
-  if (!yy_EnumElement(G))  goto l792;
+  l803:;	  if (!yy_WS(G))  goto l798;
+  if (!yy_EnumElement(G))  goto l798;
 
   }
-  l793:;	  goto l791;
-  l792:;	  G->pos= yypos792; G->thunkpos= yythunkpos792;
-  }  goto l790;
-  l789:;	  G->pos= yypos789; G->thunkpos= yythunkpos789;
+  l799:;	  goto l797;
+  l798:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;
+  }  goto l796;
+  l795:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;
   }
-  l790:;	  if (!yy_WS(G))  goto l784;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l784; }
+  l796:;	  if (!yy_WS(G))  goto l790;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l790; }
   yyDo(G, yy_4_EnumDecl, G->begin, G->end, "yy_4_EnumDecl");
   yyprintf((stderr, "  ok   EnumDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l784:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
+  l790:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12091,40 +12180,40 @@ YY_RULE(int) yy_EnumDecl(GREG *G)
 YY_RULE(int) yy_ExtendDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ExtendDecl"));
-  if (!yy_OocDoc(G))  goto l801;
+  if (!yy_OocDoc(G))  goto l807;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yymatchString(G, "extend")) goto l801;
-  if (!yy_WS(G))  goto l801;
-  if (!yy_Type(G))  goto l801;
+  if (!yymatchString(G, "extend")) goto l807;
+  if (!yy_WS(G))  goto l807;
+  if (!yy_Type(G))  goto l807;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ExtendDecl, G->begin, G->end, "yy_1_ExtendDecl");
-  if (!yy_WS(G))  goto l801;
-  if (!yymatchChar(G, '{')) goto l801;
-  if (!yy_WS(G))  goto l801;
+  if (!yy_WS(G))  goto l807;
+  if (!yymatchChar(G, '{')) goto l807;
+  if (!yy_WS(G))  goto l807;
 
-  l802:;	
-  {  int yypos803= G->pos, yythunkpos803= G->thunkpos;  if (!yy_WS(G))  goto l803;
+  l808:;	
+  {  int yypos809= G->pos, yythunkpos809= G->thunkpos;  if (!yy_WS(G))  goto l809;
 
-  {  int yypos804= G->pos, yythunkpos804= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l805;
+  {  int yypos810= G->pos, yythunkpos810= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l811;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l804;
-  l805:;	  G->pos= yypos804; G->thunkpos= yythunkpos804;  if (!yy_PropertyDecl(G))  goto l803;
+  goto l810;
+  l811:;	  G->pos= yypos810; G->thunkpos= yythunkpos810;  if (!yy_PropertyDecl(G))  goto l809;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ExtendDecl, G->begin, G->end, "yy_2_ExtendDecl");
 
   }
-  l804:;	  if (!yy_WS(G))  goto l803;
-  goto l802;
-  l803:;	  G->pos= yypos803; G->thunkpos= yythunkpos803;
-  }  if (!yy_WS(G))  goto l801;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l801; }
+  l810:;	  if (!yy_WS(G))  goto l809;
+  goto l808;
+  l809:;	  G->pos= yypos809; G->thunkpos= yythunkpos809;
+  }  if (!yy_WS(G))  goto l807;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l807; }
   yyDo(G, yy_3_ExtendDecl, G->begin, G->end, "yy_3_ExtendDecl");
   yyprintf((stderr, "  ok   ExtendDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l801:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
+  l807:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12133,124 +12222,124 @@ YY_RULE(int) yy_ExtendDecl(GREG *G)
 YY_RULE(int) yy_CoverDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CoverDecl"));
-  if (!yy_OocDoc(G))  goto l806;
+  if (!yy_OocDoc(G))  goto l812;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l806;
+  if (!yy_IDENT(G))  goto l812;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_CoverDecl, G->begin, G->end, "yy_1_CoverDecl");
-  if (!yy__(G))  goto l806;
-  if (!yy_COLON(G))  goto l806;
+  if (!yy__(G))  goto l812;
+  if (!yy_COLON(G))  goto l812;
 
-  {  int yypos807= G->pos, yythunkpos807= G->thunkpos;  if (!yy__(G))  goto l807;
-  if (!yy_ExternName(G))  goto l807;
+  {  int yypos813= G->pos, yythunkpos813= G->thunkpos;  if (!yy__(G))  goto l813;
+  if (!yy_ExternName(G))  goto l813;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_2_CoverDecl, G->begin, G->end, "yy_2_CoverDecl");
-  goto l808;
-  l807:;	  G->pos= yypos807; G->thunkpos= yythunkpos807;
-  }
-  l808:;	
-  {  int yypos809= G->pos, yythunkpos809= G->thunkpos;  if (!yy__(G))  goto l809;
-  if (!yy_PROTO_KW(G))  goto l809;
-  yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
-  goto l810;
-  l809:;	  G->pos= yypos809; G->thunkpos= yythunkpos809;
-  }
-  l810:;	  if (!yy__(G))  goto l806;
-  if (!yy_COVER_KW(G))  goto l806;
-
-  {  int yypos811= G->pos, yythunkpos811= G->thunkpos;  if (!yy_GenericArguments(G))  goto l811;
-  goto l812;
-  l811:;	  G->pos= yypos811; G->thunkpos= yythunkpos811;
-  }
-  l812:;	
-  {  int yypos813= G->pos, yythunkpos813= G->thunkpos;  if (!yy_TemplateDef(G))  goto l813;
   goto l814;
   l813:;	  G->pos= yypos813; G->thunkpos= yythunkpos813;
   }
   l814:;	
   {  int yypos815= G->pos, yythunkpos815= G->thunkpos;  if (!yy__(G))  goto l815;
-  if (!yy_FROM_KW(G))  goto l815;
-  if (!yy__(G))  goto l815;
-  if (!yy_Type(G))  goto l815;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
+  if (!yy_PROTO_KW(G))  goto l815;
+  yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
   goto l816;
   l815:;	  G->pos= yypos815; G->thunkpos= yythunkpos815;
   }
-  l816:;	
-  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;  if (!yy__(G))  goto l817;
-  if (!yy_EXTENDS_KW(G))  goto l817;
-  if (!yy__(G))  goto l817;
-  if (!yy_Type(G))  goto l817;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
+  l816:;	  if (!yy__(G))  goto l812;
+  if (!yy_COVER_KW(G))  goto l812;
+
+  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;  if (!yy_GenericArguments(G))  goto l817;
   goto l818;
   l817:;	  G->pos= yypos817; G->thunkpos= yythunkpos817;
   }
   l818:;	
-  {  int yypos819= G->pos, yythunkpos819= G->thunkpos;  if (!yy__(G))  goto l819;
-  if (!yy_IMPLEMENTS_KW(G))  goto l819;
-  if (!yy__(G))  goto l819;
-  if (!yy_Type(G))  goto l819;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
-
-  l821:;	
-  {  int yypos822= G->pos, yythunkpos822= G->thunkpos;  if (!yy__(G))  goto l822;
-  if (!yymatchChar(G, ',')) goto l822;
-  if (!yy__(G))  goto l822;
-  if (!yy_Type(G))  goto l822;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
-  goto l821;
-  l822:;	  G->pos= yypos822; G->thunkpos= yythunkpos822;
-  }  goto l820;
+  {  int yypos819= G->pos, yythunkpos819= G->thunkpos;  if (!yy_TemplateDef(G))  goto l819;
+  goto l820;
   l819:;	  G->pos= yypos819; G->thunkpos= yythunkpos819;
   }
   l820:;	
-  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;  if (!yy_WS(G))  goto l823;
-  if (!yymatchChar(G, '{')) goto l823;
-  if (!yy_WS(G))  goto l823;
-
-  l825:;	
-  {  int yypos826= G->pos, yythunkpos826= G->thunkpos;  if (!yy_WS(G))  goto l826;
-
-  {  int yypos827= G->pos, yythunkpos827= G->thunkpos;  if (!yy_VariableDecl(G))  goto l828;
-  yyDo(G, yySet, -4, 0, "yySet");
-  yyDo(G, yy_8_CoverDecl, G->begin, G->end, "yy_8_CoverDecl");
-  if (!yy_Terminator(G))  goto l828;
-
-  l829:;	
-  {  int yypos830= G->pos, yythunkpos830= G->thunkpos;  if (!yy_Terminator(G))  goto l830;
-  goto l829;
-  l830:;	  G->pos= yypos830; G->thunkpos= yythunkpos830;
-  }  goto l827;
-  l828:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;  if (!yy_PropertyDecl(G))  goto l831;
-  yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_9_CoverDecl, G->begin, G->end, "yy_9_CoverDecl");
-  goto l827;
-  l831:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;  if (!yy_OperatorDecl(G))  goto l832;
-  yyDo(G, yySet, -2, 0, "yySet");
-  goto l827;
-  l832:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;  if (!yy_FunctionDecl(G))  goto l826;
-  yyDo(G, yySet, -1, 0, "yySet");
-
+  {  int yypos821= G->pos, yythunkpos821= G->thunkpos;  if (!yy__(G))  goto l821;
+  if (!yy_FROM_KW(G))  goto l821;
+  if (!yy__(G))  goto l821;
+  if (!yy_Type(G))  goto l821;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
+  goto l822;
+  l821:;	  G->pos= yypos821; G->thunkpos= yythunkpos821;
   }
-  l827:;	  if (!yy_WS(G))  goto l826;
-  goto l825;
-  l826:;	  G->pos= yypos826; G->thunkpos= yythunkpos826;
-  }  if (!yy_WS(G))  goto l823;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l823; }
+  l822:;	
+  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;  if (!yy__(G))  goto l823;
+  if (!yy_EXTENDS_KW(G))  goto l823;
+  if (!yy__(G))  goto l823;
+  if (!yy_Type(G))  goto l823;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
   goto l824;
   l823:;	  G->pos= yypos823; G->thunkpos= yythunkpos823;
   }
-  l824:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
+  l824:;	
+  {  int yypos825= G->pos, yythunkpos825= G->thunkpos;  if (!yy__(G))  goto l825;
+  if (!yy_IMPLEMENTS_KW(G))  goto l825;
+  if (!yy__(G))  goto l825;
+  if (!yy_Type(G))  goto l825;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
+
+  l827:;	
+  {  int yypos828= G->pos, yythunkpos828= G->thunkpos;  if (!yy__(G))  goto l828;
+  if (!yymatchChar(G, ',')) goto l828;
+  if (!yy__(G))  goto l828;
+  if (!yy_Type(G))  goto l828;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
+  goto l827;
+  l828:;	  G->pos= yypos828; G->thunkpos= yythunkpos828;
+  }  goto l826;
+  l825:;	  G->pos= yypos825; G->thunkpos= yythunkpos825;
+  }
+  l826:;	
+  {  int yypos829= G->pos, yythunkpos829= G->thunkpos;  if (!yy_WS(G))  goto l829;
+  if (!yymatchChar(G, '{')) goto l829;
+  if (!yy_WS(G))  goto l829;
+
+  l831:;	
+  {  int yypos832= G->pos, yythunkpos832= G->thunkpos;  if (!yy_WS(G))  goto l832;
+
+  {  int yypos833= G->pos, yythunkpos833= G->thunkpos;  if (!yy_VariableDecl(G))  goto l834;
+  yyDo(G, yySet, -4, 0, "yySet");
+  yyDo(G, yy_8_CoverDecl, G->begin, G->end, "yy_8_CoverDecl");
+  if (!yy_Terminator(G))  goto l834;
+
+  l835:;	
+  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy_Terminator(G))  goto l836;
+  goto l835;
+  l836:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;
+  }  goto l833;
+  l834:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_PropertyDecl(G))  goto l837;
+  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yy_9_CoverDecl, G->begin, G->end, "yy_9_CoverDecl");
+  goto l833;
+  l837:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_OperatorDecl(G))  goto l838;
+  yyDo(G, yySet, -2, 0, "yySet");
+  goto l833;
+  l838:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_FunctionDecl(G))  goto l832;
+  yyDo(G, yySet, -1, 0, "yySet");
+
+  }
+  l833:;	  if (!yy_WS(G))  goto l832;
+  goto l831;
+  l832:;	  G->pos= yypos832; G->thunkpos= yythunkpos832;
+  }  if (!yy_WS(G))  goto l829;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l829; }
+  goto l830;
+  l829:;	  G->pos= yypos829; G->thunkpos= yythunkpos829;
+  }
+  l830:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
   yyprintf((stderr, "  ok   CoverDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l806:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
+  l812:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12259,110 +12348,110 @@ YY_RULE(int) yy_CoverDecl(GREG *G)
 YY_RULE(int) yy_ClassDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ClassDecl"));
-  if (!yy_OocDoc(G))  goto l833;
+  if (!yy_OocDoc(G))  goto l839;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l833;
+  if (!yy_IDENT(G))  goto l839;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_ClassDecl, G->begin, G->end, "yy_1_ClassDecl");
-  if (!yy__(G))  goto l833;
-  if (!yy_COLON(G))  goto l833;
+  if (!yy__(G))  goto l839;
+  if (!yy_COLON(G))  goto l839;
 
-  l834:;	
-  {  int yypos835= G->pos, yythunkpos835= G->thunkpos;  if (!yy__(G))  goto l835;
+  l840:;	
+  {  int yypos841= G->pos, yythunkpos841= G->thunkpos;  if (!yy__(G))  goto l841;
 
-  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy_ExternName(G))  goto l837;
-  goto l836;
-  l837:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;  if (!yy_ABSTRACT_KW(G))  goto l838;
+  {  int yypos842= G->pos, yythunkpos842= G->thunkpos;  if (!yy_ExternName(G))  goto l843;
+  goto l842;
+  l843:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;  if (!yy_ABSTRACT_KW(G))  goto l844;
   yyDo(G, yy_2_ClassDecl, G->begin, G->end, "yy_2_ClassDecl");
-  goto l836;
-  l838:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;  if (!yy_FINAL_KW(G))  goto l835;
+  goto l842;
+  l844:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;  if (!yy_FINAL_KW(G))  goto l841;
   yyDo(G, yy_3_ClassDecl, G->begin, G->end, "yy_3_ClassDecl");
 
   }
-  l836:;	  goto l834;
-  l835:;	  G->pos= yypos835; G->thunkpos= yythunkpos835;
-  }  if (!yy__(G))  goto l833;
-  if (!yy_CLASS_KW(G))  goto l833;
+  l842:;	  goto l840;
+  l841:;	  G->pos= yypos841; G->thunkpos= yythunkpos841;
+  }  if (!yy__(G))  goto l839;
+  if (!yy_CLASS_KW(G))  goto l839;
 
-  {  int yypos839= G->pos, yythunkpos839= G->thunkpos;  if (!yy_GenericArguments(G))  goto l839;
-  goto l840;
-  l839:;	  G->pos= yypos839; G->thunkpos= yythunkpos839;
+  {  int yypos845= G->pos, yythunkpos845= G->thunkpos;  if (!yy_GenericArguments(G))  goto l845;
+  goto l846;
+  l845:;	  G->pos= yypos845; G->thunkpos= yythunkpos845;
   }
-  l840:;	
-  {  int yypos841= G->pos, yythunkpos841= G->thunkpos;  if (!yy__(G))  goto l841;
-  if (!yy_EXTENDS_KW(G))  goto l841;
-  if (!yy__(G))  goto l841;
-  if (!yy_Type(G))  goto l841;
+  l846:;	
+  {  int yypos847= G->pos, yythunkpos847= G->thunkpos;  if (!yy__(G))  goto l847;
+  if (!yy_EXTENDS_KW(G))  goto l847;
+  if (!yy__(G))  goto l847;
+  if (!yy_Type(G))  goto l847;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_4_ClassDecl, G->begin, G->end, "yy_4_ClassDecl");
-  goto l842;
-  l841:;	  G->pos= yypos841; G->thunkpos= yythunkpos841;
+  goto l848;
+  l847:;	  G->pos= yypos847; G->thunkpos= yythunkpos847;
   }
-  l842:;	
-  {  int yypos843= G->pos, yythunkpos843= G->thunkpos;  if (!yy__(G))  goto l843;
-  if (!yy_IMPLEMENTS_KW(G))  goto l843;
-  if (!yy__(G))  goto l843;
-  if (!yy_Type(G))  goto l843;
+  l848:;	
+  {  int yypos849= G->pos, yythunkpos849= G->thunkpos;  if (!yy__(G))  goto l849;
+  if (!yy_IMPLEMENTS_KW(G))  goto l849;
+  if (!yy__(G))  goto l849;
+  if (!yy_Type(G))  goto l849;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_5_ClassDecl, G->begin, G->end, "yy_5_ClassDecl");
 
-  l845:;	
-  {  int yypos846= G->pos, yythunkpos846= G->thunkpos;  if (!yy__(G))  goto l846;
-  if (!yymatchChar(G, ',')) goto l846;
-  if (!yy__(G))  goto l846;
-  if (!yy_Type(G))  goto l846;
+  l851:;	
+  {  int yypos852= G->pos, yythunkpos852= G->thunkpos;  if (!yy__(G))  goto l852;
+  if (!yymatchChar(G, ',')) goto l852;
+  if (!yy__(G))  goto l852;
+  if (!yy_Type(G))  goto l852;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_6_ClassDecl, G->begin, G->end, "yy_6_ClassDecl");
-  goto l845;
-  l846:;	  G->pos= yypos846; G->thunkpos= yythunkpos846;
-  }  goto l844;
-  l843:;	  G->pos= yypos843; G->thunkpos= yythunkpos843;
-  }
-  l844:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
-  if (!yy_WS(G))  goto l833;
-  if (!yymatchChar(G, '{')) goto l833;
-  if (!yy_WS(G))  goto l833;
-
-  l847:;	
-  {  int yypos848= G->pos, yythunkpos848= G->thunkpos;  if (!yy_WS(G))  goto l848;
-
-  {  int yypos849= G->pos, yythunkpos849= G->thunkpos;  if (!yy_VariableDecl(G))  goto l850;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_8_ClassDecl, G->begin, G->end, "yy_8_ClassDecl");
-  if (!yy_Terminator(G))  goto l850;
-
-  l851:;	
-  {  int yypos852= G->pos, yythunkpos852= G->thunkpos;  if (!yy_Terminator(G))  goto l852;
   goto l851;
   l852:;	  G->pos= yypos852; G->thunkpos= yythunkpos852;
-  }  goto l849;
-  l850:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;  if (!yy_PropertyDecl(G))  goto l853;
+  }  goto l850;
+  l849:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;
+  }
+  l850:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
+  if (!yy_WS(G))  goto l839;
+  if (!yymatchChar(G, '{')) goto l839;
+  if (!yy_WS(G))  goto l839;
+
+  l853:;	
+  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy_WS(G))  goto l854;
+
+  {  int yypos855= G->pos, yythunkpos855= G->thunkpos;  if (!yy_VariableDecl(G))  goto l856;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_8_ClassDecl, G->begin, G->end, "yy_8_ClassDecl");
+  if (!yy_Terminator(G))  goto l856;
+
+  l857:;	
+  {  int yypos858= G->pos, yythunkpos858= G->thunkpos;  if (!yy_Terminator(G))  goto l858;
+  goto l857;
+  l858:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;
+  }  goto l855;
+  l856:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_PropertyDecl(G))  goto l859;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_9_ClassDecl, G->begin, G->end, "yy_9_ClassDecl");
-  goto l849;
-  l853:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;  if (!yy_FunctionDecl(G))  goto l854;
+  goto l855;
+  l859:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_FunctionDecl(G))  goto l860;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l849;
-  l854:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;  if (!yy_OperatorDecl(G))  goto l855;
+  goto l855;
+  l860:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_OperatorDecl(G))  goto l861;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l849;
-  l855:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;  if (!yy_Stmt(G))  goto l848;
+  goto l855;
+  l861:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_Stmt(G))  goto l854;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ClassDecl, G->begin, G->end, "yy_10_ClassDecl");
 
   }
-  l849:;	  if (!yy_WS(G))  goto l848;
-  goto l847;
-  l848:;	  G->pos= yypos848; G->thunkpos= yythunkpos848;
-  }  if (!yy_WS(G))  goto l833;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l833; }
+  l855:;	  if (!yy_WS(G))  goto l854;
+  goto l853;
+  l854:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;
+  }  if (!yy_WS(G))  goto l839;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l839; }
   yyDo(G, yy_11_ClassDecl, G->begin, G->end, "yy_11_ClassDecl");
   yyprintf((stderr, "  ok   ClassDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l833:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
+  l839:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12371,15 +12460,15 @@ YY_RULE(int) yy_ClassDecl(GREG *G)
 YY_RULE(int) yy_IDENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IDENT"));
-  if (!yy_IDENT_CORE(G))  goto l856;
+  if (!yy_IDENT_CORE(G))  goto l862;
   yyDo(G, yySet, 0, 0, "yySet");
-  if (!yy__(G))  goto l856;
+  if (!yy__(G))  goto l862;
   yyprintf((stderr, "  ok   IDENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l856:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
+  l862:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12387,13 +12476,13 @@ YY_RULE(int) yy_IDENT(GREG *G)
 }
 YY_RULE(int) yy_INTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTO_KW"));
-  if (!yymatchString(G, "into")) goto l857;
+  if (!yymatchString(G, "into")) goto l863;
   yyprintf((stderr, "  ok   INTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l857:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
+  l863:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12401,29 +12490,29 @@ YY_RULE(int) yy_INTO_KW(GREG *G)
 }
 YY_RULE(int) yy_ImportName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l858;
-  {  int yypos861= G->pos, yythunkpos861= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l862;
-  goto l861;
-  l862:;	  G->pos= yypos861; G->thunkpos= yythunkpos861;  if (!yymatchChar(G, '-')) goto l858;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l864;
+  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l868;
+  goto l867;
+  l868:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;  if (!yymatchChar(G, '-')) goto l864;
 
   }
-  l861:;	
-  l859:;	
-  {  int yypos860= G->pos, yythunkpos860= G->thunkpos;
-  {  int yypos863= G->pos, yythunkpos863= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l864;
-  goto l863;
-  l864:;	  G->pos= yypos863; G->thunkpos= yythunkpos863;  if (!yymatchChar(G, '-')) goto l860;
+  l867:;	
+  l865:;	
+  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;
+  {  int yypos869= G->pos, yythunkpos869= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l870;
+  goto l869;
+  l870:;	  G->pos= yypos869; G->thunkpos= yythunkpos869;  if (!yymatchChar(G, '-')) goto l866;
 
   }
-  l863:;	  goto l859;
-  l860:;	  G->pos= yypos860; G->thunkpos= yythunkpos860;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l858;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
+  l869:;	  goto l865;
+  l866:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l864;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
   yyprintf((stderr, "  ok   ImportName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l858:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
+  l864:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12431,38 +12520,38 @@ YY_RULE(int) yy_ImportName(GREG *G)
 }
 YY_RULE(int) yy_ImportPath(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportPath"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l865;
-  l866:;	
-  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;
-  {  int yypos870= G->pos, yythunkpos870= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l871;
-  goto l870;
-  l871:;	  G->pos= yypos870; G->thunkpos= yythunkpos870;  if (!yymatchChar(G, '.')) goto l872;
-  goto l870;
-  l872:;	  G->pos= yypos870; G->thunkpos= yythunkpos870;  if (!yymatchChar(G, '-')) goto l867;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l871;
+  l872:;	
+  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;
+  {  int yypos876= G->pos, yythunkpos876= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l877;
+  goto l876;
+  l877:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yymatchChar(G, '.')) goto l878;
+  goto l876;
+  l878:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yymatchChar(G, '-')) goto l873;
 
   }
-  l870:;	
-  l868:;	
-  {  int yypos869= G->pos, yythunkpos869= G->thunkpos;
-  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l874;
-  goto l873;
-  l874:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;  if (!yymatchChar(G, '.')) goto l875;
-  goto l873;
-  l875:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;  if (!yymatchChar(G, '-')) goto l869;
+  l876:;	
+  l874:;	
+  {  int yypos875= G->pos, yythunkpos875= G->thunkpos;
+  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l880;
+  goto l879;
+  l880:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;  if (!yymatchChar(G, '.')) goto l881;
+  goto l879;
+  l881:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;  if (!yymatchChar(G, '-')) goto l875;
 
   }
-  l873:;	  goto l868;
-  l869:;	  G->pos= yypos869; G->thunkpos= yythunkpos869;
-  }  if (!yymatchChar(G, '/')) goto l867;
-  goto l866;
-  l867:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l865;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
+  l879:;	  goto l874;
+  l875:;	  G->pos= yypos875; G->thunkpos= yythunkpos875;
+  }  if (!yymatchChar(G, '/')) goto l873;
+  goto l872;
+  l873:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l871;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
   yyprintf((stderr, "  ok   ImportPath"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l865:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
+  l871:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12471,60 +12560,60 @@ YY_RULE(int) yy_ImportPath(GREG *G)
 YY_RULE(int) yy_ImportAtom(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImportAtom"));
-  if (!yy_ImportPath(G))  goto l876;
+  if (!yy_ImportPath(G))  goto l882;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos877= G->pos, yythunkpos877= G->thunkpos;  if (!yy_ImportName(G))  goto l878;
+  {  int yypos883= G->pos, yythunkpos883= G->thunkpos;  if (!yy_ImportName(G))  goto l884;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_ImportAtom, G->begin, G->end, "yy_1_ImportAtom");
   yyDo(G, yy_2_ImportAtom, G->begin, G->end, "yy_2_ImportAtom");
 
-  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;  if (!yy__(G))  goto l879;
-  if (!yy_INTO_KW(G))  goto l879;
-  if (!yy__(G))  goto l879;
-  if (!yy_IDENT(G))  goto l879;
+  {  int yypos885= G->pos, yythunkpos885= G->thunkpos;  if (!yy__(G))  goto l885;
+  if (!yy_INTO_KW(G))  goto l885;
+  if (!yy__(G))  goto l885;
+  if (!yy_IDENT(G))  goto l885;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImportAtom, G->begin, G->end, "yy_3_ImportAtom");
-  goto l880;
-  l879:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;
+  goto l886;
+  l885:;	  G->pos= yypos885; G->thunkpos= yythunkpos885;
   }
-  l880:;	  goto l877;
-  l878:;	  G->pos= yypos877; G->thunkpos= yythunkpos877;  if (!yymatchChar(G, '[')) goto l876;
+  l886:;	  goto l883;
+  l884:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;  if (!yymatchChar(G, '[')) goto l882;
   yyDo(G, yy_4_ImportAtom, G->begin, G->end, "yy_4_ImportAtom");
 
-  l881:;	
-  {  int yypos882= G->pos, yythunkpos882= G->thunkpos;  if (!yy_ImportName(G))  goto l882;
+  l887:;	
+  {  int yypos888= G->pos, yythunkpos888= G->thunkpos;  if (!yy_ImportName(G))  goto l888;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_5_ImportAtom, G->begin, G->end, "yy_5_ImportAtom");
-  if (!yy__(G))  goto l882;
-  if (!yymatchChar(G, ',')) goto l882;
-  if (!yy_WS(G))  goto l882;
+  if (!yy__(G))  goto l888;
+  if (!yymatchChar(G, ',')) goto l888;
+  if (!yy_WS(G))  goto l888;
   yyDo(G, yy_6_ImportAtom, G->begin, G->end, "yy_6_ImportAtom");
-  goto l881;
-  l882:;	  G->pos= yypos882; G->thunkpos= yythunkpos882;
-  }  if (!yy_ImportName(G))  goto l876;
+  goto l887;
+  l888:;	  G->pos= yypos888; G->thunkpos= yythunkpos888;
+  }  if (!yy_ImportName(G))  goto l882;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_7_ImportAtom, G->begin, G->end, "yy_7_ImportAtom");
   yyDo(G, yy_8_ImportAtom, G->begin, G->end, "yy_8_ImportAtom");
-  if (!yymatchChar(G, ']')) goto l876;
+  if (!yymatchChar(G, ']')) goto l882;
 
-  {  int yypos883= G->pos, yythunkpos883= G->thunkpos;  if (!yy__(G))  goto l883;
-  if (!yy_INTO_KW(G))  goto l883;
-  if (!yy__(G))  goto l883;
-  if (!yy_IDENT(G))  goto l883;
+  {  int yypos889= G->pos, yythunkpos889= G->thunkpos;  if (!yy__(G))  goto l889;
+  if (!yy_INTO_KW(G))  goto l889;
+  if (!yy__(G))  goto l889;
+  if (!yy_IDENT(G))  goto l889;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_ImportAtom, G->begin, G->end, "yy_9_ImportAtom");
-  goto l884;
-  l883:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;
+  goto l890;
+  l889:;	  G->pos= yypos889; G->thunkpos= yythunkpos889;
   }
-  l884:;	
+  l890:;	
   }
-  l877:;	  yyprintf((stderr, "  ok   ImportAtom"));
+  l883:;	  yyprintf((stderr, "  ok   ImportAtom"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l876:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
+  l882:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12532,13 +12621,13 @@ YY_RULE(int) yy_ImportAtom(GREG *G)
 }
 YY_RULE(int) yy_IMPORT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPORT_KW"));
-  if (!yymatchString(G, "import")) goto l885;
+  if (!yymatchString(G, "import")) goto l891;
   yyprintf((stderr, "  ok   IMPORT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l885:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
+  l891:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12547,38 +12636,38 @@ YY_RULE(int) yy_IMPORT_KW(GREG *G)
 YY_RULE(int) yy_DefineValue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineValue"));
 
-  {  int yypos887= G->pos, yythunkpos887= G->thunkpos;
-  {  int yypos889= G->pos, yythunkpos889= G->thunkpos;  if (!yymatchChar(G, '=')) goto l889;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l889;
-  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l894;
+  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;
+  {  int yypos895= G->pos, yythunkpos895= G->thunkpos;  if (!yymatchChar(G, '=')) goto l895;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l895;
+  {  int yypos899= G->pos, yythunkpos899= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l900;
+  goto l899;
+  l900:;	  G->pos= yypos899; G->thunkpos= yythunkpos899;  if (!yymatchChar(G, '-')) goto l895;
+
+  }
+  l899:;	
+  l897:;	
+  {  int yypos898= G->pos, yythunkpos898= G->thunkpos;
+  {  int yypos901= G->pos, yythunkpos901= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l902;
+  goto l901;
+  l902:;	  G->pos= yypos901; G->thunkpos= yythunkpos901;  if (!yymatchChar(G, '-')) goto l898;
+
+  }
+  l901:;	  goto l897;
+  l898:;	  G->pos= yypos898; G->thunkpos= yythunkpos898;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l895;  goto l896;
+  l895:;	  G->pos= yypos895; G->thunkpos= yythunkpos895;
+  }
+  l896:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
   goto l893;
-  l894:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;  if (!yymatchChar(G, '-')) goto l889;
+  l894:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
 
   }
-  l893:;	
-  l891:;	
-  {  int yypos892= G->pos, yythunkpos892= G->thunkpos;
-  {  int yypos895= G->pos, yythunkpos895= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l896;
-  goto l895;
-  l896:;	  G->pos= yypos895; G->thunkpos= yythunkpos895;  if (!yymatchChar(G, '-')) goto l892;
-
-  }
-  l895:;	  goto l891;
-  l892:;	  G->pos= yypos892; G->thunkpos= yythunkpos892;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l889;  goto l890;
-  l889:;	  G->pos= yypos889; G->thunkpos= yythunkpos889;
-  }
-  l890:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
-  goto l887;
-  l888:;	  G->pos= yypos887; G->thunkpos= yythunkpos887;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
-
-  }
-  l887:;	  yyprintf((stderr, "  ok   DefineValue"));
+  l893:;	  yyprintf((stderr, "  ok   DefineValue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l886:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
+  l892:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12586,29 +12675,29 @@ YY_RULE(int) yy_DefineValue(GREG *G)
 }
 YY_RULE(int) yy_DefineName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l897;
-  {  int yypos900= G->pos, yythunkpos900= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l901;
-  goto l900;
-  l901:;	  G->pos= yypos900; G->thunkpos= yythunkpos900;  if (!yymatchChar(G, '-')) goto l897;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l903;
+  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l907;
+  goto l906;
+  l907:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;  if (!yymatchChar(G, '-')) goto l903;
 
   }
-  l900:;	
-  l898:;	
-  {  int yypos899= G->pos, yythunkpos899= G->thunkpos;
-  {  int yypos902= G->pos, yythunkpos902= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l903;
-  goto l902;
-  l903:;	  G->pos= yypos902; G->thunkpos= yythunkpos902;  if (!yymatchChar(G, '-')) goto l899;
+  l906:;	
+  l904:;	
+  {  int yypos905= G->pos, yythunkpos905= G->thunkpos;
+  {  int yypos908= G->pos, yythunkpos908= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l909;
+  goto l908;
+  l909:;	  G->pos= yypos908; G->thunkpos= yythunkpos908;  if (!yymatchChar(G, '-')) goto l905;
 
   }
-  l902:;	  goto l898;
-  l899:;	  G->pos= yypos899; G->thunkpos= yythunkpos899;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l897;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
+  l908:;	  goto l904;
+  l905:;	  G->pos= yypos905; G->thunkpos= yythunkpos905;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l903;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
   yyprintf((stderr, "  ok   DefineName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l897:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
+  l903:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12617,57 +12706,57 @@ YY_RULE(int) yy_DefineName(GREG *G)
 YY_RULE(int) yy_IncludeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IncludeCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l904;
-  {  int yypos907= G->pos, yythunkpos907= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l908;
-  goto l907;
-  l908:;	  G->pos= yypos907; G->thunkpos= yythunkpos907;  if (!yymatchChar(G, '-')) goto l904;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l910;
+  {  int yypos913= G->pos, yythunkpos913= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l914;
+  goto l913;
+  l914:;	  G->pos= yypos913; G->thunkpos= yythunkpos913;  if (!yymatchChar(G, '-')) goto l910;
 
   }
-  l907:;	
-  l905:;	
-  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;
-  {  int yypos909= G->pos, yythunkpos909= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l910;
-  goto l909;
-  l910:;	  G->pos= yypos909; G->thunkpos= yythunkpos909;  if (!yymatchChar(G, '-')) goto l906;
+  l913:;	
+  l911:;	
+  {  int yypos912= G->pos, yythunkpos912= G->thunkpos;
+  {  int yypos915= G->pos, yythunkpos915= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l916;
+  goto l915;
+  l916:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;  if (!yymatchChar(G, '-')) goto l912;
 
   }
-  l909:;	  goto l905;
-  l906:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l904;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
+  l915:;	  goto l911;
+  l912:;	  G->pos= yypos912; G->thunkpos= yythunkpos912;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l910;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
 
-  {  int yypos911= G->pos, yythunkpos911= G->thunkpos;  if (!yy__(G))  goto l911;
-  if (!yymatchChar(G, '|')) goto l911;
-  if (!yy__(G))  goto l911;
-  if (!yymatchChar(G, '(')) goto l911;
-  if (!yy__(G))  goto l911;
-  if (!yy_DefineName(G))  goto l911;
+  {  int yypos917= G->pos, yythunkpos917= G->thunkpos;  if (!yy__(G))  goto l917;
+  if (!yymatchChar(G, '|')) goto l917;
+  if (!yy__(G))  goto l917;
+  if (!yymatchChar(G, '(')) goto l917;
+  if (!yy__(G))  goto l917;
+  if (!yy_DefineName(G))  goto l917;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l911;
+  if (!yy_DefineValue(G))  goto l917;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_IncludeCore, G->begin, G->end, "yy_2_IncludeCore");
 
-  l913:;	
-  {  int yypos914= G->pos, yythunkpos914= G->thunkpos;  if (!yy__(G))  goto l914;
-  if (!yymatchChar(G, ',')) goto l914;
-  if (!yy__(G))  goto l914;
-  if (!yy_DefineName(G))  goto l914;
+  l919:;	
+  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;  if (!yy__(G))  goto l920;
+  if (!yymatchChar(G, ',')) goto l920;
+  if (!yy__(G))  goto l920;
+  if (!yy_DefineName(G))  goto l920;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l914;
+  if (!yy_DefineValue(G))  goto l920;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_IncludeCore, G->begin, G->end, "yy_3_IncludeCore");
-  goto l913;
-  l914:;	  G->pos= yypos914; G->thunkpos= yythunkpos914;
-  }  if (!yy__(G))  goto l911;
-  if (!yymatchChar(G, ')')) goto l911;
-  goto l912;
-  l911:;	  G->pos= yypos911; G->thunkpos= yythunkpos911;
+  goto l919;
+  l920:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;
+  }  if (!yy__(G))  goto l917;
+  if (!yymatchChar(G, ')')) goto l917;
+  goto l918;
+  l917:;	  G->pos= yypos917; G->thunkpos= yythunkpos917;
   }
-  l912:;	  yyprintf((stderr, "  ok   IncludeCore"));
+  l918:;	  yyprintf((stderr, "  ok   IncludeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l904:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
+  l910:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12675,13 +12764,13 @@ YY_RULE(int) yy_IncludeCore(GREG *G)
 }
 YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INCLUDE_KW"));
-  if (!yymatchString(G, "include")) goto l915;
+  if (!yymatchString(G, "include")) goto l921;
   yyprintf((stderr, "  ok   INCLUDE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l915:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
+  l921:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12689,29 +12778,29 @@ YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 }
 YY_RULE(int) yy_UseCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UseCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l916;
-  {  int yypos919= G->pos, yythunkpos919= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l920;
-  goto l919;
-  l920:;	  G->pos= yypos919; G->thunkpos= yythunkpos919;  if (!yymatchChar(G, '-')) goto l916;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l922;
+  {  int yypos925= G->pos, yythunkpos925= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l926;
+  goto l925;
+  l926:;	  G->pos= yypos925; G->thunkpos= yythunkpos925;  if (!yymatchChar(G, '-')) goto l922;
 
   }
-  l919:;	
-  l917:;	
-  {  int yypos918= G->pos, yythunkpos918= G->thunkpos;
-  {  int yypos921= G->pos, yythunkpos921= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l922;
-  goto l921;
-  l922:;	  G->pos= yypos921; G->thunkpos= yythunkpos921;  if (!yymatchChar(G, '-')) goto l918;
+  l925:;	
+  l923:;	
+  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;
+  {  int yypos927= G->pos, yythunkpos927= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l928;
+  goto l927;
+  l928:;	  G->pos= yypos927; G->thunkpos= yythunkpos927;  if (!yymatchChar(G, '-')) goto l924;
 
   }
-  l921:;	  goto l917;
-  l918:;	  G->pos= yypos918; G->thunkpos= yythunkpos918;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l916;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
+  l927:;	  goto l923;
+  l924:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l922;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
   yyprintf((stderr, "  ok   UseCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l916:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
+  l922:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12719,13 +12808,13 @@ YY_RULE(int) yy_UseCore(GREG *G)
 }
 YY_RULE(int) yy_USE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "USE_KW"));
-  if (!yymatchString(G, "use")) goto l923;
+  if (!yymatchString(G, "use")) goto l929;
   yyprintf((stderr, "  ok   USE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l923:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
+  l929:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12733,20 +12822,20 @@ YY_RULE(int) yy_USE_KW(GREG *G)
 }
 YY_RULE(int) yy_VersionName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionName"));
-  if (!yy__(G))  goto l924;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l924;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l924;
+  if (!yy__(G))  goto l930;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l930;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l930;
 
-  l925:;	
-  {  int yypos926= G->pos, yythunkpos926= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l926;
-  goto l925;
-  l926:;	  G->pos= yypos926; G->thunkpos= yythunkpos926;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l924;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
+  l931:;	
+  {  int yypos932= G->pos, yythunkpos932= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l932;
+  goto l931;
+  l932:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l930;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
   yyprintf((stderr, "  ok   VersionName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l924:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
+  l930:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12755,11 +12844,11 @@ YY_RULE(int) yy_VersionName(GREG *G)
 YY_RULE(int) yy_VersionNegation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionNegation"));
-  if (!yy__(G))  goto l927;
-  if (!yymatchChar(G, '!')) goto l927;
+  if (!yy__(G))  goto l933;
+  if (!yymatchChar(G, '!')) goto l933;
   yyDo(G, yy_1_VersionNegation, G->begin, G->end, "yy_1_VersionNegation");
-  if (!yy__(G))  goto l927;
-  if (!yy_VersionSpec(G))  goto l927;
+  if (!yy__(G))  goto l933;
+  if (!yy_VersionSpec(G))  goto l933;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionNegation, G->begin, G->end, "yy_2_VersionNegation");
   yyprintf((stderr, "  ok   VersionNegation"));
@@ -12767,7 +12856,7 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l927:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
+  l933:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12776,17 +12865,17 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
 YY_RULE(int) yy_VersionCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionCore"));
 
-  {  int yypos929= G->pos, yythunkpos929= G->thunkpos;  if (!yy_VersionNegation(G))  goto l930;
-  goto l929;
-  l930:;	  G->pos= yypos929; G->thunkpos= yythunkpos929;  if (!yy_VersionName(G))  goto l928;
+  {  int yypos935= G->pos, yythunkpos935= G->thunkpos;  if (!yy_VersionNegation(G))  goto l936;
+  goto l935;
+  l936:;	  G->pos= yypos935; G->thunkpos= yythunkpos935;  if (!yy_VersionName(G))  goto l934;
 
   }
-  l929:;	  yyprintf((stderr, "  ok   VersionCore"));
+  l935:;	  yyprintf((stderr, "  ok   VersionCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l928:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
+  l934:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12795,52 +12884,52 @@ YY_RULE(int) yy_VersionCore(GREG *G)
 YY_RULE(int) yy_OocDocCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDocCore"));
 
-  {  int yypos932= G->pos, yythunkpos932= G->thunkpos;  if (!yymatchString(G, "/**")) goto l933;
+  {  int yypos938= G->pos, yythunkpos938= G->thunkpos;  if (!yymatchString(G, "/**")) goto l939;
 
-  {  int yypos934= G->pos, yythunkpos934= G->thunkpos;  if (!yymatchChar(G, '*')) goto l934;
-  goto l933;
-  l934:;	  G->pos= yypos934; G->thunkpos= yythunkpos934;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l933;
-  l935:;	
-  {  int yypos936= G->pos, yythunkpos936= G->thunkpos;
-  {  int yypos937= G->pos, yythunkpos937= G->thunkpos;  if (!yymatchString(G, "*/")) goto l937;
-  goto l936;
-  l937:;	  G->pos= yypos937; G->thunkpos= yythunkpos937;
-  }
-  {  int yypos938= G->pos, yythunkpos938= G->thunkpos;  if (!yy_EOL(G))  goto l939;
-  goto l938;
-  l939:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;  if (!yymatchDot(G)) goto l936;
-  }
-  l938:;	  goto l935;
-  l936:;	  G->pos= yypos936; G->thunkpos= yythunkpos936;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l933;  if (!yymatchString(G, "*/")) goto l933;
-  yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
-  if (!yy_WS(G))  goto l933;
-  goto l932;
-  l933:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;  if (!yymatchString(G, "///")) goto l931;
-
-  {  int yypos940= G->pos, yythunkpos940= G->thunkpos;  if (!yymatchChar(G, '/')) goto l940;
-  goto l931;
+  {  int yypos940= G->pos, yythunkpos940= G->thunkpos;  if (!yymatchChar(G, '*')) goto l940;
+  goto l939;
   l940:;	  G->pos= yypos940; G->thunkpos= yythunkpos940;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l931;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l939;
   l941:;	
   {  int yypos942= G->pos, yythunkpos942= G->thunkpos;
-  {  int yypos943= G->pos, yythunkpos943= G->thunkpos;  if (!yy_EOL(G))  goto l943;
+  {  int yypos943= G->pos, yythunkpos943= G->thunkpos;  if (!yymatchString(G, "*/")) goto l943;
   goto l942;
   l943:;	  G->pos= yypos943; G->thunkpos= yythunkpos943;
-  }  if (!yymatchDot(G)) goto l942;  goto l941;
+  }
+  {  int yypos944= G->pos, yythunkpos944= G->thunkpos;  if (!yy_EOL(G))  goto l945;
+  goto l944;
+  l945:;	  G->pos= yypos944; G->thunkpos= yythunkpos944;  if (!yymatchDot(G)) goto l942;
+  }
+  l944:;	  goto l941;
   l942:;	  G->pos= yypos942; G->thunkpos= yythunkpos942;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l931;  if (!yy_EOL(G))  goto l931;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l939;  if (!yymatchString(G, "*/")) goto l939;
+  yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
+  if (!yy_WS(G))  goto l939;
+  goto l938;
+  l939:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;  if (!yymatchString(G, "///")) goto l937;
+
+  {  int yypos946= G->pos, yythunkpos946= G->thunkpos;  if (!yymatchChar(G, '/')) goto l946;
+  goto l937;
+  l946:;	  G->pos= yypos946; G->thunkpos= yythunkpos946;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l937;
+  l947:;	
+  {  int yypos948= G->pos, yythunkpos948= G->thunkpos;
+  {  int yypos949= G->pos, yythunkpos949= G->thunkpos;  if (!yy_EOL(G))  goto l949;
+  goto l948;
+  l949:;	  G->pos= yypos949; G->thunkpos= yythunkpos949;
+  }  if (!yymatchDot(G)) goto l948;  goto l947;
+  l948:;	  G->pos= yypos948; G->thunkpos= yythunkpos948;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l937;  if (!yy_EOL(G))  goto l937;
   yyDo(G, yy_2_OocDocCore, G->begin, G->end, "yy_2_OocDocCore");
-  if (!yy_WS(G))  goto l931;
+  if (!yy_WS(G))  goto l937;
 
   }
-  l932:;	  yyprintf((stderr, "  ok   OocDocCore"));
+  l938:;	  yyprintf((stderr, "  ok   OocDocCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l931:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
+  l937:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12850,39 +12939,39 @@ YY_RULE(int) yy_Decl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Decl"));
 
-  {  int yypos945= G->pos, yythunkpos945= G->thunkpos;  if (!yy_ClassDecl(G))  goto l946;
-  goto l945;
-  l946:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_CoverDecl(G))  goto l947;
-  goto l945;
-  l947:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_ExtendDecl(G))  goto l948;
-  goto l945;
-  l948:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_EnumDecl(G))  goto l949;
-  goto l945;
-  l949:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_InterfaceDecl(G))  goto l950;
-  goto l945;
-  l950:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_OperatorDecl(G))  goto l951;
-  goto l945;
-  l951:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_FunctionDecl(G))  goto l952;
-  goto l945;
-  l952:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_PropertyDecl(G))  goto l953;
-  goto l945;
-  l953:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;  if (!yy_VariableDecl(G))  goto l944;
+  {  int yypos951= G->pos, yythunkpos951= G->thunkpos;  if (!yy_ClassDecl(G))  goto l952;
+  goto l951;
+  l952:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_CoverDecl(G))  goto l953;
+  goto l951;
+  l953:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_ExtendDecl(G))  goto l954;
+  goto l951;
+  l954:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_EnumDecl(G))  goto l955;
+  goto l951;
+  l955:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_InterfaceDecl(G))  goto l956;
+  goto l951;
+  l956:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_OperatorDecl(G))  goto l957;
+  goto l951;
+  l957:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_FunctionDecl(G))  goto l958;
+  goto l951;
+  l958:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_PropertyDecl(G))  goto l959;
+  goto l951;
+  l959:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_VariableDecl(G))  goto l950;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_Terminator(G))  goto l944;
+  if (!yy_Terminator(G))  goto l950;
 
-  l954:;	
-  {  int yypos955= G->pos, yythunkpos955= G->thunkpos;  if (!yy_Terminator(G))  goto l955;
-  goto l954;
-  l955:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;
+  l960:;	
+  {  int yypos961= G->pos, yythunkpos961= G->thunkpos;  if (!yy_Terminator(G))  goto l961;
+  goto l960;
+  l961:;	  G->pos= yypos961; G->thunkpos= yythunkpos961;
   }  yyDo(G, yy_1_Decl, G->begin, G->end, "yy_1_Decl");
 
   }
-  l945:;	  yyprintf((stderr, "  ok   Decl"));
+  l951:;	  yyprintf((stderr, "  ok   Decl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l944:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
+  l950:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12890,24 +12979,24 @@ YY_RULE(int) yy_Decl(GREG *G)
 }
 YY_RULE(int) yy_Use(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Use"));
-  if (!yy_USE_KW(G))  goto l956;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l956;
-  if (!yy__(G))  goto l956;
-  if (!yy_UseCore(G))  goto l956;
+  if (!yy_USE_KW(G))  goto l962;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l962;
+  if (!yy__(G))  goto l962;
+  if (!yy_UseCore(G))  goto l962;
 
-  l957:;	
-  {  int yypos958= G->pos, yythunkpos958= G->thunkpos;  if (!yy__(G))  goto l958;
-  if (!yymatchChar(G, ',')) goto l958;
-  if (!yy__(G))  goto l958;
-  if (!yy_UseCore(G))  goto l958;
-  goto l957;
-  l958:;	  G->pos= yypos958; G->thunkpos= yythunkpos958;
+  l963:;	
+  {  int yypos964= G->pos, yythunkpos964= G->thunkpos;  if (!yy__(G))  goto l964;
+  if (!yymatchChar(G, ',')) goto l964;
+  if (!yy__(G))  goto l964;
+  if (!yy_UseCore(G))  goto l964;
+  goto l963;
+  l964:;	  G->pos= yypos964; G->thunkpos= yythunkpos964;
   }  yyprintf((stderr, "  ok   Use"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l956:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
+  l962:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12915,24 +13004,24 @@ YY_RULE(int) yy_Use(GREG *G)
 }
 YY_RULE(int) yy_Import(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Import"));
-  if (!yy_IMPORT_KW(G))  goto l959;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l959;
-  if (!yy__(G))  goto l959;
-  if (!yy_ImportAtom(G))  goto l959;
+  if (!yy_IMPORT_KW(G))  goto l965;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l965;
+  if (!yy__(G))  goto l965;
+  if (!yy_ImportAtom(G))  goto l965;
 
-  l960:;	
-  {  int yypos961= G->pos, yythunkpos961= G->thunkpos;  if (!yymatchChar(G, ',')) goto l961;
-  if (!yy_WS(G))  goto l961;
-  if (!yy__(G))  goto l961;
-  if (!yy_ImportAtom(G))  goto l961;
-  goto l960;
-  l961:;	  G->pos= yypos961; G->thunkpos= yythunkpos961;
+  l966:;	
+  {  int yypos967= G->pos, yythunkpos967= G->thunkpos;  if (!yymatchChar(G, ',')) goto l967;
+  if (!yy_WS(G))  goto l967;
+  if (!yy__(G))  goto l967;
+  if (!yy_ImportAtom(G))  goto l967;
+  goto l966;
+  l967:;	  G->pos= yypos967; G->thunkpos= yythunkpos967;
   }  yyprintf((stderr, "  ok   Import"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l959:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
+  l965:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12940,24 +13029,24 @@ YY_RULE(int) yy_Import(GREG *G)
 }
 YY_RULE(int) yy_Include(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Include"));
-  if (!yy_INCLUDE_KW(G))  goto l962;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l962;
-  if (!yy__(G))  goto l962;
-  if (!yy_IncludeCore(G))  goto l962;
+  if (!yy_INCLUDE_KW(G))  goto l968;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l968;
+  if (!yy__(G))  goto l968;
+  if (!yy_IncludeCore(G))  goto l968;
 
-  l963:;	
-  {  int yypos964= G->pos, yythunkpos964= G->thunkpos;  if (!yy__(G))  goto l964;
-  if (!yymatchChar(G, ',')) goto l964;
-  if (!yy__(G))  goto l964;
-  if (!yy_IncludeCore(G))  goto l964;
-  goto l963;
-  l964:;	  G->pos= yypos964; G->thunkpos= yythunkpos964;
+  l969:;	
+  {  int yypos970= G->pos, yythunkpos970= G->thunkpos;  if (!yy__(G))  goto l970;
+  if (!yymatchChar(G, ',')) goto l970;
+  if (!yy__(G))  goto l970;
+  if (!yy_IncludeCore(G))  goto l970;
+  goto l969;
+  l970:;	  G->pos= yypos970; G->thunkpos= yythunkpos970;
   }  yyprintf((stderr, "  ok   Include"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l962:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
+  l968:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12967,120 +13056,120 @@ YY_RULE(int) yy_Stmt(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Stmt"));
 
-  {  int yypos966= G->pos, yythunkpos966= G->thunkpos;  if (!yy_Old(G))  goto l967;
+  {  int yypos972= G->pos, yythunkpos972= G->thunkpos;  if (!yy_Old(G))  goto l973;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l967;
-  if (!yymatchString(G, "version")) goto l967;
-  yyDo(G, yy_1_Stmt, G->begin, G->end, "yy_1_Stmt");
-  if (!yy_WS(G))  goto l967;
-  if (!yymatchChar(G, '(')) goto l967;
-  if (!yy__(G))  goto l967;
-  if (!yy_VersionSpec(G))  goto l967;
-  yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_WS(G))  goto l967;
-  if (!yymatchChar(G, ')')) goto l967;
-
-  {  int yypos968= G->pos, yythunkpos968= G->thunkpos;  if (!yy__(G))  goto l969;
-  if (!yymatchChar(G, '{')) goto l969;
-  yyDo(G, yy_2_Stmt, G->begin, G->end, "yy_2_Stmt");
-  if (!yy_WS(G))  goto l969;
-
-  l970:;	
-  {  int yypos971= G->pos, yythunkpos971= G->thunkpos;  if (!yy_Stmt(G))  goto l971;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_Stmt, G->begin, G->end, "yy_3_Stmt");
-  goto l970;
-  l971:;	  G->pos= yypos971; G->thunkpos= yythunkpos971;
-  }  if (!yy_WS(G))  goto l969;
-  if (!yy__(G))  goto l969;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l969; }
-  yyDo(G, yy_4_Stmt, G->begin, G->end, "yy_4_Stmt");
-  goto l968;
-  l969:;	  G->pos= yypos968; G->thunkpos= yythunkpos968;  if (!yy__(G))  goto l967;
-  if (!yy_Stmt(G))  goto l967;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_5_Stmt, G->begin, G->end, "yy_5_Stmt");
-
-  }
-  l968:;	
-  l972:;	
-  {  int yypos973= G->pos, yythunkpos973= G->thunkpos;  if (!yy_WS(G))  goto l973;
-  if (!yymatchString(G, "else")) goto l973;
-  if (!yy__(G))  goto l973;
+  if (!yy_WS(G))  goto l973;
   if (!yymatchString(G, "version")) goto l973;
-  yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
+  yyDo(G, yy_1_Stmt, G->begin, G->end, "yy_1_Stmt");
   if (!yy_WS(G))  goto l973;
   if (!yymatchChar(G, '(')) goto l973;
   if (!yy__(G))  goto l973;
   if (!yy_VersionSpec(G))  goto l973;
-  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yySet, -3, 0, "yySet");
   if (!yy_WS(G))  goto l973;
   if (!yymatchChar(G, ')')) goto l973;
 
   {  int yypos974= G->pos, yythunkpos974= G->thunkpos;  if (!yy__(G))  goto l975;
   if (!yymatchChar(G, '{')) goto l975;
-  yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
+  yyDo(G, yy_2_Stmt, G->begin, G->end, "yy_2_Stmt");
   if (!yy_WS(G))  goto l975;
 
   l976:;	
   {  int yypos977= G->pos, yythunkpos977= G->thunkpos;  if (!yy_Stmt(G))  goto l977;
   yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_8_Stmt, G->begin, G->end, "yy_8_Stmt");
+  yyDo(G, yy_3_Stmt, G->begin, G->end, "yy_3_Stmt");
   goto l976;
   l977:;	  G->pos= yypos977; G->thunkpos= yythunkpos977;
   }  if (!yy_WS(G))  goto l975;
   if (!yy__(G))  goto l975;
   if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l975; }
-  yyDo(G, yy_9_Stmt, G->begin, G->end, "yy_9_Stmt");
+  yyDo(G, yy_4_Stmt, G->begin, G->end, "yy_4_Stmt");
   goto l974;
   l975:;	  G->pos= yypos974; G->thunkpos= yythunkpos974;  if (!yy__(G))  goto l973;
   if (!yy_Stmt(G))  goto l973;
   yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_10_Stmt, G->begin, G->end, "yy_10_Stmt");
+  yyDo(G, yy_5_Stmt, G->begin, G->end, "yy_5_Stmt");
 
   }
-  l974:;	  goto l972;
-  l973:;	  G->pos= yypos973; G->thunkpos= yythunkpos973;
-  }
-  {  int yypos978= G->pos, yythunkpos978= G->thunkpos;  if (!yy_WS(G))  goto l978;
-  if (!yymatchString(G, "else")) goto l978;
-  yyDo(G, yy_11_Stmt, G->begin, G->end, "yy_11_Stmt");
+  l974:;	
+  l978:;	
+  {  int yypos979= G->pos, yythunkpos979= G->thunkpos;  if (!yy_WS(G))  goto l979;
+  if (!yymatchString(G, "else")) goto l979;
+  if (!yy__(G))  goto l979;
+  if (!yymatchString(G, "version")) goto l979;
+  yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
+  if (!yy_WS(G))  goto l979;
+  if (!yymatchChar(G, '(')) goto l979;
+  if (!yy__(G))  goto l979;
+  if (!yy_VersionSpec(G))  goto l979;
+  yyDo(G, yySet, -1, 0, "yySet");
+  if (!yy_WS(G))  goto l979;
+  if (!yymatchChar(G, ')')) goto l979;
 
   {  int yypos980= G->pos, yythunkpos980= G->thunkpos;  if (!yy__(G))  goto l981;
   if (!yymatchChar(G, '{')) goto l981;
-  yyDo(G, yy_12_Stmt, G->begin, G->end, "yy_12_Stmt");
+  yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
   if (!yy_WS(G))  goto l981;
 
   l982:;	
   {  int yypos983= G->pos, yythunkpos983= G->thunkpos;  if (!yy_Stmt(G))  goto l983;
   yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_13_Stmt, G->begin, G->end, "yy_13_Stmt");
+  yyDo(G, yy_8_Stmt, G->begin, G->end, "yy_8_Stmt");
   goto l982;
   l983:;	  G->pos= yypos983; G->thunkpos= yythunkpos983;
   }  if (!yy_WS(G))  goto l981;
   if (!yy__(G))  goto l981;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l981; }
-  yyDo(G, yy_14_Stmt, G->begin, G->end, "yy_14_Stmt");
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l981; }
+  yyDo(G, yy_9_Stmt, G->begin, G->end, "yy_9_Stmt");
   goto l980;
-  l981:;	  G->pos= yypos980; G->thunkpos= yythunkpos980;  if (!yy__(G))  goto l978;
-  if (!yy_Stmt(G))  goto l978;
+  l981:;	  G->pos= yypos980; G->thunkpos= yythunkpos980;  if (!yy__(G))  goto l979;
+  if (!yy_Stmt(G))  goto l979;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_10_Stmt, G->begin, G->end, "yy_10_Stmt");
+
+  }
+  l980:;	  goto l978;
+  l979:;	  G->pos= yypos979; G->thunkpos= yythunkpos979;
+  }
+  {  int yypos984= G->pos, yythunkpos984= G->thunkpos;  if (!yy_WS(G))  goto l984;
+  if (!yymatchString(G, "else")) goto l984;
+  yyDo(G, yy_11_Stmt, G->begin, G->end, "yy_11_Stmt");
+
+  {  int yypos986= G->pos, yythunkpos986= G->thunkpos;  if (!yy__(G))  goto l987;
+  if (!yymatchChar(G, '{')) goto l987;
+  yyDo(G, yy_12_Stmt, G->begin, G->end, "yy_12_Stmt");
+  if (!yy_WS(G))  goto l987;
+
+  l988:;	
+  {  int yypos989= G->pos, yythunkpos989= G->thunkpos;  if (!yy_Stmt(G))  goto l989;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_13_Stmt, G->begin, G->end, "yy_13_Stmt");
+  goto l988;
+  l989:;	  G->pos= yypos989; G->thunkpos= yythunkpos989;
+  }  if (!yy_WS(G))  goto l987;
+  if (!yy__(G))  goto l987;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l987; }
+  yyDo(G, yy_14_Stmt, G->begin, G->end, "yy_14_Stmt");
+  goto l986;
+  l987:;	  G->pos= yypos986; G->thunkpos= yythunkpos986;  if (!yy__(G))  goto l984;
+  if (!yy_Stmt(G))  goto l984;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_15_Stmt, G->begin, G->end, "yy_15_Stmt");
 
   }
-  l980:;	  goto l979;
-  l978:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;
+  l986:;	  goto l985;
+  l984:;	  G->pos= yypos984; G->thunkpos= yythunkpos984;
   }
-  l979:;	  goto l966;
-  l967:;	  G->pos= yypos966; G->thunkpos= yythunkpos966;  if (!yy_StmtCore(G))  goto l965;
+  l985:;	  goto l972;
+  l973:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_StmtCore(G))  goto l971;
 
   }
-  l966:;	  yyprintf((stderr, "  ok   Stmt"));
+  l972:;	  yyprintf((stderr, "  ok   Stmt"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l965:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
+  l971:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13088,13 +13177,13 @@ YY_RULE(int) yy_Stmt(GREG *G)
 }
 YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_BRACK"));
-  if (!yymatchChar(G, '}')) goto l984;
+  if (!yymatchChar(G, '}')) goto l990;
   yyprintf((stderr, "  ok   CLOS_BRACK"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l984:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
+  l990:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13102,13 +13191,13 @@ YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 }
 YY_RULE(int) yy_CLOS_PAREN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_PAREN"));
-  if (!yymatchChar(G, ')')) goto l985;
+  if (!yymatchChar(G, ')')) goto l991;
   yyprintf((stderr, "  ok   CLOS_PAREN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l985:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
+  l991:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13118,46 +13207,46 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionSpec"));
 
-  {  int yypos987= G->pos, yythunkpos987= G->thunkpos;  if (!yy__(G))  goto l988;
-  if (!yymatchChar(G, '(')) goto l988;
-  if (!yy__(G))  goto l988;
-  if (!yy_VersionSpec(G))  goto l988;
+  {  int yypos993= G->pos, yythunkpos993= G->thunkpos;  if (!yy__(G))  goto l994;
+  if (!yymatchChar(G, '(')) goto l994;
+  if (!yy__(G))  goto l994;
+  if (!yy_VersionSpec(G))  goto l994;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l988;
-  if (!yymatchChar(G, ')')) goto l988;
-  goto l987;
-  l988:;	  G->pos= yypos987; G->thunkpos= yythunkpos987;  if (!yy_VersionCore(G))  goto l986;
+  if (!yy__(G))  goto l994;
+  if (!yymatchChar(G, ')')) goto l994;
+  goto l993;
+  l994:;	  G->pos= yypos993; G->thunkpos= yythunkpos993;  if (!yy_VersionCore(G))  goto l992;
   yyDo(G, yySet, -2, 0, "yySet");
 
   }
-  l987:;	
-  l989:;	
-  {  int yypos990= G->pos, yythunkpos990= G->thunkpos;
-  {  int yypos991= G->pos, yythunkpos991= G->thunkpos;  if (!yy__(G))  goto l992;
-  if (!yymatchString(G, "&&")) goto l992;
+  l993:;	
+  l995:;	
+  {  int yypos996= G->pos, yythunkpos996= G->thunkpos;
+  {  int yypos997= G->pos, yythunkpos997= G->thunkpos;  if (!yy__(G))  goto l998;
+  if (!yymatchString(G, "&&")) goto l998;
   yyDo(G, yy_1_VersionSpec, G->begin, G->end, "yy_1_VersionSpec");
-  if (!yy__(G))  goto l992;
-  if (!yy_VersionSpec(G))  goto l992;
+  if (!yy__(G))  goto l998;
+  if (!yy_VersionSpec(G))  goto l998;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionSpec, G->begin, G->end, "yy_2_VersionSpec");
-  goto l991;
-  l992:;	  G->pos= yypos991; G->thunkpos= yythunkpos991;  if (!yy__(G))  goto l990;
-  if (!yymatchString(G, "||")) goto l990;
+  goto l997;
+  l998:;	  G->pos= yypos997; G->thunkpos= yythunkpos997;  if (!yy__(G))  goto l996;
+  if (!yymatchString(G, "||")) goto l996;
   yyDo(G, yy_3_VersionSpec, G->begin, G->end, "yy_3_VersionSpec");
-  if (!yy__(G))  goto l990;
-  if (!yy_VersionSpec(G))  goto l990;
+  if (!yy__(G))  goto l996;
+  if (!yy_VersionSpec(G))  goto l996;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_VersionSpec, G->begin, G->end, "yy_4_VersionSpec");
 
   }
-  l991:;	  goto l989;
-  l990:;	  G->pos= yypos990; G->thunkpos= yythunkpos990;
+  l997:;	  goto l995;
+  l996:;	  G->pos= yypos996; G->thunkpos= yythunkpos996;
   }  yyprintf((stderr, "  ok   VersionSpec"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l986:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
+  l992:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13166,15 +13255,15 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 YY_RULE(int) yy__(GREG *G)
 {  yyprintfv((stderr, "%s\n", "_"));
 
-  l994:;	
-  {  int yypos995= G->pos, yythunkpos995= G->thunkpos;
-  {  int yypos996= G->pos, yythunkpos996= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l997;
-  goto l996;
-  l997:;	  G->pos= yypos996; G->thunkpos= yythunkpos996;  if (!yy_CommentMultiLine(G))  goto l995;
+  l1000:;	
+  {  int yypos1001= G->pos, yythunkpos1001= G->thunkpos;
+  {  int yypos1002= G->pos, yythunkpos1002= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1003;
+  goto l1002;
+  l1003:;	  G->pos= yypos1002; G->thunkpos= yythunkpos1002;  if (!yy_CommentMultiLine(G))  goto l1001;
 
   }
-  l996:;	  goto l994;
-  l995:;	  G->pos= yypos995; G->thunkpos= yythunkpos995;
+  l1002:;	  goto l1000;
+  l1001:;	  G->pos= yypos1001; G->thunkpos= yythunkpos1001;
   }  yyprintf((stderr, "  ok   _"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13184,20 +13273,20 @@ YY_RULE(int) yy__(GREG *G)
 YY_RULE(int) yy_EOL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EOL"));
 
-  {  int yypos999= G->pos, yythunkpos999= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1000;
-  goto l999;
-  l1000:;	  G->pos= yypos999; G->thunkpos= yythunkpos999;  if (!yymatchString(G, "\r\n")) goto l1001;
-  goto l999;
-  l1001:;	  G->pos= yypos999; G->thunkpos= yythunkpos999;  if (!yymatchChar(G, '\r')) goto l998;
+  {  int yypos1005= G->pos, yythunkpos1005= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1006;
+  goto l1005;
+  l1006:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yymatchString(G, "\r\n")) goto l1007;
+  goto l1005;
+  l1007:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yymatchChar(G, '\r')) goto l1004;
 
   }
-  l999:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
+  l1005:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
   yyprintf((stderr, "  ok   EOL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l998:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
+  l1004:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13206,17 +13295,17 @@ YY_RULE(int) yy_EOL(GREG *G)
 YY_RULE(int) yy_WS(GREG *G)
 {  yyprintfv((stderr, "%s\n", "WS"));
 
-  l1003:;	
-  {  int yypos1004= G->pos, yythunkpos1004= G->thunkpos;
-  {  int yypos1005= G->pos, yythunkpos1005= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1006;
-  goto l1005;
-  l1006:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yy_Comment(G))  goto l1007;
-  goto l1005;
-  l1007:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yy_EOL(G))  goto l1004;
+  l1009:;	
+  {  int yypos1010= G->pos, yythunkpos1010= G->thunkpos;
+  {  int yypos1011= G->pos, yythunkpos1011= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1012;
+  goto l1011;
+  l1012:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy_Comment(G))  goto l1013;
+  goto l1011;
+  l1013:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy_EOL(G))  goto l1010;
 
   }
-  l1005:;	  goto l1003;
-  l1004:;	  G->pos= yypos1004; G->thunkpos= yythunkpos1004;
+  l1011:;	  goto l1009;
+  l1010:;	  G->pos= yypos1010; G->thunkpos= yythunkpos1010;
   }  yyprintf((stderr, "  ok   WS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13227,55 +13316,20 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ModuleCore"));
 
-  {  int yypos1009= G->pos, yythunkpos1009= G->thunkpos;  if (!yy_WS(G))  goto l1010;
-  if (!yymatchString(G, "version")) goto l1010;
-  yyDo(G, yy_1_ModuleCore, G->begin, G->end, "yy_1_ModuleCore");
-  if (!yy_WS(G))  goto l1010;
-  if (!yymatchChar(G, '(')) goto l1010;
-  if (!yy__(G))  goto l1010;
-  if (!yy_VersionSpec(G))  goto l1010;
-  yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l1010;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1010; }
-
-  {  int yypos1011= G->pos, yythunkpos1011= G->thunkpos;  if (!yy__(G))  goto l1012;
-  if (!yymatchChar(G, '{')) goto l1012;
-  yyDo(G, yy_2_ModuleCore, G->begin, G->end, "yy_2_ModuleCore");
-  if (!yy_WS(G))  goto l1012;
-
-  l1013:;	
-  {  int yypos1014= G->pos, yythunkpos1014= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1014;
-  goto l1013;
-  l1014:;	  G->pos= yypos1014; G->thunkpos= yythunkpos1014;
-  }  if (!yy_WS(G))  goto l1012;
-  if (!yy__(G))  goto l1012;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1012; }
-  yyDo(G, yy_3_ModuleCore, G->begin, G->end, "yy_3_ModuleCore");
-  goto l1011;
-  l1012:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy__(G))  goto l1010;
-  if (!yy_Stmt(G))  goto l1010;
-  yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_4_ModuleCore, G->begin, G->end, "yy_4_ModuleCore");
-
-  }
-  l1011:;	
-  l1015:;	
-  {  int yypos1016= G->pos, yythunkpos1016= G->thunkpos;  if (!yy_WS(G))  goto l1016;
-  if (!yymatchString(G, "else")) goto l1016;
-  if (!yy__(G))  goto l1016;
+  {  int yypos1015= G->pos, yythunkpos1015= G->thunkpos;  if (!yy_WS(G))  goto l1016;
   if (!yymatchString(G, "version")) goto l1016;
-  yyDo(G, yy_5_ModuleCore, G->begin, G->end, "yy_5_ModuleCore");
+  yyDo(G, yy_1_ModuleCore, G->begin, G->end, "yy_1_ModuleCore");
   if (!yy_WS(G))  goto l1016;
   if (!yymatchChar(G, '(')) goto l1016;
   if (!yy__(G))  goto l1016;
   if (!yy_VersionSpec(G))  goto l1016;
-  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yySet, -4, 0, "yySet");
   if (!yy_WS(G))  goto l1016;
-  if (!yymatchChar(G, ')')) goto l1016;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1016; }
 
   {  int yypos1017= G->pos, yythunkpos1017= G->thunkpos;  if (!yy__(G))  goto l1018;
   if (!yymatchChar(G, '{')) goto l1018;
-  yyDo(G, yy_6_ModuleCore, G->begin, G->end, "yy_6_ModuleCore");
+  yyDo(G, yy_2_ModuleCore, G->begin, G->end, "yy_2_ModuleCore");
   if (!yy_WS(G))  goto l1018;
 
   l1019:;	
@@ -13285,24 +13339,32 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
   }  if (!yy_WS(G))  goto l1018;
   if (!yy__(G))  goto l1018;
   if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1018; }
-  yyDo(G, yy_7_ModuleCore, G->begin, G->end, "yy_7_ModuleCore");
+  yyDo(G, yy_3_ModuleCore, G->begin, G->end, "yy_3_ModuleCore");
   goto l1017;
   l1018:;	  G->pos= yypos1017; G->thunkpos= yythunkpos1017;  if (!yy__(G))  goto l1016;
   if (!yy_Stmt(G))  goto l1016;
   yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_8_ModuleCore, G->begin, G->end, "yy_8_ModuleCore");
+  yyDo(G, yy_4_ModuleCore, G->begin, G->end, "yy_4_ModuleCore");
 
   }
-  l1017:;	  goto l1015;
-  l1016:;	  G->pos= yypos1016; G->thunkpos= yythunkpos1016;
-  }
-  {  int yypos1021= G->pos, yythunkpos1021= G->thunkpos;  if (!yy_WS(G))  goto l1021;
-  if (!yymatchString(G, "else")) goto l1021;
-  yyDo(G, yy_9_ModuleCore, G->begin, G->end, "yy_9_ModuleCore");
+  l1017:;	
+  l1021:;	
+  {  int yypos1022= G->pos, yythunkpos1022= G->thunkpos;  if (!yy_WS(G))  goto l1022;
+  if (!yymatchString(G, "else")) goto l1022;
+  if (!yy__(G))  goto l1022;
+  if (!yymatchString(G, "version")) goto l1022;
+  yyDo(G, yy_5_ModuleCore, G->begin, G->end, "yy_5_ModuleCore");
+  if (!yy_WS(G))  goto l1022;
+  if (!yymatchChar(G, '(')) goto l1022;
+  if (!yy__(G))  goto l1022;
+  if (!yy_VersionSpec(G))  goto l1022;
+  yyDo(G, yySet, -2, 0, "yySet");
+  if (!yy_WS(G))  goto l1022;
+  if (!yymatchChar(G, ')')) goto l1022;
 
   {  int yypos1023= G->pos, yythunkpos1023= G->thunkpos;  if (!yy__(G))  goto l1024;
   if (!yymatchChar(G, '{')) goto l1024;
-  yyDo(G, yy_10_ModuleCore, G->begin, G->end, "yy_10_ModuleCore");
+  yyDo(G, yy_6_ModuleCore, G->begin, G->end, "yy_6_ModuleCore");
   if (!yy_WS(G))  goto l1024;
 
   l1025:;	
@@ -13312,55 +13374,82 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
   }  if (!yy_WS(G))  goto l1024;
   if (!yy__(G))  goto l1024;
   if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1024; }
-  yyDo(G, yy_11_ModuleCore, G->begin, G->end, "yy_11_ModuleCore");
+  yyDo(G, yy_7_ModuleCore, G->begin, G->end, "yy_7_ModuleCore");
   goto l1023;
-  l1024:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;  if (!yy__(G))  goto l1021;
-  if (!yy_Stmt(G))  goto l1021;
+  l1024:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;  if (!yy__(G))  goto l1022;
+  if (!yy_Stmt(G))  goto l1022;
+  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yy_8_ModuleCore, G->begin, G->end, "yy_8_ModuleCore");
+
+  }
+  l1023:;	  goto l1021;
+  l1022:;	  G->pos= yypos1022; G->thunkpos= yythunkpos1022;
+  }
+  {  int yypos1027= G->pos, yythunkpos1027= G->thunkpos;  if (!yy_WS(G))  goto l1027;
+  if (!yymatchString(G, "else")) goto l1027;
+  yyDo(G, yy_9_ModuleCore, G->begin, G->end, "yy_9_ModuleCore");
+
+  {  int yypos1029= G->pos, yythunkpos1029= G->thunkpos;  if (!yy__(G))  goto l1030;
+  if (!yymatchChar(G, '{')) goto l1030;
+  yyDo(G, yy_10_ModuleCore, G->begin, G->end, "yy_10_ModuleCore");
+  if (!yy_WS(G))  goto l1030;
+
+  l1031:;	
+  {  int yypos1032= G->pos, yythunkpos1032= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1032;
+  goto l1031;
+  l1032:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;
+  }  if (!yy_WS(G))  goto l1030;
+  if (!yy__(G))  goto l1030;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1030; }
+  yyDo(G, yy_11_ModuleCore, G->begin, G->end, "yy_11_ModuleCore");
+  goto l1029;
+  l1030:;	  G->pos= yypos1029; G->thunkpos= yythunkpos1029;  if (!yy__(G))  goto l1027;
+  if (!yy_Stmt(G))  goto l1027;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_12_ModuleCore, G->begin, G->end, "yy_12_ModuleCore");
 
   }
-  l1023:;	  goto l1022;
-  l1021:;	  G->pos= yypos1021; G->thunkpos= yythunkpos1021;
+  l1029:;	  goto l1028;
+  l1027:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;
   }
-  l1022:;	  goto l1009;
-  l1010:;	  G->pos= yypos1009; G->thunkpos= yythunkpos1009;
-  {  int yypos1027= G->pos, yythunkpos1027= G->thunkpos;  if (!yy_WS(G))  goto l1028;
-  if (!yy_Include(G))  goto l1028;
-  if (!yy_WS(G))  goto l1028;
-  goto l1027;
-  l1028:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;  if (!yy_WS(G))  goto l1029;
-  if (!yy_Import(G))  goto l1029;
-  if (!yy_WS(G))  goto l1029;
-  goto l1027;
-  l1029:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;  if (!yy_WS(G))  goto l1030;
-  if (!yy_Use(G))  goto l1030;
-  if (!yy_WS(G))  goto l1030;
-  goto l1027;
-  l1030:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;  if (!yy_WS(G))  goto l1031;
-  if (!yy_Decl(G))  goto l1031;
-  if (!yy_WS(G))  goto l1031;
-  goto l1027;
-  l1031:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;  if (!yy_WS(G))  goto l1032;
-  if (!yy_Stmt(G))  goto l1032;
+  l1028:;	  goto l1015;
+  l1016:;	  G->pos= yypos1015; G->thunkpos= yythunkpos1015;
+  {  int yypos1033= G->pos, yythunkpos1033= G->thunkpos;  if (!yy_WS(G))  goto l1034;
+  if (!yy_Include(G))  goto l1034;
+  if (!yy_WS(G))  goto l1034;
+  goto l1033;
+  l1034:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1035;
+  if (!yy_Import(G))  goto l1035;
+  if (!yy_WS(G))  goto l1035;
+  goto l1033;
+  l1035:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1036;
+  if (!yy_Use(G))  goto l1036;
+  if (!yy_WS(G))  goto l1036;
+  goto l1033;
+  l1036:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1037;
+  if (!yy_Decl(G))  goto l1037;
+  if (!yy_WS(G))  goto l1037;
+  goto l1033;
+  l1037:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1038;
+  if (!yy_Stmt(G))  goto l1038;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l1032;
+  if (!yy_WS(G))  goto l1038;
   yyDo(G, yy_13_ModuleCore, G->begin, G->end, "yy_13_ModuleCore");
-  goto l1027;
-  l1032:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;  if (!yy_WS(G))  goto l1008;
+  goto l1033;
+  l1038:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1014;
   yyDo(G, yy_14_ModuleCore, G->begin, G->end, "yy_14_ModuleCore");
-  if (!yy_OocDocCore(G))  goto l1008;
+  if (!yy_OocDocCore(G))  goto l1014;
   yyDo(G, yy_15_ModuleCore, G->begin, G->end, "yy_15_ModuleCore");
 
   }
-  l1027:;	
+  l1033:;	
   }
-  l1009:;	  yyprintf((stderr, "  ok   ModuleCore"));
+  l1015:;	  yyprintf((stderr, "  ok   ModuleCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l1008:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
+  l1014:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13369,27 +13458,27 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 YY_RULE(int) yy_Module(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Module"));
 
-  {  int yypos1034= G->pos, yythunkpos1034= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1035;
-  goto l1034;
-  l1035:;	  G->pos= yypos1034; G->thunkpos= yythunkpos1034;  if (!yy_WS(G))  goto l1033;
+  {  int yypos1040= G->pos, yythunkpos1040= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1041;
+  goto l1040;
+  l1041:;	  G->pos= yypos1040; G->thunkpos= yythunkpos1040;  if (!yy_WS(G))  goto l1039;
 
-  l1036:;	
-  {  int yypos1037= G->pos, yythunkpos1037= G->thunkpos;
-  {  int yypos1038= G->pos, yythunkpos1038= G->thunkpos;  if (!yy_EOL(G))  goto l1038;
-  goto l1037;
-  l1038:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;
-  }  if (!yymatchDot(G)) goto l1037;  goto l1036;
-  l1037:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;
-  }  if (!yy_EOL(G))  goto l1033;
+  l1042:;	
+  {  int yypos1043= G->pos, yythunkpos1043= G->thunkpos;
+  {  int yypos1044= G->pos, yythunkpos1044= G->thunkpos;  if (!yy_EOL(G))  goto l1044;
+  goto l1043;
+  l1044:;	  G->pos= yypos1044; G->thunkpos= yythunkpos1044;
+  }  if (!yymatchDot(G)) goto l1043;  goto l1042;
+  l1043:;	  G->pos= yypos1043; G->thunkpos= yythunkpos1043;
+  }  if (!yy_EOL(G))  goto l1039;
   yyDo(G, yy_1_Module, G->begin, G->end, "yy_1_Module");
 
   }
-  l1034:;	  yyprintf((stderr, "  ok   Module"));
+  l1040:;	  yyprintf((stderr, "  ok   Module"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1033:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
+  l1039:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 

--- a/source/rock/frontend/NagaQueen.c
+++ b/source/rock/frontend/NagaQueen.c
@@ -402,6 +402,7 @@ void *nq_onBinaryXor(void *this, void *left, void *right);
 void *nq_onBinaryAnd(void *this, void *left, void *right);
 
 void nq_onSafeNavigationStart(void *this, void *expr);
+void nq_onSafeNavigationSection(void *this);
 void nq_onSafeNavigationIdent(void *this, char *ident);
 void *nq_onSafeNavigationEnd(void *this);
 
@@ -2003,14 +2004,25 @@ YY_ACTION(void) yy_1_Access(GREG *G, char *yytext, int yyleng, yythunk *thunk, Y
 #undef l
 #undef ident
 }
+YY_ACTION(void) yy_4_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define expr G->val[-2]
+  yyprintf((stderr, "do yy_4_SafeNavAccess"));
+  yyprintfvTcontext(yytext);
+  yyprintf((stderr, "\n  {yy=nq_onSafeNavigationEnd(core->this); }\n"));
+  yy=nq_onSafeNavigationEnd(core->this); ;
+#undef i
+#undef expr
+}
 YY_ACTION(void) yy_3_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define i G->val[-1]
 #define expr G->val[-2]
   yyprintf((stderr, "do yy_3_SafeNavAccess"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {yy=nq_onSafeNavigationEnd(core->this); }\n"));
-  yy=nq_onSafeNavigationEnd(core->this); ;
+  yyprintf((stderr, "\n  {nq_onSafeNavigationIdent(core->this, i); }\n"));
+  nq_onSafeNavigationIdent(core->this, i); ;
 #undef i
 #undef expr
 }
@@ -2020,8 +2032,8 @@ YY_ACTION(void) yy_2_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *t
 #define expr G->val[-2]
   yyprintf((stderr, "do yy_2_SafeNavAccess"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onSafeNavigationIdent(core->this, i); }\n"));
-  nq_onSafeNavigationIdent(core->this, i); ;
+  yyprintf((stderr, "\n  {nq_onSafeNavigationSection(core->this); }\n"));
+  nq_onSafeNavigationSection(core->this); ;
 #undef i
 #undef expr
 }
@@ -7885,20 +7897,36 @@ YY_RULE(int) yy_SafeNavAccess(GREG *G)
 
   {  int yypos219= G->pos, yythunkpos219= G->thunkpos;  yyDo(G, yy_1_SafeNavAccess, G->begin, G->end, "yy_1_SafeNavAccess");
   if (!yy_SAFE_NAV(G))  goto l219;
+  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
   if (!yy__(G))  goto l219;
   if (!yy_IDENT(G))  goto l219;
   yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
+  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
 
+  l223:;	
+  {  int yypos224= G->pos, yythunkpos224= G->thunkpos;  if (!yy_IDENT(G))  goto l224;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  goto l223;
+  l224:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;
+  }
   l221:;	
   {  int yypos222= G->pos, yythunkpos222= G->thunkpos;  if (!yy_SAFE_NAV(G))  goto l222;
+  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
   if (!yy__(G))  goto l222;
   if (!yy_IDENT(G))  goto l222;
   yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
-  goto l221;
+  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+
+  l225:;	
+  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;  if (!yy_IDENT(G))  goto l226;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  goto l225;
+  l226:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;
+  }  goto l221;
   l222:;	  G->pos= yypos222; G->thunkpos= yythunkpos222;
-  }  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  }  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
   goto l220;
   l219:;	  G->pos= yypos219; G->thunkpos= yythunkpos219;
   }
@@ -7915,18 +7943,18 @@ YY_RULE(int) yy_SafeNavAccess(GREG *G)
 }
 YY_RULE(int) yy_B_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_NOT"));
-  if (!yymatchChar(G, '~')) goto l223;
+  if (!yymatchChar(G, '~')) goto l227;
 
-  {  int yypos224= G->pos, yythunkpos224= G->thunkpos;  if (!yymatchChar(G, '=')) goto l224;
-  goto l223;
-  l224:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;
-  }  if (!yy__(G))  goto l223;
+  {  int yypos228= G->pos, yythunkpos228= G->thunkpos;  if (!yymatchChar(G, '=')) goto l228;
+  goto l227;
+  l228:;	  G->pos= yypos228; G->thunkpos= yythunkpos228;
+  }  if (!yy__(G))  goto l227;
   yyprintf((stderr, "  ok   B_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l223:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
+  l227:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7934,18 +7962,18 @@ YY_RULE(int) yy_B_NOT(GREG *G)
 }
 YY_RULE(int) yy_L_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_NOT"));
-  if (!yymatchChar(G, '!')) goto l225;
+  if (!yymatchChar(G, '!')) goto l229;
 
-  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;  if (!yymatchChar(G, '=')) goto l226;
-  goto l225;
-  l226:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;
-  }  if (!yy__(G))  goto l225;
+  {  int yypos230= G->pos, yythunkpos230= G->thunkpos;  if (!yymatchChar(G, '=')) goto l230;
+  goto l229;
+  l230:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;
+  }  if (!yy__(G))  goto l229;
   yyprintf((stderr, "  ok   L_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l225:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
+  l229:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7954,41 +7982,41 @@ YY_RULE(int) yy_L_NOT(GREG *G)
 YY_RULE(int) yy_ProductCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductCore"));
-  if (!yy_SafeNavAccess(G))  goto l227;
+  if (!yy_SafeNavAccess(G))  goto l231;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l228:;	
-  {  int yypos229= G->pos, yythunkpos229= G->thunkpos;
-  {  int yypos230= G->pos, yythunkpos230= G->thunkpos;  if (!yy_EXP(G))  goto l231;
+  l232:;	
+  {  int yypos233= G->pos, yythunkpos233= G->thunkpos;
+  {  int yypos234= G->pos, yythunkpos234= G->thunkpos;  if (!yy_EXP(G))  goto l235;
   yyDo(G, yy_1_ProductCore, G->begin, G->end, "yy_1_ProductCore");
-  if (!yy_WS(G))  goto l231;
-  if (!yy_Product(G))  goto l231;
+  if (!yy_WS(G))  goto l235;
+  if (!yy_Product(G))  goto l235;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ProductCore, G->begin, G->end, "yy_2_ProductCore");
-  goto l230;
-  l231:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;  if (!yy_STAR(G))  goto l232;
+  goto l234;
+  l235:;	  G->pos= yypos234; G->thunkpos= yythunkpos234;  if (!yy_STAR(G))  goto l236;
   yyDo(G, yy_3_ProductCore, G->begin, G->end, "yy_3_ProductCore");
-  if (!yy_WS(G))  goto l232;
-  if (!yy_SafeNavAccess(G))  goto l232;
+  if (!yy_WS(G))  goto l236;
+  if (!yy_SafeNavAccess(G))  goto l236;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_ProductCore, G->begin, G->end, "yy_4_ProductCore");
-  goto l230;
-  l232:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;  if (!yy_SLASH(G))  goto l229;
+  goto l234;
+  l236:;	  G->pos= yypos234; G->thunkpos= yythunkpos234;  if (!yy_SLASH(G))  goto l233;
   yyDo(G, yy_5_ProductCore, G->begin, G->end, "yy_5_ProductCore");
-  if (!yy_WS(G))  goto l229;
-  if (!yy_SafeNavAccess(G))  goto l229;
+  if (!yy_WS(G))  goto l233;
+  if (!yy_SafeNavAccess(G))  goto l233;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_ProductCore, G->begin, G->end, "yy_6_ProductCore");
 
   }
-  l230:;	  goto l228;
-  l229:;	  G->pos= yypos229; G->thunkpos= yythunkpos229;
+  l234:;	  goto l232;
+  l233:;	  G->pos= yypos233; G->thunkpos= yythunkpos233;
   }  yyprintf((stderr, "  ok   ProductCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l227:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
+  l231:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7997,19 +8025,19 @@ YY_RULE(int) yy_ProductCore(GREG *G)
 YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductBinaryNot"));
-  if (!yy_B_NOT(G))  goto l233;
+  if (!yy_B_NOT(G))  goto l237;
   yyDo(G, yy_1_ProductBinaryNot, G->begin, G->end, "yy_1_ProductBinaryNot");
-  if (!yy__(G))  goto l233;
-  if (!yy_Product(G))  goto l233;
+  if (!yy__(G))  goto l237;
+  if (!yy_Product(G))  goto l237;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l233;
+  if (!yy__(G))  goto l237;
   yyDo(G, yy_2_ProductBinaryNot, G->begin, G->end, "yy_2_ProductBinaryNot");
   yyprintf((stderr, "  ok   ProductBinaryNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l233:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
+  l237:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8018,19 +8046,19 @@ YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductLogicalNot"));
-  if (!yy_L_NOT(G))  goto l234;
+  if (!yy_L_NOT(G))  goto l238;
   yyDo(G, yy_1_ProductLogicalNot, G->begin, G->end, "yy_1_ProductLogicalNot");
-  if (!yy__(G))  goto l234;
-  if (!yy_Product(G))  goto l234;
+  if (!yy__(G))  goto l238;
+  if (!yy_Product(G))  goto l238;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l234;
+  if (!yy__(G))  goto l238;
   yyDo(G, yy_2_ProductLogicalNot, G->begin, G->end, "yy_2_ProductLogicalNot");
   yyprintf((stderr, "  ok   ProductLogicalNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l234:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
+  l238:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8038,18 +8066,18 @@ YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 }
 YY_RULE(int) yy_PERCENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PERCENT"));
-  if (!yymatchChar(G, '%')) goto l235;
+  if (!yymatchChar(G, '%')) goto l239;
 
-  {  int yypos236= G->pos, yythunkpos236= G->thunkpos;  if (!yymatchChar(G, '=')) goto l236;
-  goto l235;
-  l236:;	  G->pos= yypos236; G->thunkpos= yythunkpos236;
-  }  if (!yy__(G))  goto l235;
+  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yymatchChar(G, '=')) goto l240;
+  goto l239;
+  l240:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;
+  }  if (!yy__(G))  goto l239;
   yyprintf((stderr, "  ok   PERCENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l235:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
+  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8057,18 +8085,18 @@ YY_RULE(int) yy_PERCENT(GREG *G)
 }
 YY_RULE(int) yy_MINUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MINUS"));
-  if (!yymatchChar(G, '-')) goto l237;
+  if (!yymatchChar(G, '-')) goto l241;
 
-  {  int yypos238= G->pos, yythunkpos238= G->thunkpos;  if (!yymatchChar(G, '=')) goto l238;
-  goto l237;
-  l238:;	  G->pos= yypos238; G->thunkpos= yythunkpos238;
-  }  if (!yy__(G))  goto l237;
+  {  int yypos242= G->pos, yythunkpos242= G->thunkpos;  if (!yymatchChar(G, '=')) goto l242;
+  goto l241;
+  l242:;	  G->pos= yypos242; G->thunkpos= yythunkpos242;
+  }  if (!yy__(G))  goto l241;
   yyprintf((stderr, "  ok   MINUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l237:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
+  l241:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8077,19 +8105,19 @@ YY_RULE(int) yy_MINUS(GREG *G)
 YY_RULE(int) yy_Product(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Product"));
 
-  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l241;
-  goto l240;
-  l241:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;  if (!yy_ProductBinaryNot(G))  goto l242;
-  goto l240;
-  l242:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;  if (!yy_ProductCore(G))  goto l239;
+  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l245;
+  goto l244;
+  l245:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_ProductBinaryNot(G))  goto l246;
+  goto l244;
+  l246:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_ProductCore(G))  goto l243;
 
   }
-  l240:;	  yyprintf((stderr, "  ok   Product"));
+  l244:;	  yyprintf((stderr, "  ok   Product"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
+  l243:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8097,18 +8125,18 @@ YY_RULE(int) yy_Product(GREG *G)
 }
 YY_RULE(int) yy_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_RSHIFT"));
-  if (!yymatchString(G, ">>")) goto l243;
+  if (!yymatchString(G, ">>")) goto l247;
 
-  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yymatchChar(G, '=')) goto l244;
-  goto l243;
-  l244:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;
-  }  if (!yy__(G))  goto l243;
+  {  int yypos248= G->pos, yythunkpos248= G->thunkpos;  if (!yymatchChar(G, '=')) goto l248;
+  goto l247;
+  l248:;	  G->pos= yypos248; G->thunkpos= yythunkpos248;
+  }  if (!yy__(G))  goto l247;
   yyprintf((stderr, "  ok   B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l243:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
+  l247:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8116,18 +8144,18 @@ YY_RULE(int) yy_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_LSHIFT"));
-  if (!yymatchString(G, "<<")) goto l245;
+  if (!yymatchString(G, "<<")) goto l249;
 
-  {  int yypos246= G->pos, yythunkpos246= G->thunkpos;  if (!yymatchChar(G, '=')) goto l246;
-  goto l245;
-  l246:;	  G->pos= yypos246; G->thunkpos= yythunkpos246;
-  }  if (!yy__(G))  goto l245;
+  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;  if (!yymatchChar(G, '=')) goto l250;
+  goto l249;
+  l250:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;
+  }  if (!yy__(G))  goto l249;
   yyprintf((stderr, "  ok   B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l245:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
+  l249:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8136,41 +8164,41 @@ YY_RULE(int) yy_B_LSHIFT(GREG *G)
 YY_RULE(int) yy_Sum(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Sum"));
-  if (!yy_Product(G))  goto l247;
+  if (!yy_Product(G))  goto l251;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l248:;	
-  {  int yypos249= G->pos, yythunkpos249= G->thunkpos;
-  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;  if (!yy_PLUS(G))  goto l251;
+  l252:;	
+  {  int yypos253= G->pos, yythunkpos253= G->thunkpos;
+  {  int yypos254= G->pos, yythunkpos254= G->thunkpos;  if (!yy_PLUS(G))  goto l255;
   yyDo(G, yy_1_Sum, G->begin, G->end, "yy_1_Sum");
-  if (!yy_WS(G))  goto l251;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l251; }
+  if (!yy_WS(G))  goto l255;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l255; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Sum, G->begin, G->end, "yy_2_Sum");
-  goto l250;
-  l251:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;  if (!yy_MINUS(G))  goto l252;
+  goto l254;
+  l255:;	  G->pos= yypos254; G->thunkpos= yythunkpos254;  if (!yy_MINUS(G))  goto l256;
   yyDo(G, yy_3_Sum, G->begin, G->end, "yy_3_Sum");
-  if (!yy_WS(G))  goto l252;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l252; }
+  if (!yy_WS(G))  goto l256;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l256; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Sum, G->begin, G->end, "yy_4_Sum");
-  goto l250;
-  l252:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;  if (!yy_PERCENT(G))  goto l249;
+  goto l254;
+  l256:;	  G->pos= yypos254; G->thunkpos= yythunkpos254;  if (!yy_PERCENT(G))  goto l253;
   yyDo(G, yy_5_Sum, G->begin, G->end, "yy_5_Sum");
-  if (!yy_WS(G))  goto l249;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l249; }
+  if (!yy_WS(G))  goto l253;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l253; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Sum, G->begin, G->end, "yy_6_Sum");
 
   }
-  l250:;	  goto l248;
-  l249:;	  G->pos= yypos249; G->thunkpos= yythunkpos249;
+  l254:;	  goto l252;
+  l253:;	  G->pos= yypos253; G->thunkpos= yythunkpos253;
   }  yyprintf((stderr, "  ok   Sum"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l247:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
+  l251:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8178,14 +8206,14 @@ YY_RULE(int) yy_Sum(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_DOT"));
-  if (!yymatchString(G, "..")) goto l253;
-  if (!yy__(G))  goto l253;
+  if (!yymatchString(G, "..")) goto l257;
+  if (!yy__(G))  goto l257;
   yyprintf((stderr, "  ok   DOUBLE_DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l253:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
+  l257:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8194,34 +8222,34 @@ YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 YY_RULE(int) yy_Shift(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Shift"));
-  if (!yy_Sum(G))  goto l254;
+  if (!yy_Sum(G))  goto l258;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l255:;	
-  {  int yypos256= G->pos, yythunkpos256= G->thunkpos;
-  {  int yypos257= G->pos, yythunkpos257= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l258;
+  l259:;	
+  {  int yypos260= G->pos, yythunkpos260= G->thunkpos;
+  {  int yypos261= G->pos, yythunkpos261= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l262;
   yyDo(G, yy_1_Shift, G->begin, G->end, "yy_1_Shift");
-  if (!yy_WS(G))  goto l258;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l258; }
+  if (!yy_WS(G))  goto l262;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l262; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Shift, G->begin, G->end, "yy_2_Shift");
-  goto l257;
-  l258:;	  G->pos= yypos257; G->thunkpos= yythunkpos257;  if (!yy_B_RSHIFT(G))  goto l256;
+  goto l261;
+  l262:;	  G->pos= yypos261; G->thunkpos= yythunkpos261;  if (!yy_B_RSHIFT(G))  goto l260;
   yyDo(G, yy_3_Shift, G->begin, G->end, "yy_3_Shift");
-  if (!yy_WS(G))  goto l256;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l256; }
+  if (!yy_WS(G))  goto l260;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l260; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Shift, G->begin, G->end, "yy_4_Shift");
 
   }
-  l257:;	  goto l255;
-  l256:;	  G->pos= yypos256; G->thunkpos= yythunkpos256;
+  l261:;	  goto l259;
+  l260:;	  G->pos= yypos260; G->thunkpos= yythunkpos260;
   }  yyprintf((stderr, "  ok   Shift"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l254:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
+  l258:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8229,14 +8257,14 @@ YY_RULE(int) yy_Shift(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN_EQ"));
-  if (!yymatchString(G, ">=")) goto l259;
-  if (!yy__(G))  goto l259;
+  if (!yymatchString(G, ">=")) goto l263;
+  if (!yy__(G))  goto l263;
   yyprintf((stderr, "  ok   MORETHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l259:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
+  l263:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8244,14 +8272,14 @@ YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN_EQ"));
-  if (!yymatchString(G, "<=")) goto l260;
-  if (!yy__(G))  goto l260;
+  if (!yymatchString(G, "<=")) goto l264;
+  if (!yy__(G))  goto l264;
   yyprintf((stderr, "  ok   LESSTHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l260:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
+  l264:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8259,14 +8287,14 @@ YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_CMP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CMP"));
-  if (!yymatchString(G, "<=>")) goto l261;
-  if (!yy__(G))  goto l261;
+  if (!yymatchString(G, "<=>")) goto l265;
+  if (!yy__(G))  goto l265;
   yyprintf((stderr, "  ok   CMP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l261:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
+  l265:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8275,24 +8303,24 @@ YY_RULE(int) yy_CMP(GREG *G)
 YY_RULE(int) yy_Range(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Range"));
-  if (!yy_Shift(G))  goto l262;
+  if (!yy_Shift(G))  goto l266;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l263:;	
-  {  int yypos264= G->pos, yythunkpos264= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l264;
+  l267:;	
+  {  int yypos268= G->pos, yythunkpos268= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l268;
   yyDo(G, yy_1_Range, G->begin, G->end, "yy_1_Range");
-  if (!yy_WS(G))  goto l264;
-  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l264; }
+  if (!yy_WS(G))  goto l268;
+  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l268; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Range, G->begin, G->end, "yy_2_Range");
-  goto l263;
-  l264:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;
+  goto l267;
+  l268:;	  G->pos= yypos268; G->thunkpos= yythunkpos268;
   }  yyprintf((stderr, "  ok   Range"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l262:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
+  l266:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8300,14 +8328,14 @@ YY_RULE(int) yy_Range(GREG *G)
 }
 YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "NOT_EQUALS"));
-  if (!yymatchString(G, "!=")) goto l265;
-  if (!yy__(G))  goto l265;
+  if (!yymatchString(G, "!=")) goto l269;
+  if (!yy__(G))  goto l269;
   yyprintf((stderr, "  ok   NOT_EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l265:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
+  l269:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8315,14 +8343,14 @@ YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 }
 YY_RULE(int) yy_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EQUALS"));
-  if (!yymatchString(G, "==")) goto l266;
-  if (!yy__(G))  goto l266;
+  if (!yymatchString(G, "==")) goto l270;
+  if (!yy__(G))  goto l270;
   yyprintf((stderr, "  ok   EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l266:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
+  l270:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8331,55 +8359,55 @@ YY_RULE(int) yy_EQUALS(GREG *G)
 YY_RULE(int) yy_Inequality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Inequality"));
-  if (!yy_Range(G))  goto l267;
+  if (!yy_Range(G))  goto l271;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l268:;	
-  {  int yypos269= G->pos, yythunkpos269= G->thunkpos;
-  {  int yypos270= G->pos, yythunkpos270= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l271;
+  l272:;	
+  {  int yypos273= G->pos, yythunkpos273= G->thunkpos;
+  {  int yypos274= G->pos, yythunkpos274= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l275;
   yyDo(G, yy_1_Inequality, G->begin, G->end, "yy_1_Inequality");
-  if (!yy_WS(G))  goto l271;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l271; }
+  if (!yy_WS(G))  goto l275;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l275; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Inequality, G->begin, G->end, "yy_2_Inequality");
-  goto l270;
-  l271:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_MORETHAN(G))  goto l272;
+  goto l274;
+  l275:;	  G->pos= yypos274; G->thunkpos= yythunkpos274;  if (!yy_MORETHAN(G))  goto l276;
   yyDo(G, yy_3_Inequality, G->begin, G->end, "yy_3_Inequality");
-  if (!yy_WS(G))  goto l272;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l272; }
+  if (!yy_WS(G))  goto l276;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l276; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Inequality, G->begin, G->end, "yy_4_Inequality");
-  goto l270;
-  l272:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_CMP(G))  goto l273;
+  goto l274;
+  l276:;	  G->pos= yypos274; G->thunkpos= yythunkpos274;  if (!yy_CMP(G))  goto l277;
   yyDo(G, yy_5_Inequality, G->begin, G->end, "yy_5_Inequality");
-  if (!yy_WS(G))  goto l273;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l273; }
+  if (!yy_WS(G))  goto l277;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l277; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Inequality, G->begin, G->end, "yy_6_Inequality");
-  goto l270;
-  l273:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_LESSTHAN_EQ(G))  goto l274;
+  goto l274;
+  l277:;	  G->pos= yypos274; G->thunkpos= yythunkpos274;  if (!yy_LESSTHAN_EQ(G))  goto l278;
   yyDo(G, yy_7_Inequality, G->begin, G->end, "yy_7_Inequality");
-  if (!yy_WS(G))  goto l274;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l274; }
+  if (!yy_WS(G))  goto l278;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l278; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Inequality, G->begin, G->end, "yy_8_Inequality");
-  goto l270;
-  l274:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;  if (!yy_MORETHAN_EQ(G))  goto l269;
+  goto l274;
+  l278:;	  G->pos= yypos274; G->thunkpos= yythunkpos274;  if (!yy_MORETHAN_EQ(G))  goto l273;
   yyDo(G, yy_9_Inequality, G->begin, G->end, "yy_9_Inequality");
-  if (!yy_WS(G))  goto l269;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l269; }
+  if (!yy_WS(G))  goto l273;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l273; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Inequality, G->begin, G->end, "yy_10_Inequality");
 
   }
-  l270:;	  goto l268;
-  l269:;	  G->pos= yypos269; G->thunkpos= yythunkpos269;
+  l274:;	  goto l272;
+  l273:;	  G->pos= yypos273; G->thunkpos= yythunkpos273;
   }  yyprintf((stderr, "  ok   Inequality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l267:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
+  l271:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8388,21 +8416,21 @@ YY_RULE(int) yy_Inequality(GREG *G)
 YY_RULE(int) yy_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_AND"));
 
-  {  int yypos276= G->pos, yythunkpos276= G->thunkpos;  if (!yy_L_AND(G))  goto l276;
-  goto l275;
-  l276:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;
-  }  if (!yymatchChar(G, '&')) goto l275;
+  {  int yypos280= G->pos, yythunkpos280= G->thunkpos;  if (!yy_L_AND(G))  goto l280;
+  goto l279;
+  l280:;	  G->pos= yypos280; G->thunkpos= yythunkpos280;
+  }  if (!yymatchChar(G, '&')) goto l279;
 
-  {  int yypos277= G->pos, yythunkpos277= G->thunkpos;  if (!yymatchChar(G, '=')) goto l277;
-  goto l275;
-  l277:;	  G->pos= yypos277; G->thunkpos= yythunkpos277;
-  }  if (!yy__(G))  goto l275;
+  {  int yypos281= G->pos, yythunkpos281= G->thunkpos;  if (!yymatchChar(G, '=')) goto l281;
+  goto l279;
+  l281:;	  G->pos= yypos281; G->thunkpos= yythunkpos281;
+  }  if (!yy__(G))  goto l279;
   yyprintf((stderr, "  ok   B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l275:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
+  l279:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8411,34 +8439,34 @@ YY_RULE(int) yy_B_AND(GREG *G)
 YY_RULE(int) yy_Equality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Equality"));
-  if (!yy_Inequality(G))  goto l278;
+  if (!yy_Inequality(G))  goto l282;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l279:;	
-  {  int yypos280= G->pos, yythunkpos280= G->thunkpos;
-  {  int yypos281= G->pos, yythunkpos281= G->thunkpos;  if (!yy_EQUALS(G))  goto l282;
+  l283:;	
+  {  int yypos284= G->pos, yythunkpos284= G->thunkpos;
+  {  int yypos285= G->pos, yythunkpos285= G->thunkpos;  if (!yy_EQUALS(G))  goto l286;
   yyDo(G, yy_1_Equality, G->begin, G->end, "yy_1_Equality");
-  if (!yy_WS(G))  goto l282;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l282; }
+  if (!yy_WS(G))  goto l286;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l286; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Equality, G->begin, G->end, "yy_2_Equality");
-  goto l281;
-  l282:;	  G->pos= yypos281; G->thunkpos= yythunkpos281;  if (!yy_NOT_EQUALS(G))  goto l280;
+  goto l285;
+  l286:;	  G->pos= yypos285; G->thunkpos= yythunkpos285;  if (!yy_NOT_EQUALS(G))  goto l284;
   yyDo(G, yy_3_Equality, G->begin, G->end, "yy_3_Equality");
-  if (!yy_WS(G))  goto l280;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l280; }
+  if (!yy_WS(G))  goto l284;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l284; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Equality, G->begin, G->end, "yy_4_Equality");
 
   }
-  l281:;	  goto l279;
-  l280:;	  G->pos= yypos280; G->thunkpos= yythunkpos280;
+  l285:;	  goto l283;
+  l284:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;
   }  yyprintf((stderr, "  ok   Equality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l278:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
+  l282:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8446,18 +8474,18 @@ YY_RULE(int) yy_Equality(GREG *G)
 }
 YY_RULE(int) yy_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_XOR"));
-  if (!yymatchChar(G, '^')) goto l283;
+  if (!yymatchChar(G, '^')) goto l287;
 
-  {  int yypos284= G->pos, yythunkpos284= G->thunkpos;  if (!yymatchChar(G, '=')) goto l284;
-  goto l283;
-  l284:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;
-  }  if (!yy__(G))  goto l283;
+  {  int yypos288= G->pos, yythunkpos288= G->thunkpos;  if (!yymatchChar(G, '=')) goto l288;
+  goto l287;
+  l288:;	  G->pos= yypos288; G->thunkpos= yythunkpos288;
+  }  if (!yy__(G))  goto l287;
   yyprintf((stderr, "  ok   B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l283:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
+  l287:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8466,24 +8494,24 @@ YY_RULE(int) yy_B_XOR(GREG *G)
 YY_RULE(int) yy_BinaryAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryAnd"));
-  if (!yy_Equality(G))  goto l285;
+  if (!yy_Equality(G))  goto l289;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l286:;	
-  {  int yypos287= G->pos, yythunkpos287= G->thunkpos;  if (!yy_B_AND(G))  goto l287;
+  l290:;	
+  {  int yypos291= G->pos, yythunkpos291= G->thunkpos;  if (!yy_B_AND(G))  goto l291;
   yyDo(G, yy_1_BinaryAnd, G->begin, G->end, "yy_1_BinaryAnd");
-  if (!yy_WS(G))  goto l287;
-  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l287; }
+  if (!yy_WS(G))  goto l291;
+  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l291; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryAnd, G->begin, G->end, "yy_2_BinaryAnd");
-  goto l286;
-  l287:;	  G->pos= yypos287; G->thunkpos= yythunkpos287;
+  goto l290;
+  l291:;	  G->pos= yypos291; G->thunkpos= yythunkpos291;
   }  yyprintf((stderr, "  ok   BinaryAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l285:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
+  l289:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8492,21 +8520,21 @@ YY_RULE(int) yy_BinaryAnd(GREG *G)
 YY_RULE(int) yy_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_OR"));
 
-  {  int yypos289= G->pos, yythunkpos289= G->thunkpos;  if (!yy_L_OR(G))  goto l289;
-  goto l288;
-  l289:;	  G->pos= yypos289; G->thunkpos= yythunkpos289;
-  }  if (!yymatchChar(G, '|')) goto l288;
+  {  int yypos293= G->pos, yythunkpos293= G->thunkpos;  if (!yy_L_OR(G))  goto l293;
+  goto l292;
+  l293:;	  G->pos= yypos293; G->thunkpos= yythunkpos293;
+  }  if (!yymatchChar(G, '|')) goto l292;
 
-  {  int yypos290= G->pos, yythunkpos290= G->thunkpos;  if (!yymatchChar(G, '=')) goto l290;
-  goto l288;
-  l290:;	  G->pos= yypos290; G->thunkpos= yythunkpos290;
-  }  if (!yy__(G))  goto l288;
+  {  int yypos294= G->pos, yythunkpos294= G->thunkpos;  if (!yymatchChar(G, '=')) goto l294;
+  goto l292;
+  l294:;	  G->pos= yypos294; G->thunkpos= yythunkpos294;
+  }  if (!yy__(G))  goto l292;
   yyprintf((stderr, "  ok   B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l288:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
+  l292:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8515,24 +8543,24 @@ YY_RULE(int) yy_B_OR(GREG *G)
 YY_RULE(int) yy_BinaryXor(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryXor"));
-  if (!yy_BinaryAnd(G))  goto l291;
+  if (!yy_BinaryAnd(G))  goto l295;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l292:;	
-  {  int yypos293= G->pos, yythunkpos293= G->thunkpos;  if (!yy_B_XOR(G))  goto l293;
+  l296:;	
+  {  int yypos297= G->pos, yythunkpos297= G->thunkpos;  if (!yy_B_XOR(G))  goto l297;
   yyDo(G, yy_1_BinaryXor, G->begin, G->end, "yy_1_BinaryXor");
-  if (!yy_WS(G))  goto l293;
-  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l293; }
+  if (!yy_WS(G))  goto l297;
+  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l297; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryXor, G->begin, G->end, "yy_2_BinaryXor");
-  goto l292;
-  l293:;	  G->pos= yypos293; G->thunkpos= yythunkpos293;
+  goto l296;
+  l297:;	  G->pos= yypos297; G->thunkpos= yythunkpos297;
   }  yyprintf((stderr, "  ok   BinaryXor"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l291:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
+  l295:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8540,14 +8568,14 @@ YY_RULE(int) yy_BinaryXor(GREG *G)
 }
 YY_RULE(int) yy_L_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_AND"));
-  if (!yymatchString(G, "&&")) goto l294;
-  if (!yy__(G))  goto l294;
+  if (!yymatchString(G, "&&")) goto l298;
+  if (!yy__(G))  goto l298;
   yyprintf((stderr, "  ok   L_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l294:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
+  l298:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8556,24 +8584,24 @@ YY_RULE(int) yy_L_AND(GREG *G)
 YY_RULE(int) yy_BinaryOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryOr"));
-  if (!yy_BinaryXor(G))  goto l295;
+  if (!yy_BinaryXor(G))  goto l299;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l296:;	
-  {  int yypos297= G->pos, yythunkpos297= G->thunkpos;  if (!yy_B_OR(G))  goto l297;
+  l300:;	
+  {  int yypos301= G->pos, yythunkpos301= G->thunkpos;  if (!yy_B_OR(G))  goto l301;
   yyDo(G, yy_1_BinaryOr, G->begin, G->end, "yy_1_BinaryOr");
-  if (!yy_WS(G))  goto l297;
-  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l297; }
+  if (!yy_WS(G))  goto l301;
+  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l301; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryOr, G->begin, G->end, "yy_2_BinaryOr");
-  goto l296;
-  l297:;	  G->pos= yypos297; G->thunkpos= yythunkpos297;
+  goto l300;
+  l301:;	  G->pos= yypos301; G->thunkpos= yythunkpos301;
   }  yyprintf((stderr, "  ok   BinaryOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l295:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
+  l299:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8581,14 +8609,14 @@ YY_RULE(int) yy_BinaryOr(GREG *G)
 }
 YY_RULE(int) yy_L_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_OR"));
-  if (!yymatchString(G, "||")) goto l298;
-  if (!yy__(G))  goto l298;
+  if (!yymatchString(G, "||")) goto l302;
+  if (!yy__(G))  goto l302;
   yyprintf((stderr, "  ok   L_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l298:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
+  l302:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8597,24 +8625,24 @@ YY_RULE(int) yy_L_OR(GREG *G)
 YY_RULE(int) yy_LogicalAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalAnd"));
-  if (!yy_BinaryOr(G))  goto l299;
+  if (!yy_BinaryOr(G))  goto l303;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l300:;	
-  {  int yypos301= G->pos, yythunkpos301= G->thunkpos;  if (!yy_L_AND(G))  goto l301;
+  l304:;	
+  {  int yypos305= G->pos, yythunkpos305= G->thunkpos;  if (!yy_L_AND(G))  goto l305;
   yyDo(G, yy_1_LogicalAnd, G->begin, G->end, "yy_1_LogicalAnd");
-  if (!yy_WS(G))  goto l301;
-  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l301; }
+  if (!yy_WS(G))  goto l305;
+  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l305; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalAnd, G->begin, G->end, "yy_2_LogicalAnd");
-  goto l300;
-  l301:;	  G->pos= yypos301; G->thunkpos= yythunkpos301;
+  goto l304;
+  l305:;	  G->pos= yypos305; G->thunkpos= yythunkpos305;
   }  yyprintf((stderr, "  ok   LogicalAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l299:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
+  l303:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8622,14 +8650,14 @@ YY_RULE(int) yy_LogicalAnd(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_QUEST"));
-  if (!yymatchString(G, "??")) goto l302;
-  if (!yy__(G))  goto l302;
+  if (!yymatchString(G, "??")) goto l306;
+  if (!yy__(G))  goto l306;
   yyprintf((stderr, "  ok   DOUBLE_QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l302:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
+  l306:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8638,24 +8666,24 @@ YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 YY_RULE(int) yy_LogicalOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalOr"));
-  if (!yy_LogicalAnd(G))  goto l303;
+  if (!yy_LogicalAnd(G))  goto l307;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l304:;	
-  {  int yypos305= G->pos, yythunkpos305= G->thunkpos;  if (!yy_L_OR(G))  goto l305;
+  l308:;	
+  {  int yypos309= G->pos, yythunkpos309= G->thunkpos;  if (!yy_L_OR(G))  goto l309;
   yyDo(G, yy_1_LogicalOr, G->begin, G->end, "yy_1_LogicalOr");
-  if (!yy_WS(G))  goto l305;
-  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l305; }
+  if (!yy_WS(G))  goto l309;
+  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l309; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalOr, G->begin, G->end, "yy_2_LogicalOr");
-  goto l304;
-  l305:;	  G->pos= yypos305; G->thunkpos= yythunkpos305;
+  goto l308;
+  l309:;	  G->pos= yypos309; G->thunkpos= yythunkpos309;
   }  yyprintf((stderr, "  ok   LogicalOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l303:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
+  l307:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8663,14 +8691,14 @@ YY_RULE(int) yy_LogicalOr(GREG *G)
 }
 YY_RULE(int) yy_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "QUEST"));
-  if (!yymatchChar(G, '?')) goto l306;
-  if (!yy__(G))  goto l306;
+  if (!yymatchChar(G, '?')) goto l310;
+  if (!yy__(G))  goto l310;
   yyprintf((stderr, "  ok   QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l306:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
+  l310:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8679,24 +8707,24 @@ YY_RULE(int) yy_QUEST(GREG *G)
 YY_RULE(int) yy_NullCoalescing(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "NullCoalescing"));
-  if (!yy_LogicalOr(G))  goto l307;
+  if (!yy_LogicalOr(G))  goto l311;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos308= G->pos, yythunkpos308= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l308;
+  {  int yypos312= G->pos, yythunkpos312= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l312;
   yyDo(G, yy_1_NullCoalescing, G->begin, G->end, "yy_1_NullCoalescing");
-  if (!yy_WS(G))  goto l308;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l308; }
+  if (!yy_WS(G))  goto l312;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l312; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_NullCoalescing, G->begin, G->end, "yy_2_NullCoalescing");
-  goto l309;
-  l308:;	  G->pos= yypos308; G->thunkpos= yythunkpos308;
+  goto l313;
+  l312:;	  G->pos= yypos312; G->thunkpos= yythunkpos312;
   }
-  l309:;	  yyprintf((stderr, "  ok   NullCoalescing"));
+  l313:;	  yyprintf((stderr, "  ok   NullCoalescing"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l307:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
+  l311:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8704,14 +8732,14 @@ YY_RULE(int) yy_NullCoalescing(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_AND"));
-  if (!yymatchString(G, "&=")) goto l310;
-  if (!yy__(G))  goto l310;
+  if (!yymatchString(G, "&=")) goto l314;
+  if (!yy__(G))  goto l314;
   yyprintf((stderr, "  ok   ASS_B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l310:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
+  l314:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8719,14 +8747,14 @@ YY_RULE(int) yy_ASS_B_AND(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_OR"));
-  if (!yymatchString(G, "|=")) goto l311;
-  if (!yy__(G))  goto l311;
+  if (!yymatchString(G, "|=")) goto l315;
+  if (!yy__(G))  goto l315;
   yyprintf((stderr, "  ok   ASS_B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l311:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
+  l315:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8734,14 +8762,14 @@ YY_RULE(int) yy_ASS_B_OR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_XOR"));
-  if (!yymatchString(G, "^=")) goto l312;
-  if (!yy__(G))  goto l312;
+  if (!yymatchString(G, "^=")) goto l316;
+  if (!yy__(G))  goto l316;
   yyprintf((stderr, "  ok   ASS_B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
+  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8749,14 +8777,14 @@ YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_RSHIFT"));
-  if (!yymatchString(G, ">>=")) goto l313;
-  if (!yy__(G))  goto l313;
+  if (!yymatchString(G, ">>=")) goto l317;
+  if (!yy__(G))  goto l317;
   yyprintf((stderr, "  ok   ASS_B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
+  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8764,14 +8792,14 @@ YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_LSHIFT"));
-  if (!yymatchString(G, "<<=")) goto l314;
-  if (!yy__(G))  goto l314;
+  if (!yymatchString(G, "<<=")) goto l318;
+  if (!yy__(G))  goto l318;
   yyprintf((stderr, "  ok   ASS_B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l314:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
+  l318:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8779,14 +8807,14 @@ YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_DIV(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DIV"));
-  if (!yymatchString(G, "/=")) goto l315;
-  if (!yy__(G))  goto l315;
+  if (!yymatchString(G, "/=")) goto l319;
+  if (!yy__(G))  goto l319;
   yyprintf((stderr, "  ok   ASS_DIV"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l315:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
+  l319:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8794,14 +8822,14 @@ YY_RULE(int) yy_ASS_DIV(GREG *G)
 }
 YY_RULE(int) yy_ASS_EXP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_EXP"));
-  if (!yymatchString(G, "**=")) goto l316;
-  if (!yy__(G))  goto l316;
+  if (!yymatchString(G, "**=")) goto l320;
+  if (!yy__(G))  goto l320;
   yyprintf((stderr, "  ok   ASS_EXP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
+  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8809,14 +8837,14 @@ YY_RULE(int) yy_ASS_EXP(GREG *G)
 }
 YY_RULE(int) yy_ASS_MUL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MUL"));
-  if (!yymatchString(G, "*=")) goto l317;
-  if (!yy__(G))  goto l317;
+  if (!yymatchString(G, "*=")) goto l321;
+  if (!yy__(G))  goto l321;
   yyprintf((stderr, "  ok   ASS_MUL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
+  l321:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8824,14 +8852,14 @@ YY_RULE(int) yy_ASS_MUL(GREG *G)
 }
 YY_RULE(int) yy_ASS_SUB(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_SUB"));
-  if (!yymatchString(G, "-=")) goto l318;
-  if (!yy__(G))  goto l318;
+  if (!yymatchString(G, "-=")) goto l322;
+  if (!yy__(G))  goto l322;
   yyprintf((stderr, "  ok   ASS_SUB"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l318:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
+  l322:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8839,14 +8867,14 @@ YY_RULE(int) yy_ASS_SUB(GREG *G)
 }
 YY_RULE(int) yy_ASS_MOD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MOD"));
-  if (!yymatchString(G, "%=")) goto l319;
-  if (!yy__(G))  goto l319;
+  if (!yymatchString(G, "%=")) goto l323;
+  if (!yy__(G))  goto l323;
   yyprintf((stderr, "  ok   ASS_MOD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l319:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
+  l323:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8854,14 +8882,14 @@ YY_RULE(int) yy_ASS_MOD(GREG *G)
 }
 YY_RULE(int) yy_ASS_ADD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_ADD"));
-  if (!yymatchString(G, "+=")) goto l320;
-  if (!yy__(G))  goto l320;
+  if (!yymatchString(G, "+=")) goto l324;
+  if (!yy__(G))  goto l324;
   yyprintf((stderr, "  ok   ASS_ADD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
+  l324:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8870,30 +8898,30 @@ YY_RULE(int) yy_ASS_ADD(GREG *G)
 YY_RULE(int) yy_Ternary(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Ternary"));
-  if (!yy_NullCoalescing(G))  goto l321;
+  if (!yy_NullCoalescing(G))  goto l325;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos322= G->pos, yythunkpos322= G->thunkpos;  if (!yy__(G))  goto l322;
-  if (!yy_QUEST(G))  goto l322;
+  {  int yypos326= G->pos, yythunkpos326= G->thunkpos;  if (!yy__(G))  goto l326;
+  if (!yy_QUEST(G))  goto l326;
   yyDo(G, yy_1_Ternary, G->begin, G->end, "yy_1_Ternary");
-  if (!yy_WS(G))  goto l322;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l322; }
+  if (!yy_WS(G))  goto l326;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l326; }
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l322;
-  if (!yy_COLON(G))  goto l322;
-  if (!yy_WS(G))  goto l322;
-  if (!yy_NullCoalescing(G))  goto l322;
+  if (!yy__(G))  goto l326;
+  if (!yy_COLON(G))  goto l326;
+  if (!yy_WS(G))  goto l326;
+  if (!yy_NullCoalescing(G))  goto l326;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Ternary, G->begin, G->end, "yy_2_Ternary");
-  goto l323;
-  l322:;	  G->pos= yypos322; G->thunkpos= yythunkpos322;
+  goto l327;
+  l326:;	  G->pos= yypos326; G->thunkpos= yythunkpos326;
   }
-  l323:;	  yyprintf((stderr, "  ok   Ternary"));
+  l327:;	  yyprintf((stderr, "  ok   Ternary"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l321:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
+  l325:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8902,111 +8930,111 @@ YY_RULE(int) yy_Ternary(GREG *G)
 YY_RULE(int) yy_Assignment(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Assignment"));
-  if (!yy_Ternary(G))  goto l324;
+  if (!yy_Ternary(G))  goto l328;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l325:;	
-  {  int yypos326= G->pos, yythunkpos326= G->thunkpos;
-  {  int yypos327= G->pos, yythunkpos327= G->thunkpos;  if (!yy_ASS(G))  goto l328;
+  l329:;	
+  {  int yypos330= G->pos, yythunkpos330= G->thunkpos;
+  {  int yypos331= G->pos, yythunkpos331= G->thunkpos;  if (!yy_ASS(G))  goto l332;
   yyDo(G, yy_1_Assignment, G->begin, G->end, "yy_1_Assignment");
-  if (!yy_WS(G))  goto l328;
-  if (!yy_Ternary(G))  goto l328;
+  if (!yy_WS(G))  goto l332;
+  if (!yy_Ternary(G))  goto l332;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Assignment, G->begin, G->end, "yy_2_Assignment");
-  goto l327;
-  l328:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS(G))  goto l329;
+  goto l331;
+  l332:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS(G))  goto l333;
   yyDo(G, yy_3_Assignment, G->begin, G->end, "yy_3_Assignment");
-  if (!yy_WS(G))  goto l329;
-  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l329; }
+  if (!yy_WS(G))  goto l333;
+  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l333; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Assignment, G->begin, G->end, "yy_4_Assignment");
-  goto l327;
-  l329:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_ADD(G))  goto l330;
+  goto l331;
+  l333:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_ADD(G))  goto l334;
   yyDo(G, yy_5_Assignment, G->begin, G->end, "yy_5_Assignment");
-  if (!yy_WS(G))  goto l330;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l330; }
+  if (!yy_WS(G))  goto l334;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l334; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Assignment, G->begin, G->end, "yy_6_Assignment");
-  goto l327;
-  l330:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_MOD(G))  goto l331;
+  goto l331;
+  l334:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_MOD(G))  goto l335;
   yyDo(G, yy_7_Assignment, G->begin, G->end, "yy_7_Assignment");
-  if (!yy_WS(G))  goto l331;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l331; }
+  if (!yy_WS(G))  goto l335;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l335; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Assignment, G->begin, G->end, "yy_8_Assignment");
-  goto l327;
-  l331:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_SUB(G))  goto l332;
+  goto l331;
+  l335:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_SUB(G))  goto l336;
   yyDo(G, yy_9_Assignment, G->begin, G->end, "yy_9_Assignment");
-  if (!yy_WS(G))  goto l332;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l332; }
+  if (!yy_WS(G))  goto l336;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l336; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Assignment, G->begin, G->end, "yy_10_Assignment");
-  goto l327;
-  l332:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_MUL(G))  goto l333;
+  goto l331;
+  l336:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_MUL(G))  goto l337;
   yyDo(G, yy_11_Assignment, G->begin, G->end, "yy_11_Assignment");
-  if (!yy_WS(G))  goto l333;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l333; }
+  if (!yy_WS(G))  goto l337;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l337; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_12_Assignment, G->begin, G->end, "yy_12_Assignment");
-  goto l327;
-  l333:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_EXP(G))  goto l334;
+  goto l331;
+  l337:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_EXP(G))  goto l338;
   yyDo(G, yy_13_Assignment, G->begin, G->end, "yy_13_Assignment");
-  if (!yy_WS(G))  goto l334;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l334; }
+  if (!yy_WS(G))  goto l338;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l338; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_14_Assignment, G->begin, G->end, "yy_14_Assignment");
-  goto l327;
-  l334:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_DIV(G))  goto l335;
+  goto l331;
+  l338:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_DIV(G))  goto l339;
   yyDo(G, yy_15_Assignment, G->begin, G->end, "yy_15_Assignment");
-  if (!yy_WS(G))  goto l335;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l335; }
+  if (!yy_WS(G))  goto l339;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l339; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_16_Assignment, G->begin, G->end, "yy_16_Assignment");
-  goto l327;
-  l335:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_LSHIFT(G))  goto l336;
+  goto l331;
+  l339:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_B_LSHIFT(G))  goto l340;
   yyDo(G, yy_17_Assignment, G->begin, G->end, "yy_17_Assignment");
-  if (!yy_WS(G))  goto l336;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l336; }
+  if (!yy_WS(G))  goto l340;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l340; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_18_Assignment, G->begin, G->end, "yy_18_Assignment");
-  goto l327;
-  l336:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_RSHIFT(G))  goto l337;
+  goto l331;
+  l340:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_B_RSHIFT(G))  goto l341;
   yyDo(G, yy_19_Assignment, G->begin, G->end, "yy_19_Assignment");
-  if (!yy_WS(G))  goto l337;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l337; }
+  if (!yy_WS(G))  goto l341;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l341; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_20_Assignment, G->begin, G->end, "yy_20_Assignment");
-  goto l327;
-  l337:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_XOR(G))  goto l338;
+  goto l331;
+  l341:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_B_XOR(G))  goto l342;
   yyDo(G, yy_21_Assignment, G->begin, G->end, "yy_21_Assignment");
-  if (!yy_WS(G))  goto l338;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l338; }
+  if (!yy_WS(G))  goto l342;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l342; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_22_Assignment, G->begin, G->end, "yy_22_Assignment");
-  goto l327;
-  l338:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_OR(G))  goto l339;
+  goto l331;
+  l342:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_B_OR(G))  goto l343;
   yyDo(G, yy_23_Assignment, G->begin, G->end, "yy_23_Assignment");
-  if (!yy_WS(G))  goto l339;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l339; }
+  if (!yy_WS(G))  goto l343;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l343; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_24_Assignment, G->begin, G->end, "yy_24_Assignment");
-  goto l327;
-  l339:;	  G->pos= yypos327; G->thunkpos= yythunkpos327;  if (!yy_ASS_B_AND(G))  goto l326;
+  goto l331;
+  l343:;	  G->pos= yypos331; G->thunkpos= yythunkpos331;  if (!yy_ASS_B_AND(G))  goto l330;
   yyDo(G, yy_25_Assignment, G->begin, G->end, "yy_25_Assignment");
-  if (!yy_WS(G))  goto l326;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l326; }
+  if (!yy_WS(G))  goto l330;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l330; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_26_Assignment, G->begin, G->end, "yy_26_Assignment");
 
   }
-  l327:;	  goto l325;
-  l326:;	  G->pos= yypos326; G->thunkpos= yythunkpos326;
+  l331:;	  goto l329;
+  l330:;	  G->pos= yypos330; G->thunkpos= yythunkpos330;
   }  yyprintf((stderr, "  ok   Assignment"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l324:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
+  l328:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9015,17 +9043,17 @@ YY_RULE(int) yy_Assignment(GREG *G)
 YY_RULE(int) yy_FunctionCall(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionCall"));
-  if (!yy_IDENT(G))  goto l340;
+  if (!yy_IDENT(G))  goto l344;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_FunctionCall, G->begin, G->end, "yy_1_FunctionCall");
-  if (!yy_FunctionCallCore(G))  goto l340;
+  if (!yy_FunctionCallCore(G))  goto l344;
   yyDo(G, yy_2_FunctionCall, G->begin, G->end, "yy_2_FunctionCall");
   yyprintf((stderr, "  ok   FunctionCall"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l340:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
+  l344:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9033,13 +9061,13 @@ YY_RULE(int) yy_FunctionCall(GREG *G)
 }
 YY_RULE(int) yy_BinaryOperation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BinaryOperation"));
-  if (!yy_Assignment(G))  goto l341;
+  if (!yy_Assignment(G))  goto l345;
   yyprintf((stderr, "  ok   BinaryOperation"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l341:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
+  l345:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9048,12 +9076,12 @@ YY_RULE(int) yy_BinaryOperation(GREG *G)
 YY_RULE(int) yy_DoubleArrow(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "DoubleArrow"));
-  if (!yy_Assignment(G))  goto l342;
+  if (!yy_Assignment(G))  goto l346;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DOUBLE_ARROW(G))  goto l342;
+  if (!yy_DOUBLE_ARROW(G))  goto l346;
   yyDo(G, yy_1_DoubleArrow, G->begin, G->end, "yy_1_DoubleArrow");
-  if (!yy_WS(G))  goto l342;
-  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l342; }
+  if (!yy_WS(G))  goto l346;
+  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l346; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_DoubleArrow, G->begin, G->end, "yy_2_DoubleArrow");
   yyprintf((stderr, "  ok   DoubleArrow"));
@@ -9061,7 +9089,7 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l342:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
+  l346:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9069,13 +9097,13 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
 }
 YY_RULE(int) yy_RETURN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "RETURN_KW"));
-  if (!yymatchString(G, "return")) goto l343;
+  if (!yymatchString(G, "return")) goto l347;
   yyprintf((stderr, "  ok   RETURN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l343:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
+  l347:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9083,13 +9111,13 @@ YY_RULE(int) yy_RETURN_KW(GREG *G)
 }
 YY_RULE(int) yy_WHILE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "WHILE_KW"));
-  if (!yymatchString(G, "while")) goto l344;
+  if (!yymatchString(G, "while")) goto l348;
   yyprintf((stderr, "  ok   WHILE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l344:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
+  l348:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9097,13 +9125,13 @@ YY_RULE(int) yy_WHILE_KW(GREG *G)
 }
 YY_RULE(int) yy_IN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IN_KW"));
-  if (!yymatchString(G, "in")) goto l345;
+  if (!yymatchString(G, "in")) goto l349;
   yyprintf((stderr, "  ok   IN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l345:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
+  l349:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9111,13 +9139,13 @@ YY_RULE(int) yy_IN_KW(GREG *G)
 }
 YY_RULE(int) yy_FOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FOR_KW"));
-  if (!yymatchString(G, "for")) goto l346;
+  if (!yymatchString(G, "for")) goto l350;
   yyprintf((stderr, "  ok   FOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l346:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
+  l350:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9127,25 +9155,25 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImplicitDecl"));
 
-  {  int yypos348= G->pos, yythunkpos348= G->thunkpos;  if (!yy_VariableDecl(G))  goto l349;
+  {  int yypos352= G->pos, yythunkpos352= G->thunkpos;  if (!yy_VariableDecl(G))  goto l353;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ImplicitDecl, G->begin, G->end, "yy_1_ImplicitDecl");
-  goto l348;
-  l349:;	  G->pos= yypos348; G->thunkpos= yythunkpos348;  if (!yy_Tuple(G))  goto l350;
+  goto l352;
+  l353:;	  G->pos= yypos352; G->thunkpos= yythunkpos352;  if (!yy_Tuple(G))  goto l354;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_ImplicitDecl, G->begin, G->end, "yy_2_ImplicitDecl");
-  goto l348;
-  l350:;	  G->pos= yypos348; G->thunkpos= yythunkpos348;  if (!yy_IDENT(G))  goto l347;
+  goto l352;
+  l354:;	  G->pos= yypos352; G->thunkpos= yythunkpos352;  if (!yy_IDENT(G))  goto l351;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImplicitDecl, G->begin, G->end, "yy_3_ImplicitDecl");
 
   }
-  l348:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
+  l352:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l347:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
+  l351:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9153,13 +9181,13 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 }
 YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONTINUE_KW"));
-  if (!yymatchString(G, "continue")) goto l351;
+  if (!yymatchString(G, "continue")) goto l355;
   yyprintf((stderr, "  ok   CONTINUE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l351:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
+  l355:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9167,13 +9195,13 @@ YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 }
 YY_RULE(int) yy_BREAK_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BREAK_KW"));
-  if (!yymatchString(G, "break")) goto l352;
+  if (!yymatchString(G, "break")) goto l356;
   yyprintf((stderr, "  ok   BREAK_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l352:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
+  l356:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9181,14 +9209,14 @@ YY_RULE(int) yy_BREAK_KW(GREG *G)
 }
 YY_RULE(int) yy_Continue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Continue"));
-  if (!yy_CONTINUE_KW(G))  goto l353;
+  if (!yy_CONTINUE_KW(G))  goto l357;
   yyDo(G, yy_1_Continue, G->begin, G->end, "yy_1_Continue");
   yyprintf((stderr, "  ok   Continue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l353:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
+  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9196,14 +9224,14 @@ YY_RULE(int) yy_Continue(GREG *G)
 }
 YY_RULE(int) yy_Break(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Break"));
-  if (!yy_BREAK_KW(G))  goto l354;
+  if (!yy_BREAK_KW(G))  goto l358;
   yyDo(G, yy_1_Break, G->begin, G->end, "yy_1_Break");
   yyprintf((stderr, "  ok   Break"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l354:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
+  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9212,27 +9240,27 @@ YY_RULE(int) yy_Break(GREG *G)
 YY_RULE(int) yy_While(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "While"));
-  if (!yy_WHILE_KW(G))  goto l355;
+  if (!yy_WHILE_KW(G))  goto l359;
   yyDo(G, yy_1_While, G->begin, G->end, "yy_1_While");
-  if (!yy_WS(G))  goto l355;
-  if (!yymatchChar(G, '(')) goto l355;
-  if (!yy_WS(G))  goto l355;
-  if (!yy__(G))  goto l355;
-  if (!yy_Expr(G))  goto l355;
+  if (!yy_WS(G))  goto l359;
+  if (!yymatchChar(G, '(')) goto l359;
+  if (!yy_WS(G))  goto l359;
+  if (!yy__(G))  goto l359;
+  if (!yy_Expr(G))  goto l359;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l355;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l355; }
+  if (!yy_WS(G))  goto l359;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l359; }
   yyDo(G, yy_2_While, G->begin, G->end, "yy_2_While");
-  if (!yy__(G))  goto l355;
-  if (!yy_Body(G))  goto l355;
-  if (!yy__(G))  goto l355;
+  if (!yy__(G))  goto l359;
+  if (!yy_Body(G))  goto l359;
+  if (!yy__(G))  goto l359;
   yyDo(G, yy_3_While, G->begin, G->end, "yy_3_While");
   yyprintf((stderr, "  ok   While"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l355:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
+  l359:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9241,32 +9269,32 @@ YY_RULE(int) yy_While(GREG *G)
 YY_RULE(int) yy_Foreach(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Foreach"));
-  if (!yy_FOR_KW(G))  goto l356;
+  if (!yy_FOR_KW(G))  goto l360;
   yyDo(G, yy_1_Foreach, G->begin, G->end, "yy_1_Foreach");
-  if (!yy_WS(G))  goto l356;
-  if (!yymatchChar(G, '(')) goto l356;
-  if (!yy_WS(G))  goto l356;
-  if (!yy__(G))  goto l356;
-  if (!yy_ImplicitDecl(G))  goto l356;
+  if (!yy_WS(G))  goto l360;
+  if (!yymatchChar(G, '(')) goto l360;
+  if (!yy_WS(G))  goto l360;
+  if (!yy__(G))  goto l360;
+  if (!yy_ImplicitDecl(G))  goto l360;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l356;
-  if (!yy_IN_KW(G))  goto l356;
-  if (!yy__(G))  goto l356;
-  if (!yy_Expr(G))  goto l356;
+  if (!yy__(G))  goto l360;
+  if (!yy_IN_KW(G))  goto l360;
+  if (!yy__(G))  goto l360;
+  if (!yy_Expr(G))  goto l360;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l356;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l356; }
+  if (!yy_WS(G))  goto l360;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l360; }
   yyDo(G, yy_2_Foreach, G->begin, G->end, "yy_2_Foreach");
-  if (!yy__(G))  goto l356;
-  if (!yy_Body(G))  goto l356;
-  if (!yy__(G))  goto l356;
+  if (!yy__(G))  goto l360;
+  if (!yy_Body(G))  goto l360;
+  if (!yy__(G))  goto l360;
   yyDo(G, yy_3_Foreach, G->begin, G->end, "yy_3_Foreach");
   yyprintf((stderr, "  ok   Foreach"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l356:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
+  l360:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9274,13 +9302,13 @@ YY_RULE(int) yy_Foreach(GREG *G)
 }
 YY_RULE(int) yy_CATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CATCH_KW"));
-  if (!yymatchString(G, "catch")) goto l357;
+  if (!yymatchString(G, "catch")) goto l361;
   yyprintf((stderr, "  ok   CATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
+  l361:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9289,36 +9317,36 @@ YY_RULE(int) yy_CATCH_KW(GREG *G)
 YY_RULE(int) yy_Catch(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Catch"));
-  if (!yy_CATCH_KW(G))  goto l358;
+  if (!yy_CATCH_KW(G))  goto l362;
   yyDo(G, yy_1_Catch, G->begin, G->end, "yy_1_Catch");
 
-  {  int yypos359= G->pos, yythunkpos359= G->thunkpos;  if (!yy__(G))  goto l359;
-  if (!yy_Expr(G))  goto l359;
+  {  int yypos363= G->pos, yythunkpos363= G->thunkpos;  if (!yy__(G))  goto l363;
+  if (!yy_Expr(G))  goto l363;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Catch, G->begin, G->end, "yy_2_Catch");
-  goto l360;
-  l359:;	  G->pos= yypos359; G->thunkpos= yythunkpos359;
+  goto l364;
+  l363:;	  G->pos= yypos363; G->thunkpos= yythunkpos363;
   }
-  l360:;	  if (!yy_WS(G))  goto l358;
-  if (!yymatchChar(G, '{')) goto l358;
+  l364:;	  if (!yy_WS(G))  goto l362;
+  if (!yymatchChar(G, '{')) goto l362;
 
-  l361:;	
-  {  int yypos362= G->pos, yythunkpos362= G->thunkpos;  if (!yy_WS(G))  goto l362;
-  if (!yy_Stmt(G))  goto l362;
+  l365:;	
+  {  int yypos366= G->pos, yythunkpos366= G->thunkpos;  if (!yy_WS(G))  goto l366;
+  if (!yy_Stmt(G))  goto l366;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l362;
+  if (!yy_WS(G))  goto l366;
   yyDo(G, yy_3_Catch, G->begin, G->end, "yy_3_Catch");
-  goto l361;
-  l362:;	  G->pos= yypos362; G->thunkpos= yythunkpos362;
-  }  if (!yy_WS(G))  goto l358;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l358; }
+  goto l365;
+  l366:;	  G->pos= yypos366; G->thunkpos= yythunkpos366;
+  }  if (!yy_WS(G))  goto l362;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l362; }
   yyDo(G, yy_4_Catch, G->begin, G->end, "yy_4_Catch");
   yyprintf((stderr, "  ok   Catch"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
+  l362:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9326,13 +9354,13 @@ YY_RULE(int) yy_Catch(GREG *G)
 }
 YY_RULE(int) yy_TRY_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TRY_KW"));
-  if (!yymatchString(G, "try")) goto l363;
+  if (!yymatchString(G, "try")) goto l367;
   yyprintf((stderr, "  ok   TRY_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l363:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
+  l367:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9342,73 +9370,73 @@ YY_RULE(int) yy_Value(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Value"));
 
-  {  int yypos365= G->pos, yythunkpos365= G->thunkpos;  if (!yymatchChar(G, '-')) goto l366;
-  if (!yy__(G))  goto l366;
-  if (!yymatchChar(G, '(')) goto l366;
+  {  int yypos369= G->pos, yythunkpos369= G->thunkpos;  if (!yymatchChar(G, '-')) goto l370;
+  if (!yy__(G))  goto l370;
+  if (!yymatchChar(G, '(')) goto l370;
   yyDo(G, yy_1_Value, G->begin, G->end, "yy_1_Value");
-  if (!yy_WS(G))  goto l366;
-  if (!yy_Expr(G))  goto l366;
-  yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l366;
-  if (!yymatchChar(G, ')')) goto l366;
-  yyDo(G, yy_2_Value, G->begin, G->end, "yy_2_Value");
-  if (!yy__(G))  goto l366;
-  goto l365;
-  l366:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '+')) goto l367;
-  if (!yy__(G))  goto l367;
-  if (!yymatchChar(G, '(')) goto l367;
-  yyDo(G, yy_3_Value, G->begin, G->end, "yy_3_Value");
-  if (!yy_WS(G))  goto l367;
-  if (!yy_Expr(G))  goto l367;
-  yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l367;
-  if (!yymatchChar(G, ')')) goto l367;
-  yyDo(G, yy_4_Value, G->begin, G->end, "yy_4_Value");
-  if (!yy__(G))  goto l367;
-  goto l365;
-  l367:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '-')) goto l368;
-  if (!yy__(G))  goto l368;
-  yyDo(G, yy_5_Value, G->begin, G->end, "yy_5_Value");
-  if (!yy_SafeNavAccess(G))  goto l368;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_6_Value, G->begin, G->end, "yy_6_Value");
-  goto l365;
-  l368:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '+')) goto l369;
-  if (!yy__(G))  goto l369;
-  yyDo(G, yy_7_Value, G->begin, G->end, "yy_7_Value");
-  if (!yy_SafeNavAccess(G))  goto l369;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_8_Value, G->begin, G->end, "yy_8_Value");
-  goto l365;
-  l369:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yymatchChar(G, '(')) goto l370;
-  yyDo(G, yy_9_Value, G->begin, G->end, "yy_9_Value");
   if (!yy_WS(G))  goto l370;
   if (!yy_Expr(G))  goto l370;
   yyDo(G, yySet, -2, 0, "yySet");
   if (!yy_WS(G))  goto l370;
   if (!yymatchChar(G, ')')) goto l370;
+  yyDo(G, yy_2_Value, G->begin, G->end, "yy_2_Value");
+  if (!yy__(G))  goto l370;
+  goto l369;
+  l370:;	  G->pos= yypos369; G->thunkpos= yythunkpos369;  if (!yymatchChar(G, '+')) goto l371;
+  if (!yy__(G))  goto l371;
+  if (!yymatchChar(G, '(')) goto l371;
+  yyDo(G, yy_3_Value, G->begin, G->end, "yy_3_Value");
+  if (!yy_WS(G))  goto l371;
+  if (!yy_Expr(G))  goto l371;
+  yyDo(G, yySet, -2, 0, "yySet");
+  if (!yy_WS(G))  goto l371;
+  if (!yymatchChar(G, ')')) goto l371;
+  yyDo(G, yy_4_Value, G->begin, G->end, "yy_4_Value");
+  if (!yy__(G))  goto l371;
+  goto l369;
+  l371:;	  G->pos= yypos369; G->thunkpos= yythunkpos369;  if (!yymatchChar(G, '-')) goto l372;
+  if (!yy__(G))  goto l372;
+  yyDo(G, yy_5_Value, G->begin, G->end, "yy_5_Value");
+  if (!yy_SafeNavAccess(G))  goto l372;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_6_Value, G->begin, G->end, "yy_6_Value");
+  goto l369;
+  l372:;	  G->pos= yypos369; G->thunkpos= yythunkpos369;  if (!yymatchChar(G, '+')) goto l373;
+  if (!yy__(G))  goto l373;
+  yyDo(G, yy_7_Value, G->begin, G->end, "yy_7_Value");
+  if (!yy_SafeNavAccess(G))  goto l373;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_8_Value, G->begin, G->end, "yy_8_Value");
+  goto l369;
+  l373:;	  G->pos= yypos369; G->thunkpos= yythunkpos369;  if (!yymatchChar(G, '(')) goto l374;
+  yyDo(G, yy_9_Value, G->begin, G->end, "yy_9_Value");
+  if (!yy_WS(G))  goto l374;
+  if (!yy_Expr(G))  goto l374;
+  yyDo(G, yySet, -2, 0, "yySet");
+  if (!yy_WS(G))  goto l374;
+  if (!yymatchChar(G, ')')) goto l374;
   yyDo(G, yy_10_Value, G->begin, G->end, "yy_10_Value");
 
-  {  int yypos371= G->pos, yythunkpos371= G->thunkpos;  if (!yymatchChar(G, '&')) goto l371;
+  {  int yypos375= G->pos, yythunkpos375= G->thunkpos;  if (!yymatchChar(G, '&')) goto l375;
 
-  {  int yypos373= G->pos, yythunkpos373= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l373;
-  goto l371;
-  l373:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;
+  {  int yypos377= G->pos, yythunkpos377= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l377;
+  goto l375;
+  l377:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;
   }  yyDo(G, yy_11_Value, G->begin, G->end, "yy_11_Value");
-  goto l372;
-  l371:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;
+  goto l376;
+  l375:;	  G->pos= yypos375; G->thunkpos= yythunkpos375;
   }
-  l372:;	  if (!yy__(G))  goto l370;
-  goto l365;
-  l370:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;  if (!yy_ValueCore(G))  goto l364;
+  l376:;	  if (!yy__(G))  goto l374;
+  goto l369;
+  l374:;	  G->pos= yypos369; G->thunkpos= yythunkpos369;  if (!yy_ValueCore(G))  goto l368;
 
   }
-  l365:;	  yyprintf((stderr, "  ok   Value"));
+  l369:;	  yyprintf((stderr, "  ok   Value"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l364:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
+  l368:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9416,13 +9444,13 @@ YY_RULE(int) yy_Value(GREG *G)
 }
 YY_RULE(int) yy_MATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MATCH_KW"));
-  if (!yymatchString(G, "match")) goto l374;
+  if (!yymatchString(G, "match")) goto l378;
   yyprintf((stderr, "  ok   MATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l374:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
+  l378:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9430,13 +9458,13 @@ YY_RULE(int) yy_MATCH_KW(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_ARROW"));
-  if (!yymatchString(G, "=>")) goto l375;
+  if (!yymatchString(G, "=>")) goto l379;
   yyprintf((stderr, "  ok   DOUBLE_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l375:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
+  l379:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9446,40 +9474,40 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CaseExpr"));
 
-  {  int yypos377= G->pos, yythunkpos377= G->thunkpos;  if (!yy_VariableDecl(G))  goto l378;
+  {  int yypos381= G->pos, yythunkpos381= G->thunkpos;  if (!yy_VariableDecl(G))  goto l382;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l378;
-  goto l377;
-  l378:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;  if (!yy_BinaryOperation(G))  goto l379;
+  if (!yy__(G))  goto l382;
+  goto l381;
+  l382:;	  G->pos= yypos381; G->thunkpos= yythunkpos381;  if (!yy_BinaryOperation(G))  goto l383;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l379;
+  if (!yy__(G))  goto l383;
 
-  l380:;	
-  {  int yypos381= G->pos, yythunkpos381= G->thunkpos;  if (!yy__(G))  goto l381;
-  if (!yymatchChar(G, '.')) goto l381;
+  l384:;	
+  {  int yypos385= G->pos, yythunkpos385= G->thunkpos;  if (!yy__(G))  goto l385;
+  if (!yymatchChar(G, '.')) goto l385;
   yyDo(G, yy_1_CaseExpr, G->begin, G->end, "yy_1_CaseExpr");
-  if (!yy_WS(G))  goto l381;
-  if (!yy_FunctionCall(G))  goto l381;
+  if (!yy_WS(G))  goto l385;
+  if (!yy_FunctionCall(G))  goto l385;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_CaseExpr, G->begin, G->end, "yy_2_CaseExpr");
-  goto l380;
-  l381:;	  G->pos= yypos381; G->thunkpos= yythunkpos381;
-  }  goto l377;
-  l379:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;  if (!yy_AnonymousFunctionDecl(G))  goto l382;
-  goto l377;
-  l382:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;  if (!yymatchChar(G, '(')) goto l376;
-  if (!yy__(G))  goto l376;
-  if (!yy_Expr(G))  goto l376;
-  if (!yy__(G))  goto l376;
-  if (!yymatchChar(G, ')')) goto l376;
+  goto l384;
+  l385:;	  G->pos= yypos385; G->thunkpos= yythunkpos385;
+  }  goto l381;
+  l383:;	  G->pos= yypos381; G->thunkpos= yythunkpos381;  if (!yy_AnonymousFunctionDecl(G))  goto l386;
+  goto l381;
+  l386:;	  G->pos= yypos381; G->thunkpos= yythunkpos381;  if (!yymatchChar(G, '(')) goto l380;
+  if (!yy__(G))  goto l380;
+  if (!yy_Expr(G))  goto l380;
+  if (!yy__(G))  goto l380;
+  if (!yymatchChar(G, ')')) goto l380;
 
   }
-  l377:;	  yyprintf((stderr, "  ok   CaseExpr"));
+  l381:;	  yyprintf((stderr, "  ok   CaseExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l376:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
+  l380:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9487,13 +9515,13 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 }
 YY_RULE(int) yy_CASE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CASE_KW"));
-  if (!yymatchString(G, "case")) goto l383;
+  if (!yymatchString(G, "case")) goto l387;
   yyprintf((stderr, "  ok   CASE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l383:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
+  l387:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9502,35 +9530,35 @@ YY_RULE(int) yy_CASE_KW(GREG *G)
 YY_RULE(int) yy_Case(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Case"));
-  if (!yy_CASE_KW(G))  goto l384;
+  if (!yy_CASE_KW(G))  goto l388;
   yyDo(G, yy_1_Case, G->begin, G->end, "yy_1_Case");
 
-  {  int yypos385= G->pos, yythunkpos385= G->thunkpos;  if (!yy__(G))  goto l385;
-  if (!yy_CaseExpr(G))  goto l385;
+  {  int yypos389= G->pos, yythunkpos389= G->thunkpos;  if (!yy__(G))  goto l389;
+  if (!yy_CaseExpr(G))  goto l389;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Case, G->begin, G->end, "yy_2_Case");
-  goto l386;
-  l385:;	  G->pos= yypos385; G->thunkpos= yythunkpos385;
+  goto l390;
+  l389:;	  G->pos= yypos389; G->thunkpos= yythunkpos389;
   }
-  l386:;	  if (!yy_WS(G))  goto l384;
-  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l384; }
+  l390:;	  if (!yy_WS(G))  goto l388;
+  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l388; }
 
-  l387:;	
-  {  int yypos388= G->pos, yythunkpos388= G->thunkpos;  if (!yy_WS(G))  goto l388;
-  if (!yy_Stmt(G))  goto l388;
+  l391:;	
+  {  int yypos392= G->pos, yythunkpos392= G->thunkpos;  if (!yy_WS(G))  goto l392;
+  if (!yy_Stmt(G))  goto l392;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Case, G->begin, G->end, "yy_3_Case");
-  if (!yy_WS(G))  goto l388;
-  goto l387;
-  l388:;	  G->pos= yypos388; G->thunkpos= yythunkpos388;
-  }  if (!yy_WS(G))  goto l384;
+  if (!yy_WS(G))  goto l392;
+  goto l391;
+  l392:;	  G->pos= yypos392; G->thunkpos= yythunkpos392;
+  }  if (!yy_WS(G))  goto l388;
   yyDo(G, yy_4_Case, G->begin, G->end, "yy_4_Case");
   yyprintf((stderr, "  ok   Case"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l384:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
+  l388:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9538,13 +9566,13 @@ YY_RULE(int) yy_Case(GREG *G)
 }
 YY_RULE(int) yy_ELSE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ELSE_KW"));
-  if (!yymatchString(G, "else")) goto l389;
+  if (!yymatchString(G, "else")) goto l393;
   yyprintf((stderr, "  ok   ELSE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l389:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
+  l393:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9554,30 +9582,30 @@ YY_RULE(int) yy_Body(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Body"));
 
-  {  int yypos391= G->pos, yythunkpos391= G->thunkpos;  if (!yymatchChar(G, '{')) goto l392;
+  {  int yypos395= G->pos, yythunkpos395= G->thunkpos;  if (!yymatchChar(G, '{')) goto l396;
 
-  l393:;	
-  {  int yypos394= G->pos, yythunkpos394= G->thunkpos;  if (!yy_WS(G))  goto l394;
-  if (!yy_Stmt(G))  goto l394;
+  l397:;	
+  {  int yypos398= G->pos, yythunkpos398= G->thunkpos;  if (!yy_WS(G))  goto l398;
+  if (!yy_Stmt(G))  goto l398;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Body, G->begin, G->end, "yy_1_Body");
-  if (!yy_WS(G))  goto l394;
-  goto l393;
-  l394:;	  G->pos= yypos394; G->thunkpos= yythunkpos394;
-  }  if (!yy_WS(G))  goto l392;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l392; }
-  goto l391;
-  l392:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yy_Stmt(G))  goto l390;
+  if (!yy_WS(G))  goto l398;
+  goto l397;
+  l398:;	  G->pos= yypos398; G->thunkpos= yythunkpos398;
+  }  if (!yy_WS(G))  goto l396;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l396; }
+  goto l395;
+  l396:;	  G->pos= yypos395; G->thunkpos= yythunkpos395;  if (!yy_Stmt(G))  goto l394;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Body, G->begin, G->end, "yy_2_Body");
 
   }
-  l391:;	  yyprintf((stderr, "  ok   Body"));
+  l395:;	  yyprintf((stderr, "  ok   Body"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l390:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
+  l394:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9585,13 +9613,13 @@ YY_RULE(int) yy_Body(GREG *G)
 }
 YY_RULE(int) yy_IF_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IF_KW"));
-  if (!yymatchString(G, "if")) goto l395;
+  if (!yymatchString(G, "if")) goto l399;
   yyprintf((stderr, "  ok   IF_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l395:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
+  l399:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9599,18 +9627,18 @@ YY_RULE(int) yy_IF_KW(GREG *G)
 }
 YY_RULE(int) yy_Else(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Else"));
-  if (!yy_ELSE_KW(G))  goto l396;
+  if (!yy_ELSE_KW(G))  goto l400;
   yyDo(G, yy_1_Else, G->begin, G->end, "yy_1_Else");
   yyDo(G, yy_2_Else, G->begin, G->end, "yy_2_Else");
-  if (!yy__(G))  goto l396;
-  if (!yy_Body(G))  goto l396;
+  if (!yy__(G))  goto l400;
+  if (!yy_Body(G))  goto l400;
   yyDo(G, yy_3_Else, G->begin, G->end, "yy_3_Else");
   yyprintf((stderr, "  ok   Else"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l396:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
+  l400:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9619,26 +9647,26 @@ YY_RULE(int) yy_Else(GREG *G)
 YY_RULE(int) yy_If(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "If"));
-  if (!yy_IF_KW(G))  goto l397;
+  if (!yy_IF_KW(G))  goto l401;
   yyDo(G, yy_1_If, G->begin, G->end, "yy_1_If");
-  if (!yy_WS(G))  goto l397;
-  if (!yymatchChar(G, '(')) goto l397;
-  if (!yy_WS(G))  goto l397;
-  if (!yy__(G))  goto l397;
-  if (!yy_Expr(G))  goto l397;
+  if (!yy_WS(G))  goto l401;
+  if (!yymatchChar(G, '(')) goto l401;
+  if (!yy_WS(G))  goto l401;
+  if (!yy__(G))  goto l401;
+  if (!yy_Expr(G))  goto l401;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_If, G->begin, G->end, "yy_2_If");
-  if (!yy_WS(G))  goto l397;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l397; }
-  if (!yy__(G))  goto l397;
-  if (!yy_Body(G))  goto l397;
+  if (!yy_WS(G))  goto l401;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l401; }
+  if (!yy__(G))  goto l401;
+  if (!yy_Body(G))  goto l401;
   yyDo(G, yy_3_If, G->begin, G->end, "yy_3_If");
   yyprintf((stderr, "  ok   If"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l397:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
+  l401:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9648,31 +9676,31 @@ YY_RULE(int) yy_Return(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Return"));
 
-  {  int yypos399= G->pos, yythunkpos399= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l400;
+  {  int yypos403= G->pos, yythunkpos403= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l404;
 
-  {  int yypos401= G->pos, yythunkpos401= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l400;
-  G->pos= yypos401; G->thunkpos= yythunkpos401;
+  {  int yypos405= G->pos, yythunkpos405= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l404;
+  G->pos= yypos405; G->thunkpos= yythunkpos405;
   }  yyDo(G, yy_1_Return, G->begin, G->end, "yy_1_Return");
-  if (!yy__(G))  goto l400;
-  if (!yy_Expr(G))  goto l400;
+  if (!yy__(G))  goto l404;
+  if (!yy_Expr(G))  goto l404;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Return, G->begin, G->end, "yy_2_Return");
-  goto l399;
-  l400:;	  G->pos= yypos399; G->thunkpos= yythunkpos399;  if (!yy_RETURN_KW(G))  goto l398;
+  goto l403;
+  l404:;	  G->pos= yypos403; G->thunkpos= yythunkpos403;  if (!yy_RETURN_KW(G))  goto l402;
 
-  {  int yypos402= G->pos, yythunkpos402= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l398;
-  G->pos= yypos402; G->thunkpos= yythunkpos402;
+  {  int yypos406= G->pos, yythunkpos406= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l402;
+  G->pos= yypos406; G->thunkpos= yythunkpos406;
   }  yyDo(G, yy_3_Return, G->begin, G->end, "yy_3_Return");
-  if (!yy__(G))  goto l398;
+  if (!yy__(G))  goto l402;
   yyDo(G, yy_4_Return, G->begin, G->end, "yy_4_Return");
 
   }
-  l399:;	  yyprintf((stderr, "  ok   Return"));
+  l403:;	  yyprintf((stderr, "  ok   Return"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l398:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
+  l402:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9680,24 +9708,24 @@ YY_RULE(int) yy_Return(GREG *G)
 }
 YY_RULE(int) yy_Try(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Try"));
-  if (!yy_TRY_KW(G))  goto l403;
+  if (!yy_TRY_KW(G))  goto l407;
   yyDo(G, yy_1_Try, G->begin, G->end, "yy_1_Try");
-  if (!yy__(G))  goto l403;
-  if (!yy_Body(G))  goto l403;
+  if (!yy__(G))  goto l407;
+  if (!yy_Body(G))  goto l407;
 
-  l404:;	
-  {  int yypos405= G->pos, yythunkpos405= G->thunkpos;  if (!yy_WS(G))  goto l405;
-  if (!yy_Catch(G))  goto l405;
-  if (!yy_WS(G))  goto l405;
-  goto l404;
-  l405:;	  G->pos= yypos405; G->thunkpos= yythunkpos405;
+  l408:;	
+  {  int yypos409= G->pos, yythunkpos409= G->thunkpos;  if (!yy_WS(G))  goto l409;
+  if (!yy_Catch(G))  goto l409;
+  if (!yy_WS(G))  goto l409;
+  goto l408;
+  l409:;	  G->pos= yypos409; G->thunkpos= yythunkpos409;
   }  yyDo(G, yy_2_Try, G->begin, G->end, "yy_2_Try");
   yyprintf((stderr, "  ok   Try"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l403:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
+  l407:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9706,34 +9734,34 @@ YY_RULE(int) yy_Try(GREG *G)
 YY_RULE(int) yy_Match(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Match"));
-  if (!yy_MATCH_KW(G))  goto l406;
+  if (!yy_MATCH_KW(G))  goto l410;
   yyDo(G, yy_1_Match, G->begin, G->end, "yy_1_Match");
 
-  {  int yypos407= G->pos, yythunkpos407= G->thunkpos;  if (!yy__(G))  goto l407;
-  if (!yy_Value(G))  goto l407;
+  {  int yypos411= G->pos, yythunkpos411= G->thunkpos;  if (!yy__(G))  goto l411;
+  if (!yy_Value(G))  goto l411;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Match, G->begin, G->end, "yy_2_Match");
-  goto l408;
-  l407:;	  G->pos= yypos407; G->thunkpos= yythunkpos407;
+  goto l412;
+  l411:;	  G->pos= yypos411; G->thunkpos= yythunkpos411;
   }
-  l408:;	  if (!yy_WS(G))  goto l406;
-  if (!yymatchChar(G, '{')) goto l406;
+  l412:;	  if (!yy_WS(G))  goto l410;
+  if (!yymatchChar(G, '{')) goto l410;
 
-  l409:;	
-  {  int yypos410= G->pos, yythunkpos410= G->thunkpos;  if (!yy_WS(G))  goto l410;
-  if (!yy_Case(G))  goto l410;
-  if (!yy_WS(G))  goto l410;
-  goto l409;
-  l410:;	  G->pos= yypos410; G->thunkpos= yythunkpos410;
-  }  if (!yy_WS(G))  goto l406;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l406; }
+  l413:;	
+  {  int yypos414= G->pos, yythunkpos414= G->thunkpos;  if (!yy_WS(G))  goto l414;
+  if (!yy_Case(G))  goto l414;
+  if (!yy_WS(G))  goto l414;
+  goto l413;
+  l414:;	  G->pos= yypos414; G->thunkpos= yythunkpos414;
+  }  if (!yy_WS(G))  goto l410;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l410; }
   yyDo(G, yy_3_Match, G->begin, G->end, "yy_3_Match");
   yyprintf((stderr, "  ok   Match"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l406:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
+  l410:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9742,21 +9770,21 @@ YY_RULE(int) yy_Match(GREG *G)
 YY_RULE(int) yy_FlowControl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FlowControl"));
 
-  {  int yypos412= G->pos, yythunkpos412= G->thunkpos;  if (!yy_Foreach(G))  goto l413;
-  goto l412;
-  l413:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;  if (!yy_While(G))  goto l414;
-  goto l412;
-  l414:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;  if (!yy_Break(G))  goto l415;
-  goto l412;
-  l415:;	  G->pos= yypos412; G->thunkpos= yythunkpos412;  if (!yy_Continue(G))  goto l411;
+  {  int yypos416= G->pos, yythunkpos416= G->thunkpos;  if (!yy_Foreach(G))  goto l417;
+  goto l416;
+  l417:;	  G->pos= yypos416; G->thunkpos= yythunkpos416;  if (!yy_While(G))  goto l418;
+  goto l416;
+  l418:;	  G->pos= yypos416; G->thunkpos= yythunkpos416;  if (!yy_Break(G))  goto l419;
+  goto l416;
+  l419:;	  G->pos= yypos416; G->thunkpos= yythunkpos416;  if (!yy_Continue(G))  goto l415;
 
   }
-  l412:;	  yyprintf((stderr, "  ok   FlowControl"));
+  l416:;	  yyprintf((stderr, "  ok   FlowControl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l411:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
+  l415:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9765,26 +9793,26 @@ YY_RULE(int) yy_FlowControl(GREG *G)
 YY_RULE(int) yy_Block(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Block"));
-  if (!yymatchChar(G, '{')) goto l416;
+  if (!yymatchChar(G, '{')) goto l420;
   yyDo(G, yy_1_Block, G->begin, G->end, "yy_1_Block");
 
-  l417:;	
-  {  int yypos418= G->pos, yythunkpos418= G->thunkpos;  if (!yy_WS(G))  goto l418;
-  if (!yy_Stmt(G))  goto l418;
+  l421:;	
+  {  int yypos422= G->pos, yythunkpos422= G->thunkpos;  if (!yy_WS(G))  goto l422;
+  if (!yy_Stmt(G))  goto l422;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Block, G->begin, G->end, "yy_2_Block");
-  if (!yy_WS(G))  goto l418;
-  goto l417;
-  l418:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;
-  }  if (!yy_WS(G))  goto l416;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l416; }
+  if (!yy_WS(G))  goto l422;
+  goto l421;
+  l422:;	  G->pos= yypos422; G->thunkpos= yythunkpos422;
+  }  if (!yy_WS(G))  goto l420;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l420; }
   yyDo(G, yy_3_Block, G->begin, G->end, "yy_3_Block");
   yyprintf((stderr, "  ok   Block"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l416:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
+  l420:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9793,22 +9821,22 @@ YY_RULE(int) yy_Block(GREG *G)
 YY_RULE(int) yy_Conditional(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Conditional"));
-  if (!yy_If(G))  goto l419;
+  if (!yy_If(G))  goto l423;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos420= G->pos, yythunkpos420= G->thunkpos;  if (!yy_WS(G))  goto l420;
-  if (!yy_Else(G))  goto l420;
+  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;  if (!yy_WS(G))  goto l424;
+  if (!yy_Else(G))  goto l424;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Conditional, G->begin, G->end, "yy_1_Conditional");
-  goto l421;
-  l420:;	  G->pos= yypos420; G->thunkpos= yythunkpos420;
+  goto l425;
+  l424:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;
   }
-  l421:;	  yyprintf((stderr, "  ok   Conditional"));
+  l425:;	  yyprintf((stderr, "  ok   Conditional"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l419:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
+  l423:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9816,22 +9844,22 @@ YY_RULE(int) yy_Conditional(GREG *G)
 }
 YY_RULE(int) yy_CommentLine(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CommentLine"));
-  if (!yymatchString(G, "//")) goto l422;
+  if (!yymatchString(G, "//")) goto l426;
 
-  l423:;	
-  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;
-  {  int yypos425= G->pos, yythunkpos425= G->thunkpos;  if (!yy_EOL(G))  goto l425;
-  goto l424;
-  l425:;	  G->pos= yypos425; G->thunkpos= yythunkpos425;
-  }  if (!yymatchDot(G)) goto l424;  goto l423;
-  l424:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;
-  }  if (!yy_EOL(G))  goto l422;
+  l427:;	
+  {  int yypos428= G->pos, yythunkpos428= G->thunkpos;
+  {  int yypos429= G->pos, yythunkpos429= G->thunkpos;  if (!yy_EOL(G))  goto l429;
+  goto l428;
+  l429:;	  G->pos= yypos429; G->thunkpos= yythunkpos429;
+  }  if (!yymatchDot(G)) goto l428;  goto l427;
+  l428:;	  G->pos= yypos428; G->thunkpos= yythunkpos428;
+  }  if (!yy_EOL(G))  goto l426;
   yyprintf((stderr, "  ok   CommentLine"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l422:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CommentLine"));
+  l426:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CommentLine"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9840,22 +9868,22 @@ YY_RULE(int) yy_CommentLine(GREG *G)
 YY_RULE(int) yy_EoledStatement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EoledStatement"));
 
-  {  int yypos427= G->pos, yythunkpos427= G->thunkpos;  if (!yy_WS(G))  goto l428;
-  if (!yy_Return(G))  goto l428;
-  goto l427;
-  l428:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l429;
-  if (!yy_VariableDecl(G))  goto l429;
-  goto l427;
-  l429:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;  if (!yy_WS(G))  goto l426;
-  if (!yy_Expr(G))  goto l426;
+  {  int yypos431= G->pos, yythunkpos431= G->thunkpos;  if (!yy_WS(G))  goto l432;
+  if (!yy_Return(G))  goto l432;
+  goto l431;
+  l432:;	  G->pos= yypos431; G->thunkpos= yythunkpos431;  if (!yy_WS(G))  goto l433;
+  if (!yy_VariableDecl(G))  goto l433;
+  goto l431;
+  l433:;	  G->pos= yypos431; G->thunkpos= yythunkpos431;  if (!yy_WS(G))  goto l430;
+  if (!yy_Expr(G))  goto l430;
 
   }
-  l427:;	  yyprintf((stderr, "  ok   EoledStatement"));
+  l431:;	  yyprintf((stderr, "  ok   EoledStatement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l426:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EoledStatement"));
+  l430:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EoledStatement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9865,72 +9893,72 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "StmtCore"));
 
-  {  int yypos431= G->pos, yythunkpos431= G->thunkpos;  if (!yy_EoledStatement(G))  goto l432;
+  {  int yypos435= G->pos, yythunkpos435= G->thunkpos;  if (!yy_EoledStatement(G))  goto l436;
   yyDo(G, yySet, 0, 0, "yySet");
 
-  {  int yypos433= G->pos, yythunkpos433= G->thunkpos;  if (!yy_Terminator(G))  goto l434;
+  {  int yypos437= G->pos, yythunkpos437= G->thunkpos;  if (!yy_Terminator(G))  goto l438;
 
-  l435:;	
-  {  int yypos436= G->pos, yythunkpos436= G->thunkpos;  if (!yy_Terminator(G))  goto l436;
-  goto l435;
-  l436:;	  G->pos= yypos436; G->thunkpos= yythunkpos436;
-  }  goto l433;
-  l434:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;  if (!yy_WS(G))  goto l437;
+  l439:;	
+  {  int yypos440= G->pos, yythunkpos440= G->thunkpos;  if (!yy_Terminator(G))  goto l440;
+  goto l439;
+  l440:;	  G->pos= yypos440; G->thunkpos= yythunkpos440;
+  }  goto l437;
+  l438:;	  G->pos= yypos437; G->thunkpos= yythunkpos437;  if (!yy_WS(G))  goto l441;
 
-  {  int yypos438= G->pos, yythunkpos438= G->thunkpos;  if (!yymatchChar(G, '}')) goto l437;
-  G->pos= yypos438; G->thunkpos= yythunkpos438;
-  }  goto l433;
-  l437:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;  if (!yy_WS(G))  goto l439;
-
-  {  int yypos440= G->pos, yythunkpos440= G->thunkpos;  if (!yymatchChar(G, ')')) goto l439;
-  G->pos= yypos440; G->thunkpos= yythunkpos440;
-  }  goto l433;
-  l439:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;  if (!yy_WS(G))  goto l441;
-
-  {  int yypos442= G->pos, yythunkpos442= G->thunkpos;  if (!yymatchChar(G, ',')) goto l441;
+  {  int yypos442= G->pos, yythunkpos442= G->thunkpos;  if (!yymatchChar(G, '}')) goto l441;
   G->pos= yypos442; G->thunkpos= yythunkpos442;
-  }  goto l433;
-  l441:;	  G->pos= yypos433; G->thunkpos= yythunkpos433;
-  {  int yypos443= G->pos, yythunkpos443= G->thunkpos;  if (!yy_CommentLine(G))  goto l432;
-  G->pos= yypos443; G->thunkpos= yythunkpos443;
-  }
-  }
-  l433:;	  goto l431;
-  l432:;	  G->pos= yypos431; G->thunkpos= yythunkpos431;
-  {  int yypos444= G->pos, yythunkpos444= G->thunkpos;  if (!yy_WS(G))  goto l445;
-  if (!yy_Conditional(G))  goto l445;
-  yyDo(G, yySet, 0, 0, "yySet");
-  goto l444;
-  l445:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l446;
-  if (!yy_Block(G))  goto l446;
-  yyDo(G, yySet, 0, 0, "yySet");
-  goto l444;
-  l446:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l447;
-  if (!yy_FlowControl(G))  goto l447;
-  yyDo(G, yySet, 0, 0, "yySet");
+  }  goto l437;
+  l441:;	  G->pos= yypos437; G->thunkpos= yythunkpos437;  if (!yy_WS(G))  goto l443;
 
-  l448:;	
-  {  int yypos449= G->pos, yythunkpos449= G->thunkpos;  if (!yy_Terminator(G))  goto l449;
+  {  int yypos444= G->pos, yythunkpos444= G->thunkpos;  if (!yymatchChar(G, ')')) goto l443;
+  G->pos= yypos444; G->thunkpos= yythunkpos444;
+  }  goto l437;
+  l443:;	  G->pos= yypos437; G->thunkpos= yythunkpos437;  if (!yy_WS(G))  goto l445;
+
+  {  int yypos446= G->pos, yythunkpos446= G->thunkpos;  if (!yymatchChar(G, ',')) goto l445;
+  G->pos= yypos446; G->thunkpos= yythunkpos446;
+  }  goto l437;
+  l445:;	  G->pos= yypos437; G->thunkpos= yythunkpos437;
+  {  int yypos447= G->pos, yythunkpos447= G->thunkpos;  if (!yy_CommentLine(G))  goto l436;
+  G->pos= yypos447; G->thunkpos= yythunkpos447;
+  }
+  }
+  l437:;	  goto l435;
+  l436:;	  G->pos= yypos435; G->thunkpos= yythunkpos435;
+  {  int yypos448= G->pos, yythunkpos448= G->thunkpos;  if (!yy_WS(G))  goto l449;
+  if (!yy_Conditional(G))  goto l449;
+  yyDo(G, yySet, 0, 0, "yySet");
   goto l448;
-  l449:;	  G->pos= yypos449; G->thunkpos= yythunkpos449;
-  }  goto l444;
-  l447:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l450;
-  if (!yy_Match(G))  goto l450;
+  l449:;	  G->pos= yypos448; G->thunkpos= yythunkpos448;  if (!yy_WS(G))  goto l450;
+  if (!yy_Block(G))  goto l450;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l444;
-  l450:;	  G->pos= yypos444; G->thunkpos= yythunkpos444;  if (!yy_WS(G))  goto l430;
-  if (!yy_Try(G))  goto l430;
+  goto l448;
+  l450:;	  G->pos= yypos448; G->thunkpos= yythunkpos448;  if (!yy_WS(G))  goto l451;
+  if (!yy_FlowControl(G))  goto l451;
+  yyDo(G, yySet, 0, 0, "yySet");
+
+  l452:;	
+  {  int yypos453= G->pos, yythunkpos453= G->thunkpos;  if (!yy_Terminator(G))  goto l453;
+  goto l452;
+  l453:;	  G->pos= yypos453; G->thunkpos= yythunkpos453;
+  }  goto l448;
+  l451:;	  G->pos= yypos448; G->thunkpos= yythunkpos448;  if (!yy_WS(G))  goto l454;
+  if (!yy_Match(G))  goto l454;
+  yyDo(G, yySet, 0, 0, "yySet");
+  goto l448;
+  l454:;	  G->pos= yypos448; G->thunkpos= yythunkpos448;  if (!yy_WS(G))  goto l434;
+  if (!yy_Try(G))  goto l434;
   yyDo(G, yySet, 0, 0, "yySet");
 
   }
-  l444:;	
+  l448:;	
   }
-  l431:;	  yyprintf((stderr, "  ok   StmtCore"));
+  l435:;	  yyprintf((stderr, "  ok   StmtCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l430:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "StmtCore"));
+  l434:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "StmtCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9938,17 +9966,17 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 }
 YY_RULE(int) yy_FuncTypeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FuncTypeCore"));
-  if (!yymatchString(G, "Func")) goto l451;
+  if (!yymatchString(G, "Func")) goto l455;
 
-  {  int yypos452= G->pos, yythunkpos452= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l451;
-  G->pos= yypos452; G->thunkpos= yythunkpos452;
+  {  int yypos456= G->pos, yythunkpos456= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l455;
+  G->pos= yypos456; G->thunkpos= yythunkpos456;
   }  yyDo(G, yy_1_FuncTypeCore, G->begin, G->end, "yy_1_FuncTypeCore");
   yyprintf((stderr, "  ok   FuncTypeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l451:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
+  l455:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9962,7 +9990,7 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l453:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
+  l457:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9971,32 +9999,32 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
 YY_RULE(int) yy_TypeList(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeList"));
-  if (!yymatchChar(G, '(')) goto l454;
-  if (!yy_WS(G))  goto l454;
-  if (!yy_TypeListCore(G))  goto l454;
+  if (!yymatchChar(G, '(')) goto l458;
+  if (!yy_WS(G))  goto l458;
+  if (!yy_TypeListCore(G))  goto l458;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_Type(G))  goto l454;
+  if (!yy_Type(G))  goto l458;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_TypeList, G->begin, G->end, "yy_1_TypeList");
 
-  l455:;	
-  {  int yypos456= G->pos, yythunkpos456= G->thunkpos;  if (!yy_WS(G))  goto l456;
-  if (!yymatchChar(G, ',')) goto l456;
-  if (!yy_WS(G))  goto l456;
-  if (!yy_Type(G))  goto l456;
+  l459:;	
+  {  int yypos460= G->pos, yythunkpos460= G->thunkpos;  if (!yy_WS(G))  goto l460;
+  if (!yymatchChar(G, ',')) goto l460;
+  if (!yy_WS(G))  goto l460;
+  if (!yy_Type(G))  goto l460;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_TypeList, G->begin, G->end, "yy_2_TypeList");
-  goto l455;
-  l456:;	  G->pos= yypos456; G->thunkpos= yythunkpos456;
-  }  if (!yymatchChar(G, ')')) goto l454;
-  if (!yy__(G))  goto l454;
+  goto l459;
+  l460:;	  G->pos= yypos460; G->thunkpos= yythunkpos460;
+  }  if (!yymatchChar(G, ')')) goto l458;
+  if (!yy__(G))  goto l458;
   yyDo(G, yy_3_TypeList, G->begin, G->end, "yy_3_TypeList");
   yyprintf((stderr, "  ok   TypeList"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l454:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
+  l458:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10010,7 +10038,7 @@ YY_RULE(int) yy_Old(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l457:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
+  l461:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10020,123 +10048,123 @@ YY_RULE(int) yy_GenericType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericType"));
 
-  {  int yypos459= G->pos, yythunkpos459= G->thunkpos;  if (!yy_Old(G))  goto l460;
+  {  int yypos463= G->pos, yythunkpos463= G->thunkpos;  if (!yy_Old(G))  goto l464;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l460;
-  if (!yy_IDENT(G))  goto l460;
+  if (!yy__(G))  goto l464;
+  if (!yy_IDENT(G))  goto l464;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_GenericType, G->begin, G->end, "yy_1_GenericType");
-  if (!yy__(G))  goto l460;
-  if (!yy_TypeBase(G))  goto l460;
+  if (!yy__(G))  goto l464;
+  if (!yy_TypeBase(G))  goto l464;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos461= G->pos, yythunkpos461= G->thunkpos;  if (!yy_FuncType(G))  goto l461;
-  goto l460;
-  l461:;	  G->pos= yypos461; G->thunkpos= yythunkpos461;
+  {  int yypos465= G->pos, yythunkpos465= G->thunkpos;  if (!yy_FuncType(G))  goto l465;
+  goto l464;
+  l465:;	  G->pos= yypos465; G->thunkpos= yythunkpos465;
   }  yyDo(G, yy_2_GenericType, G->begin, G->end, "yy_2_GenericType");
-  if (!yy__(G))  goto l460;
-  if (!yymatchChar(G, '<')) goto l460;
-  if (!yy__(G))  goto l460;
-  if (!yy_Type(G))  goto l460;
+  if (!yy__(G))  goto l464;
+  if (!yymatchChar(G, '<')) goto l464;
+  if (!yy__(G))  goto l464;
+  if (!yy_Type(G))  goto l464;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_GenericType, G->begin, G->end, "yy_3_GenericType");
 
-  l462:;	
-  {  int yypos463= G->pos, yythunkpos463= G->thunkpos;  if (!yy__(G))  goto l463;
-  if (!yymatchChar(G, ',')) goto l463;
-  if (!yy__(G))  goto l463;
-  if (!yy_Type(G))  goto l463;
+  l466:;	
+  {  int yypos467= G->pos, yythunkpos467= G->thunkpos;  if (!yy__(G))  goto l467;
+  if (!yymatchChar(G, ',')) goto l467;
+  if (!yy__(G))  goto l467;
+  if (!yy_Type(G))  goto l467;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_GenericType, G->begin, G->end, "yy_4_GenericType");
-  goto l462;
-  l463:;	  G->pos= yypos463; G->thunkpos= yythunkpos463;
-  }  if (!yy__(G))  goto l460;
-  if (!yymatchChar(G, '>')) goto l460;
-  if (!yy__(G))  goto l460;
+  goto l466;
+  l467:;	  G->pos= yypos467; G->thunkpos= yythunkpos467;
+  }  if (!yy__(G))  goto l464;
+  if (!yymatchChar(G, '>')) goto l464;
+  if (!yy__(G))  goto l464;
 
-  l464:;	
-  {  int yypos465= G->pos, yythunkpos465= G->thunkpos;
-  {  int yypos466= G->pos, yythunkpos466= G->thunkpos;  if (!yymatchChar(G, '*')) goto l467;
+  l468:;	
+  {  int yypos469= G->pos, yythunkpos469= G->thunkpos;
+  {  int yypos470= G->pos, yythunkpos470= G->thunkpos;  if (!yymatchChar(G, '*')) goto l471;
   yyDo(G, yy_5_GenericType, G->begin, G->end, "yy_5_GenericType");
-  goto l466;
-  l467:;	  G->pos= yypos466; G->thunkpos= yythunkpos466;  if (!yymatchChar(G, '@')) goto l468;
-  yyDo(G, yy_6_GenericType, G->begin, G->end, "yy_6_GenericType");
-  goto l466;
-  l468:;	  G->pos= yypos466; G->thunkpos= yythunkpos466;  if (!yymatchChar(G, '[')) goto l465;
-  if (!yy_WS(G))  goto l465;
-  yyDo(G, yy_7_GenericType, G->begin, G->end, "yy_7_GenericType");
-  if (!yy__(G))  goto l465;
-
-  {  int yypos469= G->pos, yythunkpos469= G->thunkpos;  if (!yy_Expr(G))  goto l469;
-  yyDo(G, yySet, -1, 0, "yySet");
   goto l470;
-  l469:;	  G->pos= yypos469; G->thunkpos= yythunkpos469;
+  l471:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;  if (!yymatchChar(G, '@')) goto l472;
+  yyDo(G, yy_6_GenericType, G->begin, G->end, "yy_6_GenericType");
+  goto l470;
+  l472:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;  if (!yymatchChar(G, '[')) goto l469;
+  if (!yy_WS(G))  goto l469;
+  yyDo(G, yy_7_GenericType, G->begin, G->end, "yy_7_GenericType");
+  if (!yy__(G))  goto l469;
+
+  {  int yypos473= G->pos, yythunkpos473= G->thunkpos;  if (!yy_Expr(G))  goto l473;
+  yyDo(G, yySet, -1, 0, "yySet");
+  goto l474;
+  l473:;	  G->pos= yypos473; G->thunkpos= yythunkpos473;
   }
-  l470:;	  if (!yymatchChar(G, ']')) goto l465;
+  l474:;	  if (!yymatchChar(G, ']')) goto l469;
   yyDo(G, yy_8_GenericType, G->begin, G->end, "yy_8_GenericType");
 
   }
-  l466:;	  goto l464;
-  l465:;	  G->pos= yypos465; G->thunkpos= yythunkpos465;
-  }  if (!yy__(G))  goto l460;
+  l470:;	  goto l468;
+  l469:;	  G->pos= yypos469; G->thunkpos= yythunkpos469;
+  }  if (!yy__(G))  goto l464;
   yyDo(G, yy_9_GenericType, G->begin, G->end, "yy_9_GenericType");
-  goto l459;
-  l460:;	  G->pos= yypos459; G->thunkpos= yythunkpos459;  if (!yy_TypeBase(G))  goto l458;
+  goto l463;
+  l464:;	  G->pos= yypos463; G->thunkpos= yythunkpos463;  if (!yy_TypeBase(G))  goto l462;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l458;
-  if (!yymatchChar(G, '<')) goto l458;
-  if (!yy__(G))  goto l458;
-  if (!yy_Type(G))  goto l458;
+  if (!yy__(G))  goto l462;
+  if (!yymatchChar(G, '<')) goto l462;
+  if (!yy__(G))  goto l462;
+  if (!yy_Type(G))  goto l462;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_10_GenericType, G->begin, G->end, "yy_10_GenericType");
 
-  l471:;	
-  {  int yypos472= G->pos, yythunkpos472= G->thunkpos;  if (!yy__(G))  goto l472;
-  if (!yymatchChar(G, ',')) goto l472;
-  if (!yy__(G))  goto l472;
-  if (!yy_Type(G))  goto l472;
+  l475:;	
+  {  int yypos476= G->pos, yythunkpos476= G->thunkpos;  if (!yy__(G))  goto l476;
+  if (!yymatchChar(G, ',')) goto l476;
+  if (!yy__(G))  goto l476;
+  if (!yy_Type(G))  goto l476;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_11_GenericType, G->begin, G->end, "yy_11_GenericType");
-  goto l471;
-  l472:;	  G->pos= yypos472; G->thunkpos= yythunkpos472;
-  }  if (!yy__(G))  goto l458;
-  if (!yymatchChar(G, '>')) goto l458;
-  if (!yy__(G))  goto l458;
+  goto l475;
+  l476:;	  G->pos= yypos476; G->thunkpos= yythunkpos476;
+  }  if (!yy__(G))  goto l462;
+  if (!yymatchChar(G, '>')) goto l462;
+  if (!yy__(G))  goto l462;
 
-  l473:;	
-  {  int yypos474= G->pos, yythunkpos474= G->thunkpos;
-  {  int yypos475= G->pos, yythunkpos475= G->thunkpos;  if (!yymatchChar(G, '*')) goto l476;
+  l477:;	
+  {  int yypos478= G->pos, yythunkpos478= G->thunkpos;
+  {  int yypos479= G->pos, yythunkpos479= G->thunkpos;  if (!yymatchChar(G, '*')) goto l480;
   yyDo(G, yy_12_GenericType, G->begin, G->end, "yy_12_GenericType");
-  goto l475;
-  l476:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;  if (!yymatchChar(G, '@')) goto l477;
-  yyDo(G, yy_13_GenericType, G->begin, G->end, "yy_13_GenericType");
-  goto l475;
-  l477:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;  if (!yymatchChar(G, '[')) goto l474;
-  if (!yy_WS(G))  goto l474;
-  yyDo(G, yy_14_GenericType, G->begin, G->end, "yy_14_GenericType");
-  if (!yy__(G))  goto l474;
-
-  {  int yypos478= G->pos, yythunkpos478= G->thunkpos;  if (!yy_Expr(G))  goto l478;
-  yyDo(G, yySet, -1, 0, "yySet");
   goto l479;
-  l478:;	  G->pos= yypos478; G->thunkpos= yythunkpos478;
+  l480:;	  G->pos= yypos479; G->thunkpos= yythunkpos479;  if (!yymatchChar(G, '@')) goto l481;
+  yyDo(G, yy_13_GenericType, G->begin, G->end, "yy_13_GenericType");
+  goto l479;
+  l481:;	  G->pos= yypos479; G->thunkpos= yythunkpos479;  if (!yymatchChar(G, '[')) goto l478;
+  if (!yy_WS(G))  goto l478;
+  yyDo(G, yy_14_GenericType, G->begin, G->end, "yy_14_GenericType");
+  if (!yy__(G))  goto l478;
+
+  {  int yypos482= G->pos, yythunkpos482= G->thunkpos;  if (!yy_Expr(G))  goto l482;
+  yyDo(G, yySet, -1, 0, "yySet");
+  goto l483;
+  l482:;	  G->pos= yypos482; G->thunkpos= yythunkpos482;
   }
-  l479:;	  if (!yymatchChar(G, ']')) goto l474;
+  l483:;	  if (!yymatchChar(G, ']')) goto l478;
   yyDo(G, yy_15_GenericType, G->begin, G->end, "yy_15_GenericType");
 
   }
-  l475:;	  goto l473;
-  l474:;	  G->pos= yypos474; G->thunkpos= yythunkpos474;
-  }  if (!yy__(G))  goto l458;
+  l479:;	  goto l477;
+  l478:;	  G->pos= yypos478; G->thunkpos= yythunkpos478;
+  }  if (!yy__(G))  goto l462;
   yyDo(G, yy_16_GenericType, G->begin, G->end, "yy_16_GenericType");
 
   }
-  l459:;	  yyprintf((stderr, "  ok   GenericType"));
+  l463:;	  yyprintf((stderr, "  ok   GenericType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l458:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
+  l462:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10145,79 +10173,79 @@ YY_RULE(int) yy_GenericType(GREG *G)
 YY_RULE(int) yy_FuncType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FuncType"));
-  if (!yy_FuncTypeCore(G))  goto l480;
+  if (!yy_FuncTypeCore(G))  goto l484;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy__(G))  goto l481;
-  if (!yymatchChar(G, '<')) goto l481;
-  if (!yy__(G))  goto l481;
-  if (!yy_IDENT(G))  goto l481;
+  {  int yypos485= G->pos, yythunkpos485= G->thunkpos;  if (!yy__(G))  goto l485;
+  if (!yymatchChar(G, '<')) goto l485;
+  if (!yy__(G))  goto l485;
+  if (!yy_IDENT(G))  goto l485;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_FuncType, G->begin, G->end, "yy_1_FuncType");
 
-  l483:;	
-  {  int yypos484= G->pos, yythunkpos484= G->thunkpos;  if (!yy__(G))  goto l484;
-  if (!yymatchChar(G, ',')) goto l484;
-  if (!yy__(G))  goto l484;
-  if (!yy_IDENT(G))  goto l484;
+  l487:;	
+  {  int yypos488= G->pos, yythunkpos488= G->thunkpos;  if (!yy__(G))  goto l488;
+  if (!yymatchChar(G, ',')) goto l488;
+  if (!yy__(G))  goto l488;
+  if (!yy_IDENT(G))  goto l488;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_FuncType, G->begin, G->end, "yy_2_FuncType");
-  goto l483;
-  l484:;	  G->pos= yypos484; G->thunkpos= yythunkpos484;
-  }  if (!yy__(G))  goto l481;
-  if (!yymatchChar(G, '>')) goto l481;
-  goto l482;
-  l481:;	  G->pos= yypos481; G->thunkpos= yythunkpos481;
-  }
-  l482:;	
-  {  int yypos485= G->pos, yythunkpos485= G->thunkpos;  if (!yy__(G))  goto l485;
-  if (!yymatchChar(G, '(')) goto l485;
-
-  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yy__(G))  goto l487;
-  if (!yy_Type(G))  goto l487;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
-
-  l489:;	
-  {  int yypos490= G->pos, yythunkpos490= G->thunkpos;  if (!yymatchChar(G, ',')) goto l490;
-  if (!yy__(G))  goto l490;
-  if (!yy_Type(G))  goto l490;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
-  goto l489;
-  l490:;	  G->pos= yypos490; G->thunkpos= yythunkpos490;
-  }  goto l488;
-  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
-  }
-  l488:;	
-  {  int yypos491= G->pos, yythunkpos491= G->thunkpos;  if (!yymatchString(G, "...")) goto l491;
-  if (!yy__(G))  goto l491;
-  yyDo(G, yy_5_FuncType, G->begin, G->end, "yy_5_FuncType");
-  goto l492;
-  l491:;	  G->pos= yypos491; G->thunkpos= yythunkpos491;
-  }
-  l492:;	  if (!yy__(G))  goto l485;
-  if (!yymatchChar(G, ')')) goto l485;
+  goto l487;
+  l488:;	  G->pos= yypos488; G->thunkpos= yythunkpos488;
+  }  if (!yy__(G))  goto l485;
+  if (!yymatchChar(G, '>')) goto l485;
   goto l486;
   l485:;	  G->pos= yypos485; G->thunkpos= yythunkpos485;
   }
   l486:;	
-  {  int yypos493= G->pos, yythunkpos493= G->thunkpos;  if (!yy__(G))  goto l493;
-  if (!yymatchString(G, "->")) goto l493;
-  if (!yy__(G))  goto l493;
-  if (!yy_Type(G))  goto l493;
+  {  int yypos489= G->pos, yythunkpos489= G->thunkpos;  if (!yy__(G))  goto l489;
+  if (!yymatchChar(G, '(')) goto l489;
+
+  {  int yypos491= G->pos, yythunkpos491= G->thunkpos;  if (!yy__(G))  goto l491;
+  if (!yy_Type(G))  goto l491;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
+
+  l493:;	
+  {  int yypos494= G->pos, yythunkpos494= G->thunkpos;  if (!yymatchChar(G, ',')) goto l494;
+  if (!yy__(G))  goto l494;
+  if (!yy_Type(G))  goto l494;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
+  goto l493;
+  l494:;	  G->pos= yypos494; G->thunkpos= yythunkpos494;
+  }  goto l492;
+  l491:;	  G->pos= yypos491; G->thunkpos= yythunkpos491;
+  }
+  l492:;	
+  {  int yypos495= G->pos, yythunkpos495= G->thunkpos;  if (!yymatchString(G, "...")) goto l495;
+  if (!yy__(G))  goto l495;
+  yyDo(G, yy_5_FuncType, G->begin, G->end, "yy_5_FuncType");
+  goto l496;
+  l495:;	  G->pos= yypos495; G->thunkpos= yythunkpos495;
+  }
+  l496:;	  if (!yy__(G))  goto l489;
+  if (!yymatchChar(G, ')')) goto l489;
+  goto l490;
+  l489:;	  G->pos= yypos489; G->thunkpos= yythunkpos489;
+  }
+  l490:;	
+  {  int yypos497= G->pos, yythunkpos497= G->thunkpos;  if (!yy__(G))  goto l497;
+  if (!yymatchString(G, "->")) goto l497;
+  if (!yy__(G))  goto l497;
+  if (!yy_Type(G))  goto l497;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FuncType, G->begin, G->end, "yy_6_FuncType");
-  goto l494;
-  l493:;	  G->pos= yypos493; G->thunkpos= yythunkpos493;
+  goto l498;
+  l497:;	  G->pos= yypos497; G->thunkpos= yythunkpos497;
   }
-  l494:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
+  l498:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
   yyprintf((stderr, "  ok   FuncType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l480:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
+  l484:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10227,65 +10255,65 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeBase"));
 
-  {  int yypos496= G->pos, yythunkpos496= G->thunkpos;  if (!yy_FuncType(G))  goto l497;
-  goto l496;
-  l497:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l495;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
-
-  {  int yypos498= G->pos, yythunkpos498= G->thunkpos;  if (!yy_CONST_KW(G))  goto l498;
-  if (!yy__(G))  goto l498;
-  goto l499;
-  l498:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;
-  }
-  l499:;	
-  l500:;	
-  {  int yypos501= G->pos, yythunkpos501= G->thunkpos;
-  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l503;
-  yyDo(G, yy_2_TypeBase, G->begin, G->end, "yy_2_TypeBase");
-  if (!yy__(G))  goto l503;
-  goto l502;
-  l503:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "signed")) goto l504;
-  yyDo(G, yy_3_TypeBase, G->begin, G->end, "yy_3_TypeBase");
-  if (!yy__(G))  goto l504;
-  goto l502;
-  l504:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "long")) goto l505;
-
-  {  int yypos506= G->pos, yythunkpos506= G->thunkpos;  if (!yy__(G))  goto l505;
-
-  {  int yypos507= G->pos, yythunkpos507= G->thunkpos;  if (!yymatchString(G, "long")) goto l508;
-  goto l507;
-  l508:;	  G->pos= yypos507; G->thunkpos= yythunkpos507;  if (!yymatchString(G, "double")) goto l509;
-  goto l507;
-  l509:;	  G->pos= yypos507; G->thunkpos= yythunkpos507;  if (!yymatchString(G, "int")) goto l505;
-
-  }
-  l507:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;
-  }  yyDo(G, yy_4_TypeBase, G->begin, G->end, "yy_4_TypeBase");
-  if (!yy__(G))  goto l505;
-  goto l502;
-  l505:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "struct")) goto l510;
-  yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
-  if (!yy__(G))  goto l510;
-  goto l502;
-  l510:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;  if (!yymatchString(G, "union")) goto l501;
-  yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
-  if (!yy__(G))  goto l501;
-
-  }
-  l502:;	  if (!yy__(G))  goto l501;
+  {  int yypos500= G->pos, yythunkpos500= G->thunkpos;  if (!yy_FuncType(G))  goto l501;
   goto l500;
-  l501:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;
-  }  if (!yy_IDENT(G))  goto l495;
+  l501:;	  G->pos= yypos500; G->thunkpos= yythunkpos500;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l499;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
+
+  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yy_CONST_KW(G))  goto l502;
+  if (!yy__(G))  goto l502;
+  goto l503;
+  l502:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;
+  }
+  l503:;	
+  l504:;	
+  {  int yypos505= G->pos, yythunkpos505= G->thunkpos;
+  {  int yypos506= G->pos, yythunkpos506= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l507;
+  yyDo(G, yy_2_TypeBase, G->begin, G->end, "yy_2_TypeBase");
+  if (!yy__(G))  goto l507;
+  goto l506;
+  l507:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;  if (!yymatchString(G, "signed")) goto l508;
+  yyDo(G, yy_3_TypeBase, G->begin, G->end, "yy_3_TypeBase");
+  if (!yy__(G))  goto l508;
+  goto l506;
+  l508:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;  if (!yymatchString(G, "long")) goto l509;
+
+  {  int yypos510= G->pos, yythunkpos510= G->thunkpos;  if (!yy__(G))  goto l509;
+
+  {  int yypos511= G->pos, yythunkpos511= G->thunkpos;  if (!yymatchString(G, "long")) goto l512;
+  goto l511;
+  l512:;	  G->pos= yypos511; G->thunkpos= yythunkpos511;  if (!yymatchString(G, "double")) goto l513;
+  goto l511;
+  l513:;	  G->pos= yypos511; G->thunkpos= yythunkpos511;  if (!yymatchString(G, "int")) goto l509;
+
+  }
+  l511:;	  G->pos= yypos510; G->thunkpos= yythunkpos510;
+  }  yyDo(G, yy_4_TypeBase, G->begin, G->end, "yy_4_TypeBase");
+  if (!yy__(G))  goto l509;
+  goto l506;
+  l509:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;  if (!yymatchString(G, "struct")) goto l514;
+  yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
+  if (!yy__(G))  goto l514;
+  goto l506;
+  l514:;	  G->pos= yypos506; G->thunkpos= yythunkpos506;  if (!yymatchString(G, "union")) goto l505;
+  yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
+  if (!yy__(G))  goto l505;
+
+  }
+  l506:;	  if (!yy__(G))  goto l505;
+  goto l504;
+  l505:;	  G->pos= yypos505; G->thunkpos= yythunkpos505;
+  }  if (!yy_IDENT(G))  goto l499;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_7_TypeBase, G->begin, G->end, "yy_7_TypeBase");
-  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l495;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
+  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l499;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
 
   }
-  l496:;	  yyprintf((stderr, "  ok   TypeBase"));
+  l500:;	  yyprintf((stderr, "  ok   TypeBase"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l495:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
+  l499:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10293,13 +10321,13 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 }
 YY_RULE(int) yy_SET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SET_KW"));
-  if (!yymatchString(G, "set")) goto l511;
+  if (!yymatchString(G, "set")) goto l515;
   yyprintf((stderr, "  ok   SET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l511:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
+  l515:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10307,13 +10335,13 @@ YY_RULE(int) yy_SET_KW(GREG *G)
 }
 YY_RULE(int) yy_GET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "GET_KW"));
-  if (!yymatchString(G, "get")) goto l512;
+  if (!yymatchString(G, "get")) goto l516;
   yyprintf((stderr, "  ok   GET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l512:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
+  l516:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10322,59 +10350,59 @@ YY_RULE(int) yy_GET_KW(GREG *G)
 YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclSetter"));
-  if (!yy_OocDoc(G))  goto l513;
+  if (!yy_OocDoc(G))  goto l517;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclSetter, G->begin, G->end, "yy_1_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l513;
-  if (!yy_SET_KW(G))  goto l513;
-  if (!yy_WS(G))  goto l513;
+  if (!yy_WS(G))  goto l517;
+  if (!yy_SET_KW(G))  goto l517;
+  if (!yy_WS(G))  goto l517;
 
-  {  int yypos514= G->pos, yythunkpos514= G->thunkpos;  if (!yy_COLON(G))  goto l514;
-  if (!yy_WS(G))  goto l514;
-  if (!yy_ExternName(G))  goto l514;
+  {  int yypos518= G->pos, yythunkpos518= G->thunkpos;  if (!yy_COLON(G))  goto l518;
+  if (!yy_WS(G))  goto l518;
+  if (!yy_ExternName(G))  goto l518;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclSetter, G->begin, G->end, "yy_2_PropertyDeclSetter");
-  goto l515;
-  l514:;	  G->pos= yypos514; G->thunkpos= yythunkpos514;
+  goto l519;
+  l518:;	  G->pos= yypos518; G->thunkpos= yythunkpos518;
   }
-  l515:;	
-  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;  if (!yymatchChar(G, '(')) goto l516;
-  if (!yy_WS(G))  goto l516;
+  l519:;	
+  {  int yypos520= G->pos, yythunkpos520= G->thunkpos;  if (!yymatchChar(G, '(')) goto l520;
+  if (!yy_WS(G))  goto l520;
 
-  {  int yypos518= G->pos, yythunkpos518= G->thunkpos;  if (!yy_IDENT(G))  goto l519;
+  {  int yypos522= G->pos, yythunkpos522= G->thunkpos;  if (!yy_IDENT(G))  goto l523;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclSetter, G->begin, G->end, "yy_3_PropertyDeclSetter");
-  goto l518;
-  l519:;	  G->pos= yypos518; G->thunkpos= yythunkpos518;  if (!yy_ASS(G))  goto l516;
-  if (!yy_IDENT(G))  goto l516;
+  goto l522;
+  l523:;	  G->pos= yypos522; G->thunkpos= yythunkpos522;  if (!yy_ASS(G))  goto l520;
+  if (!yy_IDENT(G))  goto l520;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l516;
+  if (!yy__(G))  goto l520;
   yyDo(G, yy_4_PropertyDeclSetter, G->begin, G->end, "yy_4_PropertyDeclSetter");
 
   }
-  l518:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l516; }
-  if (!yy_WS(G))  goto l516;
-  if (!yymatchChar(G, '{')) goto l516;
+  l522:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l520; }
+  if (!yy_WS(G))  goto l520;
+  if (!yymatchChar(G, '{')) goto l520;
 
-  l520:;	
-  {  int yypos521= G->pos, yythunkpos521= G->thunkpos;  if (!yy_WS(G))  goto l521;
-  if (!yy_Stmt(G))  goto l521;
+  l524:;	
+  {  int yypos525= G->pos, yythunkpos525= G->thunkpos;  if (!yy_WS(G))  goto l525;
+  if (!yy_Stmt(G))  goto l525;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_PropertyDeclSetter, G->begin, G->end, "yy_5_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l521;
-  goto l520;
-  l521:;	  G->pos= yypos521; G->thunkpos= yythunkpos521;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l516; }
-  goto l517;
-  l516:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;
+  if (!yy_WS(G))  goto l525;
+  goto l524;
+  l525:;	  G->pos= yypos525; G->thunkpos= yythunkpos525;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l520; }
+  goto l521;
+  l520:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;
   }
-  l517:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
+  l521:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
   yyprintf((stderr, "  ok   PropertyDeclSetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l513:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
+  l517:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10383,43 +10411,43 @@ YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclGetter"));
-  if (!yy_OocDoc(G))  goto l522;
+  if (!yy_OocDoc(G))  goto l526;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclGetter, G->begin, G->end, "yy_1_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l522;
-  if (!yy_GET_KW(G))  goto l522;
-  if (!yy_WS(G))  goto l522;
+  if (!yy_WS(G))  goto l526;
+  if (!yy_GET_KW(G))  goto l526;
+  if (!yy_WS(G))  goto l526;
 
-  {  int yypos523= G->pos, yythunkpos523= G->thunkpos;  if (!yy_COLON(G))  goto l523;
-  if (!yy_WS(G))  goto l523;
-  if (!yy_ExternName(G))  goto l523;
+  {  int yypos527= G->pos, yythunkpos527= G->thunkpos;  if (!yy_COLON(G))  goto l527;
+  if (!yy_WS(G))  goto l527;
+  if (!yy_ExternName(G))  goto l527;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclGetter, G->begin, G->end, "yy_2_PropertyDeclGetter");
-  goto l524;
-  l523:;	  G->pos= yypos523; G->thunkpos= yythunkpos523;
+  goto l528;
+  l527:;	  G->pos= yypos527; G->thunkpos= yythunkpos527;
   }
-  l524:;	
-  {  int yypos525= G->pos, yythunkpos525= G->thunkpos;  if (!yymatchChar(G, '{')) goto l525;
+  l528:;	
+  {  int yypos529= G->pos, yythunkpos529= G->thunkpos;  if (!yymatchChar(G, '{')) goto l529;
 
-  l527:;	
-  {  int yypos528= G->pos, yythunkpos528= G->thunkpos;  if (!yy_WS(G))  goto l528;
-  if (!yy_Stmt(G))  goto l528;
+  l531:;	
+  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;  if (!yy_WS(G))  goto l532;
+  if (!yy_Stmt(G))  goto l532;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclGetter, G->begin, G->end, "yy_3_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l528;
-  goto l527;
-  l528:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l525; }
-  goto l526;
-  l525:;	  G->pos= yypos525; G->thunkpos= yythunkpos525;
+  if (!yy_WS(G))  goto l532;
+  goto l531;
+  l532:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l529; }
+  goto l530;
+  l529:;	  G->pos= yypos529; G->thunkpos= yythunkpos529;
   }
-  l526:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
+  l530:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
   yyprintf((stderr, "  ok   PropertyDeclGetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l522:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
+  l526:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10427,14 +10455,14 @@ YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 }
 YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROPASS_DECL"));
-  if (!yymatchString(G, "::=")) goto l529;
-  if (!yy__(G))  goto l529;
+  if (!yymatchString(G, "::=")) goto l533;
+  if (!yy__(G))  goto l533;
   yyprintf((stderr, "  ok   PROPASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l529:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
+  l533:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10443,15 +10471,15 @@ YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 {  yyprintfv((stderr, "%s\n", "PropertyDeclCore"));
 
-  l531:;	
-  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;
-  {  int yypos533= G->pos, yythunkpos533= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l534;
-  goto l533;
-  l534:;	  G->pos= yypos533; G->thunkpos= yythunkpos533;  if (!yy_PropertyDeclSetter(G))  goto l532;
+  l535:;	
+  {  int yypos536= G->pos, yythunkpos536= G->thunkpos;
+  {  int yypos537= G->pos, yythunkpos537= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l538;
+  goto l537;
+  l538:;	  G->pos= yypos537; G->thunkpos= yythunkpos537;  if (!yy_PropertyDeclSetter(G))  goto l536;
 
   }
-  l533:;	  goto l531;
-  l532:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;
+  l537:;	  goto l535;
+  l536:;	  G->pos= yypos536; G->thunkpos= yythunkpos536;
   }  yyprintf((stderr, "  ok   PropertyDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -10461,37 +10489,37 @@ YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalPropertyDecl"));
-  if (!yy_OocDoc(G))  goto l535;
+  if (!yy_OocDoc(G))  goto l539;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_IDENT(G))  goto l535;
+  if (!yy_IDENT(G))  goto l539;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_ConventionalPropertyDecl, G->begin, G->end, "yy_1_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l535;
-  if (!yy_COLON(G))  goto l535;
-  if (!yy_WS(G))  goto l535;
+  if (!yy_WS(G))  goto l539;
+  if (!yy_COLON(G))  goto l539;
+  if (!yy_WS(G))  goto l539;
 
-  {  int yypos536= G->pos, yythunkpos536= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l536;
+  {  int yypos540= G->pos, yythunkpos540= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l540;
   yyDo(G, yy_2_ConventionalPropertyDecl, G->begin, G->end, "yy_2_ConventionalPropertyDecl");
-  goto l537;
-  l536:;	  G->pos= yypos536; G->thunkpos= yythunkpos536;
+  goto l541;
+  l540:;	  G->pos= yypos540; G->thunkpos= yythunkpos540;
   }
-  l537:;	  if (!yy_WS(G))  goto l535;
-  if (!yy_Type(G))  goto l535;
+  l541:;	  if (!yy_WS(G))  goto l539;
+  if (!yy_Type(G))  goto l539;
   yyDo(G, yy_3_ConventionalPropertyDecl, G->begin, G->end, "yy_3_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l535;
-  if (!yymatchChar(G, '{')) goto l535;
-  if (!yy_WS(G))  goto l535;
-  if (!yy_PropertyDeclCore(G))  goto l535;
-  if (!yy_WS(G))  goto l535;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l535; }
-  if (!yy_WS(G))  goto l535;
+  if (!yy_WS(G))  goto l539;
+  if (!yymatchChar(G, '{')) goto l539;
+  if (!yy_WS(G))  goto l539;
+  if (!yy_PropertyDeclCore(G))  goto l539;
+  if (!yy_WS(G))  goto l539;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l539; }
+  if (!yy_WS(G))  goto l539;
   yyDo(G, yy_4_ConventionalPropertyDecl, G->begin, G->end, "yy_4_ConventionalPropertyDecl");
   yyprintf((stderr, "  ok   ConventionalPropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l535:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
+  l539:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10500,35 +10528,35 @@ YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 YY_RULE(int) yy_PropertyDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l538;
+  if (!yy_OocDoc(G))  goto l542;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_IDENT(G))  goto l538;
+  if (!yy_IDENT(G))  goto l542;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclFromExpr, G->begin, G->end, "yy_1_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l538;
-  if (!yy_PROPASS_DECL(G))  goto l538;
+  if (!yy__(G))  goto l542;
+  if (!yy_PROPASS_DECL(G))  goto l542;
 
-  l539:;	
-  {  int yypos540= G->pos, yythunkpos540= G->thunkpos;  if (!yy__(G))  goto l540;
-  if (!yy_STATIC_KW(G))  goto l540;
+  l543:;	
+  {  int yypos544= G->pos, yythunkpos544= G->thunkpos;  if (!yy__(G))  goto l544;
+  if (!yy_STATIC_KW(G))  goto l544;
   yyDo(G, yy_2_PropertyDeclFromExpr, G->begin, G->end, "yy_2_PropertyDeclFromExpr");
 
-  {  int yypos541= G->pos, yythunkpos541= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l540;
-  G->pos= yypos541; G->thunkpos= yythunkpos541;
-  }  goto l539;
-  l540:;	  G->pos= yypos540; G->thunkpos= yythunkpos540;
-  }  if (!yy__(G))  goto l538;
-  if (!yy_Expr(G))  goto l538;
+  {  int yypos545= G->pos, yythunkpos545= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l544;
+  G->pos= yypos545; G->thunkpos= yythunkpos545;
+  }  goto l543;
+  l544:;	  G->pos= yypos544; G->thunkpos= yythunkpos544;
+  }  if (!yy__(G))  goto l542;
+  if (!yy_Expr(G))  goto l542;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclFromExpr, G->begin, G->end, "yy_3_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l538;
+  if (!yy__(G))  goto l542;
   yyDo(G, yy_4_PropertyDeclFromExpr, G->begin, G->end, "yy_4_PropertyDeclFromExpr");
   yyprintf((stderr, "  ok   PropertyDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l538:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
+  l542:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10538,88 +10566,88 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalVarDecl"));
   yyDo(G, yy_1_ConventionalVarDecl, G->begin, G->end, "yy_1_ConventionalVarDecl");
-  if (!yy_OocDoc(G))  goto l542;
-  yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l542;
-  yyDo(G, yySet, -4, 0, "yySet");
-  yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end, "yy_2_ConventionalVarDecl");
-
-  {  int yypos543= G->pos, yythunkpos543= G->thunkpos;  if (!yy__(G))  goto l543;
-  if (!yy_ASS(G))  goto l543;
-  if (!yy__(G))  goto l543;
-  if (!yy_Expr(G))  goto l543;
-  yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end, "yy_3_ConventionalVarDecl");
-  goto l544;
-  l543:;	  G->pos= yypos543; G->thunkpos= yythunkpos543;
-  }
-  l544:;	
-  l545:;	
-  {  int yypos546= G->pos, yythunkpos546= G->thunkpos;  if (!yy__(G))  goto l546;
-  if (!yymatchChar(G, ',')) goto l546;
   if (!yy_OocDoc(G))  goto l546;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_WS(G))  goto l546;
   if (!yy_IDENT(G))  goto l546;
-  yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end, "yy_4_ConventionalVarDecl");
+  yyDo(G, yySet, -4, 0, "yySet");
+  yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end, "yy_2_ConventionalVarDecl");
 
   {  int yypos547= G->pos, yythunkpos547= G->thunkpos;  if (!yy__(G))  goto l547;
   if (!yy_ASS(G))  goto l547;
   if (!yy__(G))  goto l547;
   if (!yy_Expr(G))  goto l547;
-  yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end, "yy_5_ConventionalVarDecl");
+  yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end, "yy_3_ConventionalVarDecl");
   goto l548;
   l547:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;
   }
-  l548:;	  if (!yy__(G))  goto l546;
-  goto l545;
-  l546:;	  G->pos= yypos546; G->thunkpos= yythunkpos546;
-  }  if (!yy_WS(G))  goto l542;
-  if (!yy_COLON(G))  goto l542;
-  if (!yy_WS(G))  goto l542;
-
+  l548:;	
   l549:;	
   {  int yypos550= G->pos, yythunkpos550= G->thunkpos;  if (!yy__(G))  goto l550;
+  if (!yymatchChar(G, ',')) goto l550;
+  if (!yy_OocDoc(G))  goto l550;
+  yyDo(G, yySet, -5, 0, "yySet");
+  if (!yy_WS(G))  goto l550;
+  if (!yy_IDENT(G))  goto l550;
+  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end, "yy_4_ConventionalVarDecl");
 
-  {  int yypos551= G->pos, yythunkpos551= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l552;
+  {  int yypos551= G->pos, yythunkpos551= G->thunkpos;  if (!yy__(G))  goto l551;
+  if (!yy_ASS(G))  goto l551;
+  if (!yy__(G))  goto l551;
+  if (!yy_Expr(G))  goto l551;
+  yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end, "yy_5_ConventionalVarDecl");
+  goto l552;
+  l551:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;
+  }
+  l552:;	  if (!yy__(G))  goto l550;
+  goto l549;
+  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
+  }  if (!yy_WS(G))  goto l546;
+  if (!yy_COLON(G))  goto l546;
+  if (!yy_WS(G))  goto l546;
+
+  l553:;	
+  {  int yypos554= G->pos, yythunkpos554= G->thunkpos;  if (!yy__(G))  goto l554;
+
+  {  int yypos555= G->pos, yythunkpos555= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l556;
   yyDo(G, yy_6_ConventionalVarDecl, G->begin, G->end, "yy_6_ConventionalVarDecl");
-  goto l551;
-  l552:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_CONST_KW(G))  goto l553;
+  goto l555;
+  l556:;	  G->pos= yypos555; G->thunkpos= yythunkpos555;  if (!yy_CONST_KW(G))  goto l557;
   yyDo(G, yy_7_ConventionalVarDecl, G->begin, G->end, "yy_7_ConventionalVarDecl");
-  goto l551;
-  l553:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_PROTO_KW(G))  goto l554;
+  goto l555;
+  l557:;	  G->pos= yypos555; G->thunkpos= yythunkpos555;  if (!yy_PROTO_KW(G))  goto l558;
   yyDo(G, yy_8_ConventionalVarDecl, G->begin, G->end, "yy_8_ConventionalVarDecl");
-  goto l551;
-  l554:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_ExternName(G))  goto l555;
+  goto l555;
+  l558:;	  G->pos= yypos555; G->thunkpos= yythunkpos555;  if (!yy_ExternName(G))  goto l559;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_9_ConventionalVarDecl, G->begin, G->end, "yy_9_ConventionalVarDecl");
-  goto l551;
-  l555:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_UnmangledName(G))  goto l550;
+  goto l555;
+  l559:;	  G->pos= yypos555; G->thunkpos= yythunkpos555;  if (!yy_UnmangledName(G))  goto l554;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ConventionalVarDecl, G->begin, G->end, "yy_10_ConventionalVarDecl");
 
   }
-  l551:;	  goto l549;
-  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
-  }  if (!yy_WS(G))  goto l542;
-  if (!yy_Type(G))  goto l542;
+  l555:;	  goto l553;
+  l554:;	  G->pos= yypos554; G->thunkpos= yythunkpos554;
+  }  if (!yy_WS(G))  goto l546;
+  if (!yy_Type(G))  goto l546;
   yyDo(G, yy_11_ConventionalVarDecl, G->begin, G->end, "yy_11_ConventionalVarDecl");
 
-  {  int yypos556= G->pos, yythunkpos556= G->thunkpos;  if (!yy__(G))  goto l556;
-  if (!yy_ASS(G))  goto l556;
-  if (!yy__(G))  goto l556;
-  if (!yy_Expr(G))  goto l556;
+  {  int yypos560= G->pos, yythunkpos560= G->thunkpos;  if (!yy__(G))  goto l560;
+  if (!yy_ASS(G))  goto l560;
+  if (!yy__(G))  goto l560;
+  if (!yy_Expr(G))  goto l560;
   yyDo(G, yy_12_ConventionalVarDecl, G->begin, G->end, "yy_12_ConventionalVarDecl");
-  goto l557;
-  l556:;	  G->pos= yypos556; G->thunkpos= yythunkpos556;
+  goto l561;
+  l560:;	  G->pos= yypos560; G->thunkpos= yythunkpos560;
   }
-  l557:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
+  l561:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
   yyprintf((stderr, "  ok   ConventionalVarDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l542:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
+  l546:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10627,13 +10655,13 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 }
 YY_RULE(int) yy_CONST_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONST_KW"));
-  if (!yymatchString(G, "const")) goto l558;
+  if (!yymatchString(G, "const")) goto l562;
   yyprintf((stderr, "  ok   CONST_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l558:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
+  l562:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10641,14 +10669,14 @@ YY_RULE(int) yy_CONST_KW(GREG *G)
 }
 YY_RULE(int) yy_ASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DECL"));
-  if (!yymatchString(G, ":=")) goto l559;
-  if (!yy__(G))  goto l559;
+  if (!yymatchString(G, ":=")) goto l563;
+  if (!yy__(G))  goto l563;
   yyprintf((stderr, "  ok   ASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l559:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
+  l563:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10657,41 +10685,41 @@ YY_RULE(int) yy_ASS_DECL(GREG *G)
 YY_RULE(int) yy_Tuple(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Tuple"));
-  if (!yymatchChar(G, '(')) goto l560;
+  if (!yymatchChar(G, '(')) goto l564;
   yyDo(G, yy_1_Tuple, G->begin, G->end, "yy_1_Tuple");
-  if (!yy_WS(G))  goto l560;
+  if (!yy_WS(G))  goto l564;
   yyDo(G, yy_2_Tuple, G->begin, G->end, "yy_2_Tuple");
 
-  {  int yypos561= G->pos, yythunkpos561= G->thunkpos;  if (!yy_Expr(G))  goto l561;
+  {  int yypos565= G->pos, yythunkpos565= G->thunkpos;  if (!yy_Expr(G))  goto l565;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Tuple, G->begin, G->end, "yy_3_Tuple");
 
-  l563:;	
-  {  int yypos564= G->pos, yythunkpos564= G->thunkpos;
-  {  int yypos565= G->pos, yythunkpos565= G->thunkpos;  if (!yy_WS(G))  goto l566;
-  if (!yymatchChar(G, ',')) goto l566;
-  goto l565;
-  l566:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_EOL(G))  goto l564;
+  l567:;	
+  {  int yypos568= G->pos, yythunkpos568= G->thunkpos;
+  {  int yypos569= G->pos, yythunkpos569= G->thunkpos;  if (!yy_WS(G))  goto l570;
+  if (!yymatchChar(G, ',')) goto l570;
+  goto l569;
+  l570:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;  if (!yy_EOL(G))  goto l568;
 
   }
-  l565:;	  if (!yy_WS(G))  goto l564;
-  if (!yy_Expr(G))  goto l564;
+  l569:;	  if (!yy_WS(G))  goto l568;
+  if (!yy_Expr(G))  goto l568;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Tuple, G->begin, G->end, "yy_4_Tuple");
-  goto l563;
-  l564:;	  G->pos= yypos564; G->thunkpos= yythunkpos564;
-  }  goto l562;
-  l561:;	  G->pos= yypos561; G->thunkpos= yythunkpos561;
+  goto l567;
+  l568:;	  G->pos= yypos568; G->thunkpos= yythunkpos568;
+  }  goto l566;
+  l565:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;
   }
-  l562:;	  if (!yy_WS(G))  goto l560;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l560; }
+  l566:;	  if (!yy_WS(G))  goto l564;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l564; }
   yyDo(G, yy_5_Tuple, G->begin, G->end, "yy_5_Tuple");
   yyprintf((stderr, "  ok   Tuple"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l560:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
+  l564:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10700,51 +10728,51 @@ YY_RULE(int) yy_Tuple(GREG *G)
 YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VarDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l567;
+  if (!yy_OocDoc(G))  goto l571;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos568= G->pos, yythunkpos568= G->thunkpos;  if (!yy_IDENT(G))  goto l569;
+  {  int yypos572= G->pos, yythunkpos572= G->thunkpos;  if (!yy_IDENT(G))  goto l573;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_VarDeclFromExpr, G->begin, G->end, "yy_1_VarDeclFromExpr");
-  goto l568;
-  l569:;	  G->pos= yypos568; G->thunkpos= yythunkpos568;  if (!yy_Tuple(G))  goto l567;
+  goto l572;
+  l573:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;  if (!yy_Tuple(G))  goto l571;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_VarDeclFromExpr, G->begin, G->end, "yy_2_VarDeclFromExpr");
 
   }
-  l568:;	  if (!yy__(G))  goto l567;
-  if (!yy_ASS_DECL(G))  goto l567;
+  l572:;	  if (!yy__(G))  goto l571;
+  if (!yy_ASS_DECL(G))  goto l571;
 
-  l570:;	
-  {  int yypos571= G->pos, yythunkpos571= G->thunkpos;  if (!yy__(G))  goto l571;
+  l574:;	
+  {  int yypos575= G->pos, yythunkpos575= G->thunkpos;  if (!yy__(G))  goto l575;
 
-  {  int yypos572= G->pos, yythunkpos572= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l573;
+  {  int yypos576= G->pos, yythunkpos576= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l577;
   yyDo(G, yy_3_VarDeclFromExpr, G->begin, G->end, "yy_3_VarDeclFromExpr");
-  goto l572;
-  l573:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;  if (!yy_CONST_KW(G))  goto l574;
+  goto l576;
+  l577:;	  G->pos= yypos576; G->thunkpos= yythunkpos576;  if (!yy_CONST_KW(G))  goto l578;
   yyDo(G, yy_4_VarDeclFromExpr, G->begin, G->end, "yy_4_VarDeclFromExpr");
-  goto l572;
-  l574:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;  if (!yy_PROTO_KW(G))  goto l571;
+  goto l576;
+  l578:;	  G->pos= yypos576; G->thunkpos= yythunkpos576;  if (!yy_PROTO_KW(G))  goto l575;
   yyDo(G, yy_5_VarDeclFromExpr, G->begin, G->end, "yy_5_VarDeclFromExpr");
 
   }
-  l572:;	
-  {  int yypos575= G->pos, yythunkpos575= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l571;
-  G->pos= yypos575; G->thunkpos= yythunkpos575;
-  }  goto l570;
-  l571:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;
-  }  if (!yy__(G))  goto l567;
-  if (!yy_Expr(G))  goto l567;
+  l576:;	
+  {  int yypos579= G->pos, yythunkpos579= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l575;
+  G->pos= yypos579; G->thunkpos= yythunkpos579;
+  }  goto l574;
+  l575:;	  G->pos= yypos575; G->thunkpos= yythunkpos575;
+  }  if (!yy__(G))  goto l571;
+  if (!yy_Expr(G))  goto l571;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end, "yy_6_VarDeclFromExpr");
-  if (!yy__(G))  goto l567;
+  if (!yy__(G))  goto l571;
   yyDo(G, yy_7_VarDeclFromExpr, G->begin, G->end, "yy_7_VarDeclFromExpr");
   yyprintf((stderr, "  ok   VarDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l567:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
+  l571:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10752,13 +10780,13 @@ YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 }
 YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UNMANGLED_KW"));
-  if (!yymatchString(G, "unmangled")) goto l576;
+  if (!yymatchString(G, "unmangled")) goto l580;
   yyprintf((stderr, "  ok   UNMANGLED_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l576:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
+  l580:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10766,13 +10794,13 @@ YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTERN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTERN_KW"));
-  if (!yymatchString(G, "extern")) goto l577;
+  if (!yymatchString(G, "extern")) goto l581;
   yyprintf((stderr, "  ok   EXTERN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l577:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
+  l581:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10780,13 +10808,13 @@ YY_RULE(int) yy_EXTERN_KW(GREG *G)
 }
 YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTERFACE_KW"));
-  if (!yymatchString(G, "interface")) goto l578;
+  if (!yymatchString(G, "interface")) goto l582;
   yyprintf((stderr, "  ok   INTERFACE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l578:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
+  l582:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10794,13 +10822,13 @@ YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 }
 YY_RULE(int) yy_COVER_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COVER_KW"));
-  if (!yymatchString(G, "cover")) goto l579;
+  if (!yymatchString(G, "cover")) goto l583;
   yyprintf((stderr, "  ok   COVER_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l579:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
+  l583:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10808,18 +10836,18 @@ YY_RULE(int) yy_COVER_KW(GREG *G)
 }
 YY_RULE(int) yy_PLUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PLUS"));
-  if (!yymatchChar(G, '+')) goto l580;
+  if (!yymatchChar(G, '+')) goto l584;
 
-  {  int yypos581= G->pos, yythunkpos581= G->thunkpos;  if (!yymatchChar(G, '=')) goto l581;
-  goto l580;
-  l581:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;
-  }  if (!yy__(G))  goto l580;
+  {  int yypos585= G->pos, yythunkpos585= G->thunkpos;  if (!yymatchChar(G, '=')) goto l585;
+  goto l584;
+  l585:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;
+  }  if (!yy__(G))  goto l584;
   yyprintf((stderr, "  ok   PLUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l580:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
+  l584:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10827,18 +10855,18 @@ YY_RULE(int) yy_PLUS(GREG *G)
 }
 YY_RULE(int) yy_STAR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STAR"));
-  if (!yymatchChar(G, '*')) goto l582;
+  if (!yymatchChar(G, '*')) goto l586;
 
-  {  int yypos583= G->pos, yythunkpos583= G->thunkpos;  if (!yymatchChar(G, '=')) goto l583;
-  goto l582;
-  l583:;	  G->pos= yypos583; G->thunkpos= yythunkpos583;
-  }  if (!yy__(G))  goto l582;
+  {  int yypos587= G->pos, yythunkpos587= G->thunkpos;  if (!yymatchChar(G, '=')) goto l587;
+  goto l586;
+  l587:;	  G->pos= yypos587; G->thunkpos= yythunkpos587;
+  }  if (!yy__(G))  goto l586;
   yyprintf((stderr, "  ok   STAR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l582:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
+  l586:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10848,38 +10876,38 @@ YY_RULE(int) yy_Expr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Expr"));
 
-  {  int yypos585= G->pos, yythunkpos585= G->thunkpos;  if (!yy_VariableDecl(G))  goto l586;
+  {  int yypos589= G->pos, yythunkpos589= G->thunkpos;  if (!yy_VariableDecl(G))  goto l590;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l586;
-  goto l585;
-  l586:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_DoubleArrow(G))  goto l587;
+  if (!yy__(G))  goto l590;
+  goto l589;
+  l590:;	  G->pos= yypos589; G->thunkpos= yythunkpos589;  if (!yy_DoubleArrow(G))  goto l591;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l587;
-  goto l585;
-  l587:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_BinaryOperation(G))  goto l588;
+  if (!yy__(G))  goto l591;
+  goto l589;
+  l591:;	  G->pos= yypos589; G->thunkpos= yythunkpos589;  if (!yy_BinaryOperation(G))  goto l592;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l588;
+  if (!yy__(G))  goto l592;
 
-  l589:;	
-  {  int yypos590= G->pos, yythunkpos590= G->thunkpos;  if (!yy__(G))  goto l590;
-  if (!yymatchChar(G, '.')) goto l590;
+  l593:;	
+  {  int yypos594= G->pos, yythunkpos594= G->thunkpos;  if (!yy__(G))  goto l594;
+  if (!yymatchChar(G, '.')) goto l594;
   yyDo(G, yy_1_Expr, G->begin, G->end, "yy_1_Expr");
-  if (!yy_WS(G))  goto l590;
-  if (!yy_FunctionCall(G))  goto l590;
+  if (!yy_WS(G))  goto l594;
+  if (!yy_FunctionCall(G))  goto l594;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Expr, G->begin, G->end, "yy_2_Expr");
-  goto l589;
-  l590:;	  G->pos= yypos590; G->thunkpos= yythunkpos590;
-  }  goto l585;
-  l588:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_AnonymousFunctionDecl(G))  goto l584;
+  goto l593;
+  l594:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;
+  }  goto l589;
+  l592:;	  G->pos= yypos589; G->thunkpos= yythunkpos589;  if (!yy_AnonymousFunctionDecl(G))  goto l588;
 
   }
-  l585:;	  yyprintf((stderr, "  ok   Expr"));
+  l589:;	  yyprintf((stderr, "  ok   Expr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l584:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
+  l588:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10888,36 +10916,36 @@ YY_RULE(int) yy_Expr(GREG *G)
 YY_RULE(int) yy_EnumElement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumElement"));
-  if (!yy_OocDoc(G))  goto l591;
+  if (!yy_OocDoc(G))  goto l595;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l591;
+  if (!yy_IDENT(G))  goto l595;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_EnumElement, G->begin, G->end, "yy_1_EnumElement");
-  if (!yy__(G))  goto l591;
+  if (!yy__(G))  goto l595;
 
-  {  int yypos592= G->pos, yythunkpos592= G->thunkpos;
-  {  int yypos594= G->pos, yythunkpos594= G->thunkpos;  if (!yy_ASS(G))  goto l595;
-  if (!yy_Expr(G))  goto l595;
+  {  int yypos596= G->pos, yythunkpos596= G->thunkpos;
+  {  int yypos598= G->pos, yythunkpos598= G->thunkpos;  if (!yy_ASS(G))  goto l599;
+  if (!yy_Expr(G))  goto l599;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_EnumElement, G->begin, G->end, "yy_2_EnumElement");
-  goto l594;
-  l595:;	  G->pos= yypos594; G->thunkpos= yythunkpos594;  if (!yy_COLON(G))  goto l592;
-  if (!yy__(G))  goto l592;
-  if (!yy_ExternName(G))  goto l592;
+  goto l598;
+  l599:;	  G->pos= yypos598; G->thunkpos= yythunkpos598;  if (!yy_COLON(G))  goto l596;
+  if (!yy__(G))  goto l596;
+  if (!yy_ExternName(G))  goto l596;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumElement, G->begin, G->end, "yy_3_EnumElement");
 
   }
-  l594:;	  goto l593;
-  l592:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;
+  l598:;	  goto l597;
+  l596:;	  G->pos= yypos596; G->thunkpos= yythunkpos596;
   }
-  l593:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
+  l597:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
   yyprintf((stderr, "  ok   EnumElement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l591:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
+  l595:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10927,28 +10955,28 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IntLiteral"));
 
-  {  int yypos597= G->pos, yythunkpos597= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l598;
+  {  int yypos601= G->pos, yythunkpos601= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l602;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l598;
+  if (!yy__(G))  goto l602;
   yyDo(G, yy_1_IntLiteral, G->begin, G->end, "yy_1_IntLiteral");
-  goto l597;
-  l598:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  if (!yy_HEX_LIT(G))  goto l599;
+  goto l601;
+  l602:;	  G->pos= yypos601; G->thunkpos= yythunkpos601;  if (!yy_HEX_LIT(G))  goto l603;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l599;
+  if (!yy__(G))  goto l603;
   yyDo(G, yy_2_IntLiteral, G->begin, G->end, "yy_2_IntLiteral");
-  goto l597;
-  l599:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  if (!yy_DEC_LIT(G))  goto l596;
+  goto l601;
+  l603:;	  G->pos= yypos601; G->thunkpos= yythunkpos601;  if (!yy_DEC_LIT(G))  goto l600;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l596;
+  if (!yy__(G))  goto l600;
   yyDo(G, yy_3_IntLiteral, G->begin, G->end, "yy_3_IntLiteral");
 
   }
-  l597:;	  yyprintf((stderr, "  ok   IntLiteral"));
+  l601:;	  yyprintf((stderr, "  ok   IntLiteral"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l596:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
+  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10957,19 +10985,19 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EnumIncrementOper"));
 
-  {  int yypos601= G->pos, yythunkpos601= G->thunkpos;  if (!yy_STAR(G))  goto l602;
+  {  int yypos605= G->pos, yythunkpos605= G->thunkpos;  if (!yy_STAR(G))  goto l606;
   yyDo(G, yy_1_EnumIncrementOper, G->begin, G->end, "yy_1_EnumIncrementOper");
-  goto l601;
-  l602:;	  G->pos= yypos601; G->thunkpos= yythunkpos601;  if (!yy_PLUS(G))  goto l600;
+  goto l605;
+  l606:;	  G->pos= yypos605; G->thunkpos= yythunkpos605;  if (!yy_PLUS(G))  goto l604;
   yyDo(G, yy_2_EnumIncrementOper, G->begin, G->end, "yy_2_EnumIncrementOper");
 
   }
-  l601:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
+  l605:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
+  l604:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10977,13 +11005,13 @@ YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 }
 YY_RULE(int) yy_FROM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FROM_KW"));
-  if (!yymatchString(G, "from")) goto l603;
+  if (!yymatchString(G, "from")) goto l607;
   yyprintf((stderr, "  ok   FROM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l603:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
+  l607:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10991,13 +11019,13 @@ YY_RULE(int) yy_FROM_KW(GREG *G)
 }
 YY_RULE(int) yy_ENUM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ENUM_KW"));
-  if (!yymatchString(G, "enum")) goto l604;
+  if (!yymatchString(G, "enum")) goto l608;
   yyprintf((stderr, "  ok   ENUM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l604:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
+  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11005,13 +11033,13 @@ YY_RULE(int) yy_ENUM_KW(GREG *G)
 }
 YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPLEMENTS_KW"));
-  if (!yymatchString(G, "implements")) goto l605;
+  if (!yymatchString(G, "implements")) goto l609;
   yyprintf((stderr, "  ok   IMPLEMENTS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l605:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
+  l609:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11019,13 +11047,13 @@ YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTENDS_KW"));
-  if (!yymatchString(G, "extends")) goto l606;
+  if (!yymatchString(G, "extends")) goto l610;
   yyprintf((stderr, "  ok   EXTENDS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l606:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
+  l610:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11033,13 +11061,13 @@ YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 }
 YY_RULE(int) yy_CLASS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLASS_KW"));
-  if (!yymatchString(G, "class")) goto l607;
+  if (!yymatchString(G, "class")) goto l611;
   yyprintf((stderr, "  ok   CLASS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l607:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
+  l611:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11048,17 +11076,17 @@ YY_RULE(int) yy_CLASS_KW(GREG *G)
 YY_RULE(int) yy_ASS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS"));
 
-  {  int yypos609= G->pos, yythunkpos609= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l609;
-  goto l608;
-  l609:;	  G->pos= yypos609; G->thunkpos= yythunkpos609;
-  }  if (!yymatchChar(G, '=')) goto l608;
-  if (!yy__(G))  goto l608;
+  {  int yypos613= G->pos, yythunkpos613= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l613;
+  goto l612;
+  l613:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;
+  }  if (!yymatchChar(G, '=')) goto l612;
+  if (!yy__(G))  goto l612;
   yyprintf((stderr, "  ok   ASS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
+  l612:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11067,16 +11095,16 @@ YY_RULE(int) yy_ASS(GREG *G)
 YY_RULE(int) yy_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOT"));
 
-  {  int yypos611= G->pos, yythunkpos611= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l611;
-  goto l610;
-  l611:;	  G->pos= yypos611; G->thunkpos= yythunkpos611;
-  }  if (!yymatchChar(G, '.')) goto l610;
+  {  int yypos615= G->pos, yythunkpos615= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l615;
+  goto l614;
+  l615:;	  G->pos= yypos615; G->thunkpos= yythunkpos615;
+  }  if (!yymatchChar(G, '.')) goto l614;
   yyprintf((stderr, "  ok   DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l610:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
+  l614:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11086,137 +11114,137 @@ YY_RULE(int) yy_Type(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Type"));
 
-  {  int yypos613= G->pos, yythunkpos613= G->thunkpos;  if (!yy_TypeList(G))  goto l614;
+  {  int yypos617= G->pos, yythunkpos617= G->thunkpos;  if (!yy_TypeList(G))  goto l618;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_1_Type, G->begin, G->end, "yy_1_Type");
-  goto l613;
-  l614:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;  if (!yy_TypeBase(G))  goto l615;
+  goto l617;
+  l618:;	  G->pos= yypos617; G->thunkpos= yythunkpos617;  if (!yy_TypeBase(G))  goto l619;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos616= G->pos, yythunkpos616= G->thunkpos;  if (!yy__(G))  goto l616;
-  if (!yymatchChar(G, '<')) goto l616;
-  if (!yy__(G))  goto l616;
-  if (!yy_Type(G))  goto l616;
+  {  int yypos620= G->pos, yythunkpos620= G->thunkpos;  if (!yy__(G))  goto l620;
+  if (!yymatchChar(G, '<')) goto l620;
+  if (!yy__(G))  goto l620;
+  if (!yy_Type(G))  goto l620;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_Type, G->begin, G->end, "yy_2_Type");
 
-  l618:;	
-  {  int yypos619= G->pos, yythunkpos619= G->thunkpos;  if (!yy__(G))  goto l619;
-  if (!yymatchChar(G, ',')) goto l619;
-  if (!yy__(G))  goto l619;
-  if (!yy_Type(G))  goto l619;
+  l622:;	
+  {  int yypos623= G->pos, yythunkpos623= G->thunkpos;  if (!yy__(G))  goto l623;
+  if (!yymatchChar(G, ',')) goto l623;
+  if (!yy__(G))  goto l623;
+  if (!yy_Type(G))  goto l623;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_3_Type, G->begin, G->end, "yy_3_Type");
-  goto l618;
-  l619:;	  G->pos= yypos619; G->thunkpos= yythunkpos619;
-  }  if (!yy__(G))  goto l616;
-  if (!yymatchChar(G, '>')) goto l616;
-  goto l617;
-  l616:;	  G->pos= yypos616; G->thunkpos= yythunkpos616;
+  goto l622;
+  l623:;	  G->pos= yypos623; G->thunkpos= yythunkpos623;
+  }  if (!yy__(G))  goto l620;
+  if (!yymatchChar(G, '>')) goto l620;
+  goto l621;
+  l620:;	  G->pos= yypos620; G->thunkpos= yythunkpos620;
   }
-  l617:;	  if (!yy__(G))  goto l615;
+  l621:;	  if (!yy__(G))  goto l619;
 
-  l620:;	
-  {  int yypos621= G->pos, yythunkpos621= G->thunkpos;
-  {  int yypos622= G->pos, yythunkpos622= G->thunkpos;  if (!yy_STAR(G))  goto l623;
+  l624:;	
+  {  int yypos625= G->pos, yythunkpos625= G->thunkpos;
+  {  int yypos626= G->pos, yythunkpos626= G->thunkpos;  if (!yy_STAR(G))  goto l627;
   yyDo(G, yy_4_Type, G->begin, G->end, "yy_4_Type");
-  goto l622;
-  l623:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;  if (!yymatchChar(G, '@')) goto l624;
-  yyDo(G, yy_5_Type, G->begin, G->end, "yy_5_Type");
-  goto l622;
-  l624:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;  if (!yymatchChar(G, '[')) goto l621;
-  if (!yy_WS(G))  goto l621;
-  yyDo(G, yy_6_Type, G->begin, G->end, "yy_6_Type");
-  if (!yy__(G))  goto l621;
-
-  {  int yypos625= G->pos, yythunkpos625= G->thunkpos;  if (!yy_Expr(G))  goto l625;
-  yyDo(G, yySet, -3, 0, "yySet");
   goto l626;
-  l625:;	  G->pos= yypos625; G->thunkpos= yythunkpos625;
+  l627:;	  G->pos= yypos626; G->thunkpos= yythunkpos626;  if (!yymatchChar(G, '@')) goto l628;
+  yyDo(G, yy_5_Type, G->begin, G->end, "yy_5_Type");
+  goto l626;
+  l628:;	  G->pos= yypos626; G->thunkpos= yythunkpos626;  if (!yymatchChar(G, '[')) goto l625;
+  if (!yy_WS(G))  goto l625;
+  yyDo(G, yy_6_Type, G->begin, G->end, "yy_6_Type");
+  if (!yy__(G))  goto l625;
+
+  {  int yypos629= G->pos, yythunkpos629= G->thunkpos;  if (!yy_Expr(G))  goto l629;
+  yyDo(G, yySet, -3, 0, "yySet");
+  goto l630;
+  l629:;	  G->pos= yypos629; G->thunkpos= yythunkpos629;
   }
-  l626:;	  if (!yymatchChar(G, ']')) goto l621;
+  l630:;	  if (!yymatchChar(G, ']')) goto l625;
   yyDo(G, yy_7_Type, G->begin, G->end, "yy_7_Type");
 
   }
-  l622:;	  goto l620;
-  l621:;	  G->pos= yypos621; G->thunkpos= yythunkpos621;
-  }  if (!yy__(G))  goto l615;
+  l626:;	  goto l624;
+  l625:;	  G->pos= yypos625; G->thunkpos= yythunkpos625;
+  }  if (!yy__(G))  goto l619;
   yyDo(G, yy_8_Type, G->begin, G->end, "yy_8_Type");
-  goto l613;
-  l615:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;  if (!yymatchChar(G, '(')) goto l612;
-  if (!yy_Old(G))  goto l612;
+  goto l617;
+  l619:;	  G->pos= yypos617; G->thunkpos= yythunkpos617;  if (!yymatchChar(G, '(')) goto l616;
+  if (!yy_Old(G))  goto l616;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l612;
-  if (!yy_IDENT(G))  goto l612;
+  if (!yy__(G))  goto l616;
+  if (!yy_IDENT(G))  goto l616;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_Type, G->begin, G->end, "yy_9_Type");
-  if (!yy__(G))  goto l612;
-  if (!yy_TypeBase(G))  goto l612;
+  if (!yy__(G))  goto l616;
+  if (!yy_TypeBase(G))  goto l616;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos627= G->pos, yythunkpos627= G->thunkpos;  if (!yy_FuncType(G))  goto l627;
-  goto l612;
-  l627:;	  G->pos= yypos627; G->thunkpos= yythunkpos627;
+  {  int yypos631= G->pos, yythunkpos631= G->thunkpos;  if (!yy_FuncType(G))  goto l631;
+  goto l616;
+  l631:;	  G->pos= yypos631; G->thunkpos= yythunkpos631;
   }  yyDo(G, yy_10_Type, G->begin, G->end, "yy_10_Type");
 
-  {  int yypos628= G->pos, yythunkpos628= G->thunkpos;  if (!yy__(G))  goto l628;
-  if (!yymatchChar(G, '<')) goto l628;
-  if (!yy__(G))  goto l628;
-  if (!yy_Type(G))  goto l628;
+  {  int yypos632= G->pos, yythunkpos632= G->thunkpos;  if (!yy__(G))  goto l632;
+  if (!yymatchChar(G, '<')) goto l632;
+  if (!yy__(G))  goto l632;
+  if (!yy_Type(G))  goto l632;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_11_Type, G->begin, G->end, "yy_11_Type");
 
-  l630:;	
-  {  int yypos631= G->pos, yythunkpos631= G->thunkpos;  if (!yy__(G))  goto l631;
-  if (!yymatchChar(G, ',')) goto l631;
-  if (!yy__(G))  goto l631;
-  if (!yy_Type(G))  goto l631;
+  l634:;	
+  {  int yypos635= G->pos, yythunkpos635= G->thunkpos;  if (!yy__(G))  goto l635;
+  if (!yymatchChar(G, ',')) goto l635;
+  if (!yy__(G))  goto l635;
+  if (!yy_Type(G))  goto l635;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_12_Type, G->begin, G->end, "yy_12_Type");
-  goto l630;
-  l631:;	  G->pos= yypos631; G->thunkpos= yythunkpos631;
-  }  if (!yy__(G))  goto l628;
-  if (!yymatchChar(G, '>')) goto l628;
-  goto l629;
-  l628:;	  G->pos= yypos628; G->thunkpos= yythunkpos628;
+  goto l634;
+  l635:;	  G->pos= yypos635; G->thunkpos= yythunkpos635;
+  }  if (!yy__(G))  goto l632;
+  if (!yymatchChar(G, '>')) goto l632;
+  goto l633;
+  l632:;	  G->pos= yypos632; G->thunkpos= yythunkpos632;
   }
-  l629:;	  if (!yy__(G))  goto l612;
+  l633:;	  if (!yy__(G))  goto l616;
 
-  l632:;	
-  {  int yypos633= G->pos, yythunkpos633= G->thunkpos;
-  {  int yypos634= G->pos, yythunkpos634= G->thunkpos;  if (!yy_STAR(G))  goto l635;
+  l636:;	
+  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;
+  {  int yypos638= G->pos, yythunkpos638= G->thunkpos;  if (!yy_STAR(G))  goto l639;
   yyDo(G, yy_13_Type, G->begin, G->end, "yy_13_Type");
-  goto l634;
-  l635:;	  G->pos= yypos634; G->thunkpos= yythunkpos634;  if (!yymatchChar(G, '@')) goto l636;
-  yyDo(G, yy_14_Type, G->begin, G->end, "yy_14_Type");
-  goto l634;
-  l636:;	  G->pos= yypos634; G->thunkpos= yythunkpos634;  if (!yymatchChar(G, '[')) goto l633;
-  if (!yy_WS(G))  goto l633;
-  yyDo(G, yy_15_Type, G->begin, G->end, "yy_15_Type");
-  if (!yy__(G))  goto l633;
-
-  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;  if (!yy_Expr(G))  goto l637;
-  yyDo(G, yySet, -3, 0, "yySet");
   goto l638;
-  l637:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;
+  l639:;	  G->pos= yypos638; G->thunkpos= yythunkpos638;  if (!yymatchChar(G, '@')) goto l640;
+  yyDo(G, yy_14_Type, G->begin, G->end, "yy_14_Type");
+  goto l638;
+  l640:;	  G->pos= yypos638; G->thunkpos= yythunkpos638;  if (!yymatchChar(G, '[')) goto l637;
+  if (!yy_WS(G))  goto l637;
+  yyDo(G, yy_15_Type, G->begin, G->end, "yy_15_Type");
+  if (!yy__(G))  goto l637;
+
+  {  int yypos641= G->pos, yythunkpos641= G->thunkpos;  if (!yy_Expr(G))  goto l641;
+  yyDo(G, yySet, -3, 0, "yySet");
+  goto l642;
+  l641:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;
   }
-  l638:;	  if (!yymatchChar(G, ']')) goto l633;
+  l642:;	  if (!yymatchChar(G, ']')) goto l637;
   yyDo(G, yy_16_Type, G->begin, G->end, "yy_16_Type");
 
   }
-  l634:;	  goto l632;
-  l633:;	  G->pos= yypos633; G->thunkpos= yythunkpos633;
-  }  if (!yy__(G))  goto l612;
+  l638:;	  goto l636;
+  l637:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;
+  }  if (!yy__(G))  goto l616;
   yyDo(G, yy_17_Type, G->begin, G->end, "yy_17_Type");
-  if (!yymatchChar(G, ')')) goto l612;
+  if (!yymatchChar(G, ')')) goto l616;
 
   }
-  l613:;	  yyprintf((stderr, "  ok   Type"));
+  l617:;	  yyprintf((stderr, "  ok   Type"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l612:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
+  l616:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11224,13 +11252,13 @@ YY_RULE(int) yy_Type(GREG *G)
 }
 YY_RULE(int) yy_R_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "R_ARROW"));
-  if (!yymatchString(G, "->")) goto l639;
+  if (!yymatchString(G, "->")) goto l643;
   yyprintf((stderr, "  ok   R_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l639:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
+  l643:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11240,45 +11268,45 @@ YY_RULE(int) yy_Argument(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Argument"));
 
-  {  int yypos641= G->pos, yythunkpos641= G->thunkpos;  if (!yy_DOT(G))  goto l642;
-  if (!yy_IDENT(G))  goto l642;
+  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yy_DOT(G))  goto l646;
+  if (!yy_IDENT(G))  goto l646;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l642;
+  if (!yy__(G))  goto l646;
   yyDo(G, yy_1_Argument, G->begin, G->end, "yy_1_Argument");
-  goto l641;
-  l642:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_ASS(G))  goto l643;
-  if (!yy_IDENT(G))  goto l643;
+  goto l645;
+  l646:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;  if (!yy_ASS(G))  goto l647;
+  if (!yy_IDENT(G))  goto l647;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l643;
+  if (!yy__(G))  goto l647;
   yyDo(G, yy_2_Argument, G->begin, G->end, "yy_2_Argument");
-  goto l641;
-  l643:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_VariableDecl(G))  goto l644;
+  goto l645;
+  l647:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;  if (!yy_VariableDecl(G))  goto l648;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_Argument, G->begin, G->end, "yy_3_Argument");
-  goto l641;
-  l644:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_IDENT(G))  goto l645;
+  goto l645;
+  l648:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;  if (!yy_IDENT(G))  goto l649;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l645;
-  if (!yymatchChar(G, ':')) goto l645;
-  if (!yy__(G))  goto l645;
-  if (!yymatchString(G, "...")) goto l645;
-  if (!yy__(G))  goto l645;
+  if (!yy__(G))  goto l649;
+  if (!yymatchChar(G, ':')) goto l649;
+  if (!yy__(G))  goto l649;
+  if (!yymatchString(G, "...")) goto l649;
+  if (!yy__(G))  goto l649;
   yyDo(G, yy_4_Argument, G->begin, G->end, "yy_4_Argument");
-  goto l641;
-  l645:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yy_Type(G))  goto l646;
+  goto l645;
+  l649:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;  if (!yy_Type(G))  goto l650;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_Argument, G->begin, G->end, "yy_5_Argument");
-  goto l641;
-  l646:;	  G->pos= yypos641; G->thunkpos= yythunkpos641;  if (!yymatchString(G, "...")) goto l640;
+  goto l645;
+  l650:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;  if (!yymatchString(G, "...")) goto l644;
   yyDo(G, yy_6_Argument, G->begin, G->end, "yy_6_Argument");
 
   }
-  l641:;	  yyprintf((stderr, "  ok   Argument"));
+  l645:;	  yyprintf((stderr, "  ok   Argument"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l640:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
+  l644:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11287,13 +11315,13 @@ YY_RULE(int) yy_Argument(GREG *G)
 YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "AnonymousFunctionDecl"));
   yyDo(G, yy_1_AnonymousFunctionDecl, G->begin, G->end, "yy_1_AnonymousFunctionDecl");
-  if (!yy_FunctionDeclCore(G))  goto l647;
+  if (!yy_FunctionDeclCore(G))  goto l651;
   yyprintf((stderr, "  ok   AnonymousFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l647:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
+  l651:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11302,30 +11330,30 @@ YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclCore"));
-  if (!yy__(G))  goto l648;
-  if (!yy_FUNC_KW(G))  goto l648;
+  if (!yy__(G))  goto l652;
+  if (!yy_FUNC_KW(G))  goto l652;
 
-  {  int yypos649= G->pos, yythunkpos649= G->thunkpos;  if (!yymatchChar(G, '@')) goto l649;
+  {  int yypos653= G->pos, yythunkpos653= G->thunkpos;  if (!yymatchChar(G, '@')) goto l653;
   yyDo(G, yy_1_FunctionDeclCore, G->begin, G->end, "yy_1_FunctionDeclCore");
-  goto l650;
-  l649:;	  G->pos= yypos649; G->thunkpos= yythunkpos649;
+  goto l654;
+  l653:;	  G->pos= yypos653; G->thunkpos= yythunkpos653;
   }
-  l650:;	
-  {  int yypos651= G->pos, yythunkpos651= G->thunkpos;  if (!yy__(G))  goto l651;
-  if (!yymatchChar(G, '~')) goto l651;
-  if (!yy_IDENT(G))  goto l651;
+  l654:;	
+  {  int yypos655= G->pos, yythunkpos655= G->thunkpos;  if (!yy__(G))  goto l655;
+  if (!yymatchChar(G, '~')) goto l655;
+  if (!yy_IDENT(G))  goto l655;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_FunctionDeclCore, G->begin, G->end, "yy_2_FunctionDeclCore");
-  goto l652;
-  l651:;	  G->pos= yypos651; G->thunkpos= yythunkpos651;
+  goto l656;
+  l655:;	  G->pos= yypos655; G->thunkpos= yythunkpos655;
   }
-  l652:;	  if (!yy_FunctionDeclBody(G))  goto l648;
+  l656:;	  if (!yy_FunctionDeclBody(G))  goto l652;
   yyprintf((stderr, "  ok   FunctionDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l648:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
+  l652:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11333,13 +11361,13 @@ YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 }
 YY_RULE(int) yy_PROTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROTO_KW"));
-  if (!yymatchString(G, "proto")) goto l653;
+  if (!yymatchString(G, "proto")) goto l657;
   yyprintf((stderr, "  ok   PROTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l653:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
+  l657:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11347,13 +11375,13 @@ YY_RULE(int) yy_PROTO_KW(GREG *G)
 }
 YY_RULE(int) yy_FINAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FINAL_KW"));
-  if (!yymatchString(G, "final")) goto l654;
+  if (!yymatchString(G, "final")) goto l658;
   yyprintf((stderr, "  ok   FINAL_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l654:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
+  l658:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11361,13 +11389,13 @@ YY_RULE(int) yy_FINAL_KW(GREG *G)
 }
 YY_RULE(int) yy_INLINE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INLINE_KW"));
-  if (!yymatchString(G, "inline")) goto l655;
+  if (!yymatchString(G, "inline")) goto l659;
   yyprintf((stderr, "  ok   INLINE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l655:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
+  l659:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11375,13 +11403,13 @@ YY_RULE(int) yy_INLINE_KW(GREG *G)
 }
 YY_RULE(int) yy_STATIC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STATIC_KW"));
-  if (!yymatchString(G, "static")) goto l656;
+  if (!yymatchString(G, "static")) goto l660;
   yyprintf((stderr, "  ok   STATIC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l656:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
+  l660:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11390,26 +11418,26 @@ YY_RULE(int) yy_STATIC_KW(GREG *G)
 YY_RULE(int) yy_UnmangledName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "UnmangledName"));
-  if (!yy_UNMANGLED_KW(G))  goto l657;
+  if (!yy_UNMANGLED_KW(G))  goto l661;
   yyDo(G, yy_1_UnmangledName, G->begin, G->end, "yy_1_UnmangledName");
 
-  {  int yypos658= G->pos, yythunkpos658= G->thunkpos;  if (!yy__(G))  goto l658;
-  if (!yymatchChar(G, '(')) goto l658;
-  if (!yy__(G))  goto l658;
-  if (!yy_IDENT(G))  goto l658;
+  {  int yypos662= G->pos, yythunkpos662= G->thunkpos;  if (!yy__(G))  goto l662;
+  if (!yymatchChar(G, '(')) goto l662;
+  if (!yy__(G))  goto l662;
+  if (!yy_IDENT(G))  goto l662;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_UnmangledName, G->begin, G->end, "yy_2_UnmangledName");
-  if (!yy__(G))  goto l658;
-  if (!yymatchChar(G, ')')) goto l658;
-  goto l659;
-  l658:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;
+  if (!yy__(G))  goto l662;
+  if (!yymatchChar(G, ')')) goto l662;
+  goto l663;
+  l662:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;
   }
-  l659:;	  yyprintf((stderr, "  ok   UnmangledName"));
+  l663:;	  yyprintf((stderr, "  ok   UnmangledName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l657:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
+  l661:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11417,30 +11445,30 @@ YY_RULE(int) yy_UnmangledName(GREG *G)
 }
 YY_RULE(int) yy_ExternName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ExternName"));
-  if (!yy_EXTERN_KW(G))  goto l660;
+  if (!yy_EXTERN_KW(G))  goto l664;
   yyDo(G, yy_1_ExternName, G->begin, G->end, "yy_1_ExternName");
 
-  {  int yypos661= G->pos, yythunkpos661= G->thunkpos;  if (!yy__(G))  goto l661;
-  if (!yymatchChar(G, '(')) goto l661;
-  if (!yy__(G))  goto l661;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l661;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l661;
+  {  int yypos665= G->pos, yythunkpos665= G->thunkpos;  if (!yy__(G))  goto l665;
+  if (!yymatchChar(G, '(')) goto l665;
+  if (!yy__(G))  goto l665;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l665;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l665;
 
-  l663:;	
-  {  int yypos664= G->pos, yythunkpos664= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l664;
-  goto l663;
-  l664:;	  G->pos= yypos664; G->thunkpos= yythunkpos664;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l661;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
-  if (!yy__(G))  goto l661;
-  if (!yymatchChar(G, ')')) goto l661;
-  goto l662;
-  l661:;	  G->pos= yypos661; G->thunkpos= yythunkpos661;
+  l667:;	
+  {  int yypos668= G->pos, yythunkpos668= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l668;
+  goto l667;
+  l668:;	  G->pos= yypos668; G->thunkpos= yythunkpos668;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l665;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
+  if (!yy__(G))  goto l665;
+  if (!yymatchChar(G, ')')) goto l665;
+  goto l666;
+  l665:;	  G->pos= yypos665; G->thunkpos= yythunkpos665;
   }
-  l662:;	  yyprintf((stderr, "  ok   ExternName"));
+  l666:;	  yyprintf((stderr, "  ok   ExternName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l660:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
+  l664:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11449,17 +11477,17 @@ YY_RULE(int) yy_ExternName(GREG *G)
 YY_RULE(int) yy_OocDoc(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDoc"));
 
-  {  int yypos666= G->pos, yythunkpos666= G->thunkpos;  if (!yy_OocDocCore(G))  goto l667;
-  goto l666;
-  l667:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
+  {  int yypos670= G->pos, yythunkpos670= G->thunkpos;  if (!yy_OocDocCore(G))  goto l671;
+  goto l670;
+  l671:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
 
   }
-  l666:;	  yyprintf((stderr, "  ok   OocDoc"));
+  l670:;	  yyprintf((stderr, "  ok   OocDoc"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l665:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
+  l669:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11467,13 +11495,13 @@ YY_RULE(int) yy_OocDoc(GREG *G)
 }
 YY_RULE(int) yy_FUNC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FUNC_KW"));
-  if (!yymatchString(G, "func")) goto l668;
+  if (!yymatchString(G, "func")) goto l672;
   yyprintf((stderr, "  ok   FUNC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l668:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
+  l672:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11482,20 +11510,20 @@ YY_RULE(int) yy_FUNC_KW(GREG *G)
 YY_RULE(int) yy_COLON(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COLON"));
 
-  {  int yypos670= G->pos, yythunkpos670= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l670;
-  goto l669;
-  l670:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;
+  {  int yypos674= G->pos, yythunkpos674= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l674;
+  goto l673;
+  l674:;	  G->pos= yypos674; G->thunkpos= yythunkpos674;
   }
-  {  int yypos671= G->pos, yythunkpos671= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l671;
-  goto l669;
-  l671:;	  G->pos= yypos671; G->thunkpos= yythunkpos671;
-  }  if (!yymatchChar(G, ':')) goto l669;
+  {  int yypos675= G->pos, yythunkpos675= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l675;
+  goto l673;
+  l675:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;
+  }  if (!yymatchChar(G, ':')) goto l673;
   yyprintf((stderr, "  ok   COLON"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l669:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
+  l673:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11504,50 +11532,50 @@ YY_RULE(int) yy_COLON(GREG *G)
 YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "RegularFunctionDecl"));
-  if (!yy_OocDoc(G))  goto l672;
+  if (!yy_OocDoc(G))  goto l676;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l672;
+  if (!yy_IDENT(G))  goto l676;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_RegularFunctionDecl, G->begin, G->end, "yy_1_RegularFunctionDecl");
-  if (!yy__(G))  goto l672;
-  if (!yy_COLON(G))  goto l672;
+  if (!yy__(G))  goto l676;
+  if (!yy_COLON(G))  goto l676;
 
-  l673:;	
-  {  int yypos674= G->pos, yythunkpos674= G->thunkpos;  if (!yy__(G))  goto l674;
+  l677:;	
+  {  int yypos678= G->pos, yythunkpos678= G->thunkpos;  if (!yy__(G))  goto l678;
 
-  {  int yypos675= G->pos, yythunkpos675= G->thunkpos;  if (!yy_ExternName(G))  goto l676;
+  {  int yypos679= G->pos, yythunkpos679= G->thunkpos;  if (!yy_ExternName(G))  goto l680;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_RegularFunctionDecl, G->begin, G->end, "yy_2_RegularFunctionDecl");
-  goto l675;
-  l676:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_UnmangledName(G))  goto l677;
+  goto l679;
+  l680:;	  G->pos= yypos679; G->thunkpos= yythunkpos679;  if (!yy_UnmangledName(G))  goto l681;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_RegularFunctionDecl, G->begin, G->end, "yy_3_RegularFunctionDecl");
-  goto l675;
-  l677:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_ABSTRACT_KW(G))  goto l678;
+  goto l679;
+  l681:;	  G->pos= yypos679; G->thunkpos= yythunkpos679;  if (!yy_ABSTRACT_KW(G))  goto l682;
   yyDo(G, yy_4_RegularFunctionDecl, G->begin, G->end, "yy_4_RegularFunctionDecl");
-  goto l675;
-  l678:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_STATIC_KW(G))  goto l679;
+  goto l679;
+  l682:;	  G->pos= yypos679; G->thunkpos= yythunkpos679;  if (!yy_STATIC_KW(G))  goto l683;
   yyDo(G, yy_5_RegularFunctionDecl, G->begin, G->end, "yy_5_RegularFunctionDecl");
-  goto l675;
-  l679:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_INLINE_KW(G))  goto l680;
+  goto l679;
+  l683:;	  G->pos= yypos679; G->thunkpos= yythunkpos679;  if (!yy_INLINE_KW(G))  goto l684;
   yyDo(G, yy_6_RegularFunctionDecl, G->begin, G->end, "yy_6_RegularFunctionDecl");
-  goto l675;
-  l680:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_FINAL_KW(G))  goto l681;
+  goto l679;
+  l684:;	  G->pos= yypos679; G->thunkpos= yythunkpos679;  if (!yy_FINAL_KW(G))  goto l685;
   yyDo(G, yy_7_RegularFunctionDecl, G->begin, G->end, "yy_7_RegularFunctionDecl");
-  goto l675;
-  l681:;	  G->pos= yypos675; G->thunkpos= yythunkpos675;  if (!yy_PROTO_KW(G))  goto l674;
+  goto l679;
+  l685:;	  G->pos= yypos679; G->thunkpos= yythunkpos679;  if (!yy_PROTO_KW(G))  goto l678;
   yyDo(G, yy_8_RegularFunctionDecl, G->begin, G->end, "yy_8_RegularFunctionDecl");
 
   }
-  l675:;	  goto l673;
-  l674:;	  G->pos= yypos674; G->thunkpos= yythunkpos674;
-  }  if (!yy_FunctionDeclCore(G))  goto l672;
+  l679:;	  goto l677;
+  l678:;	  G->pos= yypos678; G->thunkpos= yythunkpos678;
+  }  if (!yy_FunctionDeclCore(G))  goto l676;
   yyprintf((stderr, "  ok   RegularFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l672:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
+  l676:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11556,32 +11584,32 @@ YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 YY_RULE(int) yy_SuperFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "SuperFunctionDecl"));
-  if (!yy_IDENT(G))  goto l682;
+  if (!yy_IDENT(G))  goto l686;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l682;
-  if (!yy_COLON(G))  goto l682;
-  if (!yy__(G))  goto l682;
-  if (!yymatchString(G, "super")) goto l682;
-  if (!yy__(G))  goto l682;
-  if (!yy_FUNC_KW(G))  goto l682;
-  if (!yy__(G))  goto l682;
+  if (!yy__(G))  goto l686;
+  if (!yy_COLON(G))  goto l686;
+  if (!yy__(G))  goto l686;
+  if (!yymatchString(G, "super")) goto l686;
+  if (!yy__(G))  goto l686;
+  if (!yy_FUNC_KW(G))  goto l686;
+  if (!yy__(G))  goto l686;
   yyDo(G, yy_1_SuperFunctionDecl, G->begin, G->end, "yy_1_SuperFunctionDecl");
 
-  {  int yypos683= G->pos, yythunkpos683= G->thunkpos;  if (!yy__(G))  goto l683;
-  if (!yymatchChar(G, '~')) goto l683;
-  if (!yy_IDENT(G))  goto l683;
+  {  int yypos687= G->pos, yythunkpos687= G->thunkpos;  if (!yy__(G))  goto l687;
+  if (!yymatchChar(G, '~')) goto l687;
+  if (!yy_IDENT(G))  goto l687;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_SuperFunctionDecl, G->begin, G->end, "yy_2_SuperFunctionDecl");
-  goto l684;
-  l683:;	  G->pos= yypos683; G->thunkpos= yythunkpos683;
+  goto l688;
+  l687:;	  G->pos= yypos687; G->thunkpos= yythunkpos687;
   }
-  l684:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
+  l688:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
   yyprintf((stderr, "  ok   SuperFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l682:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
+  l686:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11591,87 +11619,87 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclBody"));
 
-  {  int yypos686= G->pos, yythunkpos686= G->thunkpos;  if (!yy_GenericArguments(G))  goto l686;
-  goto l687;
-  l686:;	  G->pos= yypos686; G->thunkpos= yythunkpos686;
-  }
-  l687:;	
-  {  int yypos688= G->pos, yythunkpos688= G->thunkpos;  if (!yy_WS(G))  goto l688;
-  if (!yymatchChar(G, '(')) goto l688;
-  yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end, "yy_1_FunctionDeclBody");
-
-  {  int yypos690= G->pos, yythunkpos690= G->thunkpos;  if (!yy_WS(G))  goto l690;
-  if (!yy_Argument(G))  goto l690;
-  if (!yy_WS(G))  goto l690;
-
-  l692:;	
-  {  int yypos693= G->pos, yythunkpos693= G->thunkpos;  if (!yymatchChar(G, ',')) goto l693;
-  if (!yy_WS(G))  goto l693;
-  if (!yy_Argument(G))  goto l693;
-  if (!yy_WS(G))  goto l693;
-  goto l692;
-  l693:;	  G->pos= yypos693; G->thunkpos= yythunkpos693;
-  }  goto l691;
+  {  int yypos690= G->pos, yythunkpos690= G->thunkpos;  if (!yy_GenericArguments(G))  goto l690;
+  goto l691;
   l690:;	  G->pos= yypos690; G->thunkpos= yythunkpos690;
   }
-  l691:;	  if (!yy_WS(G))  goto l688;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l688; }
-  yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end, "yy_2_FunctionDeclBody");
-  goto l689;
-  l688:;	  G->pos= yypos688; G->thunkpos= yythunkpos688;
-  }
-  l689:;	
-  {  int yypos694= G->pos, yythunkpos694= G->thunkpos;  if (!yy__(G))  goto l694;
-  if (!yymatchChar(G, '~')) goto l694;
-  if (!yy_IDENT(G))  goto l694;
-  yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end, "yy_3_FunctionDeclBody");
-  goto l695;
+  l691:;	
+  {  int yypos692= G->pos, yythunkpos692= G->thunkpos;  if (!yy_WS(G))  goto l692;
+  if (!yymatchChar(G, '(')) goto l692;
+  yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end, "yy_1_FunctionDeclBody");
+
+  {  int yypos694= G->pos, yythunkpos694= G->thunkpos;  if (!yy_WS(G))  goto l694;
+  if (!yy_Argument(G))  goto l694;
+  if (!yy_WS(G))  goto l694;
+
+  l696:;	
+  {  int yypos697= G->pos, yythunkpos697= G->thunkpos;  if (!yymatchChar(G, ',')) goto l697;
+  if (!yy_WS(G))  goto l697;
+  if (!yy_Argument(G))  goto l697;
+  if (!yy_WS(G))  goto l697;
+  goto l696;
+  l697:;	  G->pos= yypos697; G->thunkpos= yythunkpos697;
+  }  goto l695;
   l694:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;
   }
-  l695:;	
-  {  int yypos696= G->pos, yythunkpos696= G->thunkpos;  if (!yy__(G))  goto l696;
-  if (!yy_R_ARROW(G))  goto l696;
-  if (!yy__(G))  goto l696;
-  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l696; }
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end, "yy_4_FunctionDeclBody");
-  goto l697;
-  l696:;	  G->pos= yypos696; G->thunkpos= yythunkpos696;
+  l695:;	  if (!yy_WS(G))  goto l692;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l692; }
+  yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end, "yy_2_FunctionDeclBody");
+  goto l693;
+  l692:;	  G->pos= yypos692; G->thunkpos= yythunkpos692;
   }
-  l697:;	
-  {  int yypos698= G->pos, yythunkpos698= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
-  if (!yy_WS(G))  goto l698;
-  if (!yymatchChar(G, '{')) goto l698;
-  if (!yy_WS(G))  goto l698;
-
-  l700:;	
-  {  int yypos701= G->pos, yythunkpos701= G->thunkpos;  if (!yy_WS(G))  goto l701;
-
-  {  int yypos702= G->pos, yythunkpos702= G->thunkpos;  if (!yy_Stmt(G))  goto l703;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end, "yy_6_FunctionDeclBody");
-  goto l702;
-  l703:;	  G->pos= yypos702; G->thunkpos= yythunkpos702;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
-  if (!yy_OocDocCore(G))  goto l701;
-  yyDo(G, yy_8_FunctionDeclBody, G->begin, G->end, "yy_8_FunctionDeclBody");
-
-  }
-  l702:;	  if (!yy_WS(G))  goto l701;
-  goto l700;
-  l701:;	  G->pos= yypos701; G->thunkpos= yythunkpos701;
-  }  if (!yy_WS(G))  goto l698;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l698; }
+  l693:;	
+  {  int yypos698= G->pos, yythunkpos698= G->thunkpos;  if (!yy__(G))  goto l698;
+  if (!yymatchChar(G, '~')) goto l698;
+  if (!yy_IDENT(G))  goto l698;
+  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end, "yy_3_FunctionDeclBody");
   goto l699;
   l698:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;
   }
-  l699:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
+  l699:;	
+  {  int yypos700= G->pos, yythunkpos700= G->thunkpos;  if (!yy__(G))  goto l700;
+  if (!yy_R_ARROW(G))  goto l700;
+  if (!yy__(G))  goto l700;
+  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l700; }
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end, "yy_4_FunctionDeclBody");
+  goto l701;
+  l700:;	  G->pos= yypos700; G->thunkpos= yythunkpos700;
+  }
+  l701:;	
+  {  int yypos702= G->pos, yythunkpos702= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
+  if (!yy_WS(G))  goto l702;
+  if (!yymatchChar(G, '{')) goto l702;
+  if (!yy_WS(G))  goto l702;
+
+  l704:;	
+  {  int yypos705= G->pos, yythunkpos705= G->thunkpos;  if (!yy_WS(G))  goto l705;
+
+  {  int yypos706= G->pos, yythunkpos706= G->thunkpos;  if (!yy_Stmt(G))  goto l707;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end, "yy_6_FunctionDeclBody");
+  goto l706;
+  l707:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
+  if (!yy_OocDocCore(G))  goto l705;
+  yyDo(G, yy_8_FunctionDeclBody, G->begin, G->end, "yy_8_FunctionDeclBody");
+
+  }
+  l706:;	  if (!yy_WS(G))  goto l705;
+  goto l704;
+  l705:;	  G->pos= yypos705; G->thunkpos= yythunkpos705;
+  }  if (!yy_WS(G))  goto l702;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l702; }
+  goto l703;
+  l702:;	  G->pos= yypos702; G->thunkpos= yythunkpos702;
+  }
+  l703:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
   yyprintf((stderr, "  ok   FunctionDeclBody"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l685:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
+  l689:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11679,13 +11707,13 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 }
 YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ABSTRACT_KW"));
-  if (!yymatchString(G, "abstract")) goto l704;
+  if (!yymatchString(G, "abstract")) goto l708;
   yyprintf((stderr, "  ok   ABSTRACT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l704:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
+  l708:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11693,13 +11721,13 @@ YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 }
 YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OPERATOR_KW"));
-  if (!yymatchString(G, "operator")) goto l705;
+  if (!yymatchString(G, "operator")) goto l709;
   yyprintf((stderr, "  ok   OPERATOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l705:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
+  l709:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11707,18 +11735,18 @@ YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 }
 YY_RULE(int) yy_TemplateDef(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TemplateDef"));
-  if (!yy_WS(G))  goto l706;
-  if (!yymatchString(G, "template")) goto l706;
-  if (!yy_WS(G))  goto l706;
+  if (!yy_WS(G))  goto l710;
+  if (!yymatchString(G, "template")) goto l710;
+  if (!yy_WS(G))  goto l710;
   yyDo(G, yy_1_TemplateDef, G->begin, G->end, "yy_1_TemplateDef");
-  if (!yy_GenericArguments(G))  goto l706;
+  if (!yy_GenericArguments(G))  goto l710;
   yyDo(G, yy_2_TemplateDef, G->begin, G->end, "yy_2_TemplateDef");
   yyprintf((stderr, "  ok   TemplateDef"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l706:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
+  l710:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11726,23 +11754,23 @@ YY_RULE(int) yy_TemplateDef(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN"));
-  if (!yymatchChar(G, '>')) goto l707;
+  if (!yymatchChar(G, '>')) goto l711;
 
-  {  int yypos708= G->pos, yythunkpos708= G->thunkpos;
-  {  int yypos709= G->pos, yythunkpos709= G->thunkpos;  if (!yymatchChar(G, '=')) goto l710;
-  goto l709;
-  l710:;	  G->pos= yypos709; G->thunkpos= yythunkpos709;  if (!yymatchChar(G, '>')) goto l708;
+  {  int yypos712= G->pos, yythunkpos712= G->thunkpos;
+  {  int yypos713= G->pos, yythunkpos713= G->thunkpos;  if (!yymatchChar(G, '=')) goto l714;
+  goto l713;
+  l714:;	  G->pos= yypos713; G->thunkpos= yythunkpos713;  if (!yymatchChar(G, '>')) goto l712;
 
   }
-  l709:;	  goto l707;
-  l708:;	  G->pos= yypos708; G->thunkpos= yythunkpos708;
-  }  if (!yy__(G))  goto l707;
+  l713:;	  goto l711;
+  l712:;	  G->pos= yypos712; G->thunkpos= yythunkpos712;
+  }  if (!yy__(G))  goto l711;
   yyprintf((stderr, "  ok   MORETHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l707:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
+  l711:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11750,23 +11778,23 @@ YY_RULE(int) yy_MORETHAN(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN"));
-  if (!yymatchChar(G, '<')) goto l711;
+  if (!yymatchChar(G, '<')) goto l715;
 
-  {  int yypos712= G->pos, yythunkpos712= G->thunkpos;
-  {  int yypos713= G->pos, yythunkpos713= G->thunkpos;  if (!yymatchChar(G, '=')) goto l714;
-  goto l713;
-  l714:;	  G->pos= yypos713; G->thunkpos= yythunkpos713;  if (!yymatchChar(G, '<')) goto l712;
+  {  int yypos716= G->pos, yythunkpos716= G->thunkpos;
+  {  int yypos717= G->pos, yythunkpos717= G->thunkpos;  if (!yymatchChar(G, '=')) goto l718;
+  goto l717;
+  l718:;	  G->pos= yypos717; G->thunkpos= yythunkpos717;  if (!yymatchChar(G, '<')) goto l716;
 
   }
-  l713:;	  goto l711;
-  l712:;	  G->pos= yypos712; G->thunkpos= yythunkpos712;
-  }  if (!yy__(G))  goto l711;
+  l717:;	  goto l715;
+  l716:;	  G->pos= yypos716; G->thunkpos= yythunkpos716;
+  }  if (!yy__(G))  goto l715;
   yyprintf((stderr, "  ok   LESSTHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l711:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
+  l715:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11775,30 +11803,30 @@ YY_RULE(int) yy_LESSTHAN(GREG *G)
 YY_RULE(int) yy_GenericArguments(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericArguments"));
-  if (!yy__(G))  goto l715;
-  if (!yy_LESSTHAN(G))  goto l715;
-  if (!yy__(G))  goto l715;
-  if (!yy_IDENT(G))  goto l715;
+  if (!yy__(G))  goto l719;
+  if (!yy_LESSTHAN(G))  goto l719;
+  if (!yy__(G))  goto l719;
+  if (!yy_IDENT(G))  goto l719;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_GenericArguments, G->begin, G->end, "yy_1_GenericArguments");
 
-  l716:;	
-  {  int yypos717= G->pos, yythunkpos717= G->thunkpos;  if (!yy__(G))  goto l717;
-  if (!yymatchChar(G, ',')) goto l717;
-  if (!yy__(G))  goto l717;
-  if (!yy_IDENT(G))  goto l717;
+  l720:;	
+  {  int yypos721= G->pos, yythunkpos721= G->thunkpos;  if (!yy__(G))  goto l721;
+  if (!yymatchChar(G, ',')) goto l721;
+  if (!yy__(G))  goto l721;
+  if (!yy_IDENT(G))  goto l721;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_GenericArguments, G->begin, G->end, "yy_2_GenericArguments");
-  goto l716;
-  l717:;	  G->pos= yypos717; G->thunkpos= yythunkpos717;
-  }  if (!yy_MORETHAN(G))  goto l715;
-  if (!yy__(G))  goto l715;
+  goto l720;
+  l721:;	  G->pos= yypos721; G->thunkpos= yythunkpos721;
+  }  if (!yy_MORETHAN(G))  goto l719;
+  if (!yy__(G))  goto l719;
   yyprintf((stderr, "  ok   GenericArguments"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l715:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
+  l719:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11807,27 +11835,27 @@ YY_RULE(int) yy_GenericArguments(GREG *G)
 YY_RULE(int) yy_Terminator(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Terminator"));
 
-  {  int yypos719= G->pos, yythunkpos719= G->thunkpos;  if (!yy_CommentLine(G))  goto l720;
-  goto l719;
-  l720:;	  G->pos= yypos719; G->thunkpos= yythunkpos719;
-  {  int yypos721= G->pos, yythunkpos721= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l721;
-  goto l722;
-  l721:;	  G->pos= yypos721; G->thunkpos= yythunkpos721;
-  }
-  l722:;	
-  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_EOL(G))  goto l724;
+  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_CommentLine(G))  goto l724;
   goto l723;
-  l724:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;  if (!yymatchChar(G, ';')) goto l718;
+  l724:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;
+  {  int yypos725= G->pos, yythunkpos725= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l725;
+  goto l726;
+  l725:;	  G->pos= yypos725; G->thunkpos= yythunkpos725;
+  }
+  l726:;	
+  {  int yypos727= G->pos, yythunkpos727= G->thunkpos;  if (!yy_EOL(G))  goto l728;
+  goto l727;
+  l728:;	  G->pos= yypos727; G->thunkpos= yythunkpos727;  if (!yymatchChar(G, ';')) goto l722;
 
   }
-  l723:;	
+  l727:;	
   }
-  l719:;	  yyprintf((stderr, "  ok   Terminator"));
+  l723:;	  yyprintf((stderr, "  ok   Terminator"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l718:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
+  l722:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11837,21 +11865,21 @@ YY_RULE(int) yy_VariableDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VariableDecl"));
 
-  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l727;
+  {  int yypos730= G->pos, yythunkpos730= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l731;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_VariableDecl, G->begin, G->end, "yy_1_VariableDecl");
-  goto l726;
-  l727:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;  if (!yy_ConventionalVarDecl(G))  goto l725;
+  goto l730;
+  l731:;	  G->pos= yypos730; G->thunkpos= yythunkpos730;  if (!yy_ConventionalVarDecl(G))  goto l729;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VariableDecl, G->begin, G->end, "yy_2_VariableDecl");
 
   }
-  l726:;	  yyprintf((stderr, "  ok   VariableDecl"));
+  l730:;	  yyprintf((stderr, "  ok   VariableDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l725:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
+  l729:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11861,21 +11889,21 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDecl"));
 
-  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l730;
+  {  int yypos733= G->pos, yythunkpos733= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l734;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_PropertyDecl, G->begin, G->end, "yy_1_PropertyDecl");
-  goto l729;
-  l730:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;  if (!yy_ConventionalPropertyDecl(G))  goto l728;
+  goto l733;
+  l734:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;  if (!yy_ConventionalPropertyDecl(G))  goto l732;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_PropertyDecl, G->begin, G->end, "yy_2_PropertyDecl");
 
   }
-  l729:;	  yyprintf((stderr, "  ok   PropertyDecl"));
+  l733:;	  yyprintf((stderr, "  ok   PropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l728:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
+  l732:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11884,17 +11912,17 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 YY_RULE(int) yy_FunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FunctionDecl"));
 
-  {  int yypos732= G->pos, yythunkpos732= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l733;
-  goto l732;
-  l733:;	  G->pos= yypos732; G->thunkpos= yythunkpos732;  if (!yy_RegularFunctionDecl(G))  goto l731;
+  {  int yypos736= G->pos, yythunkpos736= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l737;
+  goto l736;
+  l737:;	  G->pos= yypos736; G->thunkpos= yythunkpos736;  if (!yy_RegularFunctionDecl(G))  goto l735;
 
   }
-  l732:;	  yyprintf((stderr, "  ok   FunctionDecl"));
+  l736:;	  yyprintf((stderr, "  ok   FunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l731:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
+  l735:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11903,115 +11931,115 @@ YY_RULE(int) yy_FunctionDecl(GREG *G)
 YY_RULE(int) yy_OperatorDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OperatorDecl"));
 
-  {  int yypos735= G->pos, yythunkpos735= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l736;
+  {  int yypos739= G->pos, yythunkpos739= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l740;
   yyDo(G, yy_1_OperatorDecl, G->begin, G->end, "yy_1_OperatorDecl");
-  goto l735;
-  l736:;	  G->pos= yypos735; G->thunkpos= yythunkpos735;  if (!yy_ABSTRACT_KW(G))  goto l734;
-  if (!yy__(G))  goto l734;
-  if (!yy_OPERATOR_KW(G))  goto l734;
+  goto l739;
+  l740:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yy_ABSTRACT_KW(G))  goto l738;
+  if (!yy__(G))  goto l738;
+  if (!yy_OPERATOR_KW(G))  goto l738;
   yyDo(G, yy_2_OperatorDecl, G->begin, G->end, "yy_2_OperatorDecl");
 
   }
-  l735:;	  if (!yy__(G))  goto l734;
+  l739:;	  if (!yy__(G))  goto l738;
 
-  {  int yypos737= G->pos, yythunkpos737= G->thunkpos;  if (!yymatchChar(G, '@')) goto l737;
+  {  int yypos741= G->pos, yythunkpos741= G->thunkpos;  if (!yymatchChar(G, '@')) goto l741;
   yyDo(G, yy_3_OperatorDecl, G->begin, G->end, "yy_3_OperatorDecl");
-  goto l738;
-  l737:;	  G->pos= yypos737; G->thunkpos= yythunkpos737;
+  goto l742;
+  l741:;	  G->pos= yypos741; G->thunkpos= yythunkpos741;
   }
-  l738:;	  if (!yy__(G))  goto l734;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l734;
-  {  int yypos739= G->pos, yythunkpos739= G->thunkpos;  if (!yymatchString(G, "=>")) goto l740;
-  goto l739;
-  l740:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<=>")) goto l741;
-  goto l739;
-  l741:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">>=")) goto l742;
-  goto l739;
-  l742:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<<=")) goto l743;
-  goto l739;
-  l743:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">>")) goto l744;
-  goto l739;
-  l744:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<<")) goto l745;
-  goto l739;
-  l745:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">=")) goto l746;
-  goto l739;
-  l746:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<=")) goto l747;
-  goto l739;
-  l747:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "!=")) goto l748;
-  goto l739;
-  l748:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "==")) goto l749;
-  goto l739;
-  l749:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '>')) goto l750;
-  goto l739;
-  l750:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '<')) goto l751;
-  goto l739;
-  l751:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '!')) goto l752;
-  goto l739;
-  l752:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "??")) goto l753;
-  goto l739;
-  l753:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "+=")) goto l754;
-  goto l739;
-  l754:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "-=")) goto l755;
-  goto l739;
-  l755:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "*=")) goto l756;
-  goto l739;
-  l756:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "**=")) goto l757;
-  goto l739;
-  l757:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "/=")) goto l758;
-  goto l739;
-  l758:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "%=")) goto l759;
-  goto l739;
-  l759:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '+')) goto l760;
-  goto l739;
-  l760:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '-')) goto l761;
-  goto l739;
-  l761:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "**")) goto l762;
-  goto l739;
-  l762:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '/')) goto l763;
-  goto l739;
-  l763:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '*')) goto l764;
-  goto l739;
-  l764:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '=')) goto l765;
-  goto l739;
-  l765:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "[]=")) goto l766;
-  goto l739;
-  l766:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "[]")) goto l767;
-  goto l739;
-  l767:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "&&")) goto l768;
-  goto l739;
-  l768:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "||")) goto l769;
-  goto l739;
-  l769:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '%')) goto l770;
-  goto l739;
-  l770:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "as")) goto l771;
-  goto l739;
-  l771:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "implicit as")) goto l772;
-  goto l739;
-  l772:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "&=")) goto l773;
-  goto l739;
-  l773:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "|=")) goto l774;
-  goto l739;
-  l774:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "^=")) goto l775;
-  goto l739;
-  l775:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '&')) goto l776;
-  goto l739;
-  l776:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '|')) goto l777;
-  goto l739;
-  l777:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '^')) goto l778;
-  goto l739;
-  l778:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '~')) goto l734;
+  l742:;	  if (!yy__(G))  goto l738;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l738;
+  {  int yypos743= G->pos, yythunkpos743= G->thunkpos;  if (!yymatchString(G, "=>")) goto l744;
+  goto l743;
+  l744:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "<=>")) goto l745;
+  goto l743;
+  l745:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, ">>=")) goto l746;
+  goto l743;
+  l746:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "<<=")) goto l747;
+  goto l743;
+  l747:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, ">>")) goto l748;
+  goto l743;
+  l748:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "<<")) goto l749;
+  goto l743;
+  l749:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, ">=")) goto l750;
+  goto l743;
+  l750:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "<=")) goto l751;
+  goto l743;
+  l751:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "!=")) goto l752;
+  goto l743;
+  l752:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "==")) goto l753;
+  goto l743;
+  l753:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '>')) goto l754;
+  goto l743;
+  l754:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '<')) goto l755;
+  goto l743;
+  l755:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '!')) goto l756;
+  goto l743;
+  l756:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "??")) goto l757;
+  goto l743;
+  l757:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "+=")) goto l758;
+  goto l743;
+  l758:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "-=")) goto l759;
+  goto l743;
+  l759:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "*=")) goto l760;
+  goto l743;
+  l760:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "**=")) goto l761;
+  goto l743;
+  l761:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "/=")) goto l762;
+  goto l743;
+  l762:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "%=")) goto l763;
+  goto l743;
+  l763:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '+')) goto l764;
+  goto l743;
+  l764:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '-')) goto l765;
+  goto l743;
+  l765:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "**")) goto l766;
+  goto l743;
+  l766:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '/')) goto l767;
+  goto l743;
+  l767:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '*')) goto l768;
+  goto l743;
+  l768:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '=')) goto l769;
+  goto l743;
+  l769:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "[]=")) goto l770;
+  goto l743;
+  l770:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "[]")) goto l771;
+  goto l743;
+  l771:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "&&")) goto l772;
+  goto l743;
+  l772:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "||")) goto l773;
+  goto l743;
+  l773:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '%')) goto l774;
+  goto l743;
+  l774:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "as")) goto l775;
+  goto l743;
+  l775:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "implicit as")) goto l776;
+  goto l743;
+  l776:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "&=")) goto l777;
+  goto l743;
+  l777:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "|=")) goto l778;
+  goto l743;
+  l778:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchString(G, "^=")) goto l779;
+  goto l743;
+  l779:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '&')) goto l780;
+  goto l743;
+  l780:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '|')) goto l781;
+  goto l743;
+  l781:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '^')) goto l782;
+  goto l743;
+  l782:;	  G->pos= yypos743; G->thunkpos= yythunkpos743;  if (!yymatchChar(G, '~')) goto l738;
 
   }
-  l739:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l734;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
-  if (!yy__(G))  goto l734;
-  if (!yy_FunctionDeclBody(G))  goto l734;
+  l743:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l738;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
+  if (!yy__(G))  goto l738;
+  if (!yy_FunctionDeclBody(G))  goto l738;
   yyDo(G, yy_5_OperatorDecl, G->begin, G->end, "yy_5_OperatorDecl");
   yyprintf((stderr, "  ok   OperatorDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l734:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
+  l738:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12020,70 +12048,70 @@ YY_RULE(int) yy_OperatorDecl(GREG *G)
 YY_RULE(int) yy_InterfaceDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "InterfaceDecl"));
-  if (!yy_OocDoc(G))  goto l779;
+  if (!yy_OocDoc(G))  goto l783;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l779;
+  if (!yy_IDENT(G))  goto l783;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_InterfaceDecl, G->begin, G->end, "yy_1_InterfaceDecl");
-  if (!yy__(G))  goto l779;
-  if (!yy_COLON(G))  goto l779;
-  if (!yy__(G))  goto l779;
-  if (!yy_INTERFACE_KW(G))  goto l779;
+  if (!yy__(G))  goto l783;
+  if (!yy_COLON(G))  goto l783;
+  if (!yy__(G))  goto l783;
+  if (!yy_INTERFACE_KW(G))  goto l783;
 
-  {  int yypos780= G->pos, yythunkpos780= G->thunkpos;  if (!yy_GenericArguments(G))  goto l780;
-  goto l781;
-  l780:;	  G->pos= yypos780; G->thunkpos= yythunkpos780;
+  {  int yypos784= G->pos, yythunkpos784= G->thunkpos;  if (!yy_GenericArguments(G))  goto l784;
+  goto l785;
+  l784:;	  G->pos= yypos784; G->thunkpos= yythunkpos784;
   }
-  l781:;	
-  {  int yypos782= G->pos, yythunkpos782= G->thunkpos;  if (!yy__(G))  goto l782;
-  if (!yy_EXTENDS_KW(G))  goto l782;
-  if (!yy__(G))  goto l782;
-  if (!yy_Type(G))  goto l782;
+  l785:;	
+  {  int yypos786= G->pos, yythunkpos786= G->thunkpos;  if (!yy__(G))  goto l786;
+  if (!yy_EXTENDS_KW(G))  goto l786;
+  if (!yy__(G))  goto l786;
+  if (!yy_Type(G))  goto l786;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_InterfaceDecl, G->begin, G->end, "yy_2_InterfaceDecl");
-  goto l783;
-  l782:;	  G->pos= yypos782; G->thunkpos= yythunkpos782;
+  goto l787;
+  l786:;	  G->pos= yypos786; G->thunkpos= yythunkpos786;
   }
-  l783:;	
-  {  int yypos784= G->pos, yythunkpos784= G->thunkpos;  if (!yy__(G))  goto l784;
-  if (!yy_IMPLEMENTS_KW(G))  goto l784;
-  if (!yy__(G))  goto l784;
-  if (!yy_Type(G))  goto l784;
+  l787:;	
+  {  int yypos788= G->pos, yythunkpos788= G->thunkpos;  if (!yy__(G))  goto l788;
+  if (!yy_IMPLEMENTS_KW(G))  goto l788;
+  if (!yy__(G))  goto l788;
+  if (!yy_Type(G))  goto l788;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_InterfaceDecl, G->begin, G->end, "yy_3_InterfaceDecl");
 
-  l786:;	
-  {  int yypos787= G->pos, yythunkpos787= G->thunkpos;  if (!yy__(G))  goto l787;
-  if (!yymatchChar(G, ',')) goto l787;
-  if (!yy__(G))  goto l787;
-  if (!yy_Type(G))  goto l787;
+  l790:;	
+  {  int yypos791= G->pos, yythunkpos791= G->thunkpos;  if (!yy__(G))  goto l791;
+  if (!yymatchChar(G, ',')) goto l791;
+  if (!yy__(G))  goto l791;
+  if (!yy_Type(G))  goto l791;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_InterfaceDecl, G->begin, G->end, "yy_4_InterfaceDecl");
-  goto l786;
-  l787:;	  G->pos= yypos787; G->thunkpos= yythunkpos787;
-  }  goto l785;
-  l784:;	  G->pos= yypos784; G->thunkpos= yythunkpos784;
+  goto l790;
+  l791:;	  G->pos= yypos791; G->thunkpos= yythunkpos791;
+  }  goto l789;
+  l788:;	  G->pos= yypos788; G->thunkpos= yythunkpos788;
   }
-  l785:;	  if (!yy_WS(G))  goto l779;
-  if (!yymatchChar(G, '{')) goto l779;
-  if (!yy_WS(G))  goto l779;
+  l789:;	  if (!yy_WS(G))  goto l783;
+  if (!yymatchChar(G, '{')) goto l783;
+  if (!yy_WS(G))  goto l783;
 
-  l788:;	
-  {  int yypos789= G->pos, yythunkpos789= G->thunkpos;  if (!yy_WS(G))  goto l789;
-  if (!yy_FunctionDecl(G))  goto l789;
+  l792:;	
+  {  int yypos793= G->pos, yythunkpos793= G->thunkpos;  if (!yy_WS(G))  goto l793;
+  if (!yy_FunctionDecl(G))  goto l793;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l789;
-  goto l788;
-  l789:;	  G->pos= yypos789; G->thunkpos= yythunkpos789;
-  }  if (!yy_WS(G))  goto l779;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l779; }
+  if (!yy_WS(G))  goto l793;
+  goto l792;
+  l793:;	  G->pos= yypos793; G->thunkpos= yythunkpos793;
+  }  if (!yy_WS(G))  goto l783;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l783; }
   yyDo(G, yy_5_InterfaceDecl, G->begin, G->end, "yy_5_InterfaceDecl");
   yyprintf((stderr, "  ok   InterfaceDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l779:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
+  l783:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12092,86 +12120,86 @@ YY_RULE(int) yy_InterfaceDecl(GREG *G)
 YY_RULE(int) yy_EnumDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumDecl"));
-  if (!yy_OocDoc(G))  goto l790;
+  if (!yy_OocDoc(G))  goto l794;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l790;
+  if (!yy_IDENT(G))  goto l794;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_EnumDecl, G->begin, G->end, "yy_1_EnumDecl");
-  if (!yy__(G))  goto l790;
-  if (!yy_COLON(G))  goto l790;
-  if (!yy__(G))  goto l790;
-  if (!yy_ENUM_KW(G))  goto l790;
+  if (!yy__(G))  goto l794;
+  if (!yy_COLON(G))  goto l794;
+  if (!yy__(G))  goto l794;
+  if (!yy_ENUM_KW(G))  goto l794;
 
-  {  int yypos791= G->pos, yythunkpos791= G->thunkpos;  if (!yy__(G))  goto l791;
-  if (!yy_FROM_KW(G))  goto l791;
-  if (!yy__(G))  goto l791;
-  if (!yy_Type(G))  goto l791;
+  {  int yypos795= G->pos, yythunkpos795= G->thunkpos;  if (!yy__(G))  goto l795;
+  if (!yy_FROM_KW(G))  goto l795;
+  if (!yy__(G))  goto l795;
+  if (!yy_Type(G))  goto l795;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_EnumDecl, G->begin, G->end, "yy_2_EnumDecl");
-  goto l792;
-  l791:;	  G->pos= yypos791; G->thunkpos= yythunkpos791;
+  goto l796;
+  l795:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;
   }
-  l792:;	
-  {  int yypos793= G->pos, yythunkpos793= G->thunkpos;  if (!yy__(G))  goto l793;
-  if (!yymatchChar(G, '(')) goto l793;
-  if (!yy__(G))  goto l793;
-  if (!yy_EnumIncrementOper(G))  goto l793;
+  l796:;	
+  {  int yypos797= G->pos, yythunkpos797= G->thunkpos;  if (!yy__(G))  goto l797;
+  if (!yymatchChar(G, '(')) goto l797;
+  if (!yy__(G))  goto l797;
+  if (!yy_EnumIncrementOper(G))  goto l797;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l793;
-  if (!yy_IntLiteral(G))  goto l793;
+  if (!yy_WS(G))  goto l797;
+  if (!yy_IntLiteral(G))  goto l797;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumDecl, G->begin, G->end, "yy_3_EnumDecl");
-  if (!yy__(G))  goto l793;
-  if (!yymatchChar(G, ')')) goto l793;
-  goto l794;
-  l793:;	  G->pos= yypos793; G->thunkpos= yythunkpos793;
+  if (!yy__(G))  goto l797;
+  if (!yymatchChar(G, ')')) goto l797;
+  goto l798;
+  l797:;	  G->pos= yypos797; G->thunkpos= yythunkpos797;
   }
-  l794:;	  if (!yy_WS(G))  goto l790;
-  if (!yymatchChar(G, '{')) goto l790;
-  if (!yy_WS(G))  goto l790;
+  l798:;	  if (!yy_WS(G))  goto l794;
+  if (!yymatchChar(G, '{')) goto l794;
+  if (!yy_WS(G))  goto l794;
 
-  {  int yypos795= G->pos, yythunkpos795= G->thunkpos;  if (!yy_EnumElement(G))  goto l795;
-
-  l797:;	
-  {  int yypos798= G->pos, yythunkpos798= G->thunkpos;
-  {  int yypos799= G->pos, yythunkpos799= G->thunkpos;  if (!yy_Terminator(G))  goto l800;
+  {  int yypos799= G->pos, yythunkpos799= G->thunkpos;  if (!yy_EnumElement(G))  goto l799;
 
   l801:;	
-  {  int yypos802= G->pos, yythunkpos802= G->thunkpos;  if (!yy_Terminator(G))  goto l802;
-  goto l801;
-  l802:;	  G->pos= yypos802; G->thunkpos= yythunkpos802;
-  }  if (!yy_WS(G))  goto l800;
-  if (!yy_FunctionDecl(G))  goto l800;
-  goto l799;
-  l800:;	  G->pos= yypos799; G->thunkpos= yythunkpos799;
-  {  int yypos803= G->pos, yythunkpos803= G->thunkpos;  if (!yymatchChar(G, ',')) goto l804;
-  goto l803;
-  l804:;	  G->pos= yypos803; G->thunkpos= yythunkpos803;  if (!yy_Terminator(G))  goto l798;
+  {  int yypos802= G->pos, yythunkpos802= G->thunkpos;
+  {  int yypos803= G->pos, yythunkpos803= G->thunkpos;  if (!yy_Terminator(G))  goto l804;
 
   l805:;	
   {  int yypos806= G->pos, yythunkpos806= G->thunkpos;  if (!yy_Terminator(G))  goto l806;
   goto l805;
   l806:;	  G->pos= yypos806; G->thunkpos= yythunkpos806;
+  }  if (!yy_WS(G))  goto l804;
+  if (!yy_FunctionDecl(G))  goto l804;
+  goto l803;
+  l804:;	  G->pos= yypos803; G->thunkpos= yythunkpos803;
+  {  int yypos807= G->pos, yythunkpos807= G->thunkpos;  if (!yymatchChar(G, ',')) goto l808;
+  goto l807;
+  l808:;	  G->pos= yypos807; G->thunkpos= yythunkpos807;  if (!yy_Terminator(G))  goto l802;
+
+  l809:;	
+  {  int yypos810= G->pos, yythunkpos810= G->thunkpos;  if (!yy_Terminator(G))  goto l810;
+  goto l809;
+  l810:;	  G->pos= yypos810; G->thunkpos= yythunkpos810;
   }
   }
-  l803:;	  if (!yy_WS(G))  goto l798;
-  if (!yy_EnumElement(G))  goto l798;
+  l807:;	  if (!yy_WS(G))  goto l802;
+  if (!yy_EnumElement(G))  goto l802;
 
   }
-  l799:;	  goto l797;
-  l798:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;
-  }  goto l796;
-  l795:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;
+  l803:;	  goto l801;
+  l802:;	  G->pos= yypos802; G->thunkpos= yythunkpos802;
+  }  goto l800;
+  l799:;	  G->pos= yypos799; G->thunkpos= yythunkpos799;
   }
-  l796:;	  if (!yy_WS(G))  goto l790;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l790; }
+  l800:;	  if (!yy_WS(G))  goto l794;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l794; }
   yyDo(G, yy_4_EnumDecl, G->begin, G->end, "yy_4_EnumDecl");
   yyprintf((stderr, "  ok   EnumDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l790:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
+  l794:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12180,40 +12208,40 @@ YY_RULE(int) yy_EnumDecl(GREG *G)
 YY_RULE(int) yy_ExtendDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ExtendDecl"));
-  if (!yy_OocDoc(G))  goto l807;
+  if (!yy_OocDoc(G))  goto l811;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yymatchString(G, "extend")) goto l807;
-  if (!yy_WS(G))  goto l807;
-  if (!yy_Type(G))  goto l807;
+  if (!yymatchString(G, "extend")) goto l811;
+  if (!yy_WS(G))  goto l811;
+  if (!yy_Type(G))  goto l811;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ExtendDecl, G->begin, G->end, "yy_1_ExtendDecl");
-  if (!yy_WS(G))  goto l807;
-  if (!yymatchChar(G, '{')) goto l807;
-  if (!yy_WS(G))  goto l807;
+  if (!yy_WS(G))  goto l811;
+  if (!yymatchChar(G, '{')) goto l811;
+  if (!yy_WS(G))  goto l811;
 
-  l808:;	
-  {  int yypos809= G->pos, yythunkpos809= G->thunkpos;  if (!yy_WS(G))  goto l809;
+  l812:;	
+  {  int yypos813= G->pos, yythunkpos813= G->thunkpos;  if (!yy_WS(G))  goto l813;
 
-  {  int yypos810= G->pos, yythunkpos810= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l811;
+  {  int yypos814= G->pos, yythunkpos814= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l815;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l810;
-  l811:;	  G->pos= yypos810; G->thunkpos= yythunkpos810;  if (!yy_PropertyDecl(G))  goto l809;
+  goto l814;
+  l815:;	  G->pos= yypos814; G->thunkpos= yythunkpos814;  if (!yy_PropertyDecl(G))  goto l813;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ExtendDecl, G->begin, G->end, "yy_2_ExtendDecl");
 
   }
-  l810:;	  if (!yy_WS(G))  goto l809;
-  goto l808;
-  l809:;	  G->pos= yypos809; G->thunkpos= yythunkpos809;
-  }  if (!yy_WS(G))  goto l807;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l807; }
+  l814:;	  if (!yy_WS(G))  goto l813;
+  goto l812;
+  l813:;	  G->pos= yypos813; G->thunkpos= yythunkpos813;
+  }  if (!yy_WS(G))  goto l811;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l811; }
   yyDo(G, yy_3_ExtendDecl, G->begin, G->end, "yy_3_ExtendDecl");
   yyprintf((stderr, "  ok   ExtendDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l807:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
+  l811:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12222,124 +12250,124 @@ YY_RULE(int) yy_ExtendDecl(GREG *G)
 YY_RULE(int) yy_CoverDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CoverDecl"));
-  if (!yy_OocDoc(G))  goto l812;
+  if (!yy_OocDoc(G))  goto l816;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l812;
+  if (!yy_IDENT(G))  goto l816;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_CoverDecl, G->begin, G->end, "yy_1_CoverDecl");
-  if (!yy__(G))  goto l812;
-  if (!yy_COLON(G))  goto l812;
+  if (!yy__(G))  goto l816;
+  if (!yy_COLON(G))  goto l816;
 
-  {  int yypos813= G->pos, yythunkpos813= G->thunkpos;  if (!yy__(G))  goto l813;
-  if (!yy_ExternName(G))  goto l813;
+  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;  if (!yy__(G))  goto l817;
+  if (!yy_ExternName(G))  goto l817;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_2_CoverDecl, G->begin, G->end, "yy_2_CoverDecl");
-  goto l814;
-  l813:;	  G->pos= yypos813; G->thunkpos= yythunkpos813;
-  }
-  l814:;	
-  {  int yypos815= G->pos, yythunkpos815= G->thunkpos;  if (!yy__(G))  goto l815;
-  if (!yy_PROTO_KW(G))  goto l815;
-  yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
-  goto l816;
-  l815:;	  G->pos= yypos815; G->thunkpos= yythunkpos815;
-  }
-  l816:;	  if (!yy__(G))  goto l812;
-  if (!yy_COVER_KW(G))  goto l812;
-
-  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;  if (!yy_GenericArguments(G))  goto l817;
   goto l818;
   l817:;	  G->pos= yypos817; G->thunkpos= yythunkpos817;
   }
   l818:;	
-  {  int yypos819= G->pos, yythunkpos819= G->thunkpos;  if (!yy_TemplateDef(G))  goto l819;
+  {  int yypos819= G->pos, yythunkpos819= G->thunkpos;  if (!yy__(G))  goto l819;
+  if (!yy_PROTO_KW(G))  goto l819;
+  yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
   goto l820;
   l819:;	  G->pos= yypos819; G->thunkpos= yythunkpos819;
   }
-  l820:;	
-  {  int yypos821= G->pos, yythunkpos821= G->thunkpos;  if (!yy__(G))  goto l821;
-  if (!yy_FROM_KW(G))  goto l821;
-  if (!yy__(G))  goto l821;
-  if (!yy_Type(G))  goto l821;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
+  l820:;	  if (!yy__(G))  goto l816;
+  if (!yy_COVER_KW(G))  goto l816;
+
+  {  int yypos821= G->pos, yythunkpos821= G->thunkpos;  if (!yy_GenericArguments(G))  goto l821;
   goto l822;
   l821:;	  G->pos= yypos821; G->thunkpos= yythunkpos821;
   }
   l822:;	
-  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;  if (!yy__(G))  goto l823;
-  if (!yy_EXTENDS_KW(G))  goto l823;
-  if (!yy__(G))  goto l823;
-  if (!yy_Type(G))  goto l823;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
+  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;  if (!yy_TemplateDef(G))  goto l823;
   goto l824;
   l823:;	  G->pos= yypos823; G->thunkpos= yythunkpos823;
   }
   l824:;	
   {  int yypos825= G->pos, yythunkpos825= G->thunkpos;  if (!yy__(G))  goto l825;
-  if (!yy_IMPLEMENTS_KW(G))  goto l825;
+  if (!yy_FROM_KW(G))  goto l825;
   if (!yy__(G))  goto l825;
   if (!yy_Type(G))  goto l825;
   yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
-
-  l827:;	
-  {  int yypos828= G->pos, yythunkpos828= G->thunkpos;  if (!yy__(G))  goto l828;
-  if (!yymatchChar(G, ',')) goto l828;
-  if (!yy__(G))  goto l828;
-  if (!yy_Type(G))  goto l828;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
-  goto l827;
-  l828:;	  G->pos= yypos828; G->thunkpos= yythunkpos828;
-  }  goto l826;
+  yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
+  goto l826;
   l825:;	  G->pos= yypos825; G->thunkpos= yythunkpos825;
   }
   l826:;	
-  {  int yypos829= G->pos, yythunkpos829= G->thunkpos;  if (!yy_WS(G))  goto l829;
-  if (!yymatchChar(G, '{')) goto l829;
-  if (!yy_WS(G))  goto l829;
+  {  int yypos827= G->pos, yythunkpos827= G->thunkpos;  if (!yy__(G))  goto l827;
+  if (!yy_EXTENDS_KW(G))  goto l827;
+  if (!yy__(G))  goto l827;
+  if (!yy_Type(G))  goto l827;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
+  goto l828;
+  l827:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;
+  }
+  l828:;	
+  {  int yypos829= G->pos, yythunkpos829= G->thunkpos;  if (!yy__(G))  goto l829;
+  if (!yy_IMPLEMENTS_KW(G))  goto l829;
+  if (!yy__(G))  goto l829;
+  if (!yy_Type(G))  goto l829;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
 
   l831:;	
-  {  int yypos832= G->pos, yythunkpos832= G->thunkpos;  if (!yy_WS(G))  goto l832;
-
-  {  int yypos833= G->pos, yythunkpos833= G->thunkpos;  if (!yy_VariableDecl(G))  goto l834;
-  yyDo(G, yySet, -4, 0, "yySet");
-  yyDo(G, yy_8_CoverDecl, G->begin, G->end, "yy_8_CoverDecl");
-  if (!yy_Terminator(G))  goto l834;
+  {  int yypos832= G->pos, yythunkpos832= G->thunkpos;  if (!yy__(G))  goto l832;
+  if (!yymatchChar(G, ',')) goto l832;
+  if (!yy__(G))  goto l832;
+  if (!yy_Type(G))  goto l832;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
+  goto l831;
+  l832:;	  G->pos= yypos832; G->thunkpos= yythunkpos832;
+  }  goto l830;
+  l829:;	  G->pos= yypos829; G->thunkpos= yythunkpos829;
+  }
+  l830:;	
+  {  int yypos833= G->pos, yythunkpos833= G->thunkpos;  if (!yy_WS(G))  goto l833;
+  if (!yymatchChar(G, '{')) goto l833;
+  if (!yy_WS(G))  goto l833;
 
   l835:;	
-  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy_Terminator(G))  goto l836;
-  goto l835;
-  l836:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;
-  }  goto l833;
-  l834:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_PropertyDecl(G))  goto l837;
+  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy_WS(G))  goto l836;
+
+  {  int yypos837= G->pos, yythunkpos837= G->thunkpos;  if (!yy_VariableDecl(G))  goto l838;
+  yyDo(G, yySet, -4, 0, "yySet");
+  yyDo(G, yy_8_CoverDecl, G->begin, G->end, "yy_8_CoverDecl");
+  if (!yy_Terminator(G))  goto l838;
+
+  l839:;	
+  {  int yypos840= G->pos, yythunkpos840= G->thunkpos;  if (!yy_Terminator(G))  goto l840;
+  goto l839;
+  l840:;	  G->pos= yypos840; G->thunkpos= yythunkpos840;
+  }  goto l837;
+  l838:;	  G->pos= yypos837; G->thunkpos= yythunkpos837;  if (!yy_PropertyDecl(G))  goto l841;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_9_CoverDecl, G->begin, G->end, "yy_9_CoverDecl");
-  goto l833;
-  l837:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_OperatorDecl(G))  goto l838;
+  goto l837;
+  l841:;	  G->pos= yypos837; G->thunkpos= yythunkpos837;  if (!yy_OperatorDecl(G))  goto l842;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l833;
-  l838:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_FunctionDecl(G))  goto l832;
+  goto l837;
+  l842:;	  G->pos= yypos837; G->thunkpos= yythunkpos837;  if (!yy_FunctionDecl(G))  goto l836;
   yyDo(G, yySet, -1, 0, "yySet");
 
   }
-  l833:;	  if (!yy_WS(G))  goto l832;
-  goto l831;
-  l832:;	  G->pos= yypos832; G->thunkpos= yythunkpos832;
-  }  if (!yy_WS(G))  goto l829;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l829; }
-  goto l830;
-  l829:;	  G->pos= yypos829; G->thunkpos= yythunkpos829;
+  l837:;	  if (!yy_WS(G))  goto l836;
+  goto l835;
+  l836:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;
+  }  if (!yy_WS(G))  goto l833;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l833; }
+  goto l834;
+  l833:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;
   }
-  l830:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
+  l834:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
   yyprintf((stderr, "  ok   CoverDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l812:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
+  l816:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12348,110 +12376,110 @@ YY_RULE(int) yy_CoverDecl(GREG *G)
 YY_RULE(int) yy_ClassDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ClassDecl"));
-  if (!yy_OocDoc(G))  goto l839;
+  if (!yy_OocDoc(G))  goto l843;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l839;
+  if (!yy_IDENT(G))  goto l843;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_ClassDecl, G->begin, G->end, "yy_1_ClassDecl");
-  if (!yy__(G))  goto l839;
-  if (!yy_COLON(G))  goto l839;
+  if (!yy__(G))  goto l843;
+  if (!yy_COLON(G))  goto l843;
 
-  l840:;	
-  {  int yypos841= G->pos, yythunkpos841= G->thunkpos;  if (!yy__(G))  goto l841;
+  l844:;	
+  {  int yypos845= G->pos, yythunkpos845= G->thunkpos;  if (!yy__(G))  goto l845;
 
-  {  int yypos842= G->pos, yythunkpos842= G->thunkpos;  if (!yy_ExternName(G))  goto l843;
-  goto l842;
-  l843:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;  if (!yy_ABSTRACT_KW(G))  goto l844;
+  {  int yypos846= G->pos, yythunkpos846= G->thunkpos;  if (!yy_ExternName(G))  goto l847;
+  goto l846;
+  l847:;	  G->pos= yypos846; G->thunkpos= yythunkpos846;  if (!yy_ABSTRACT_KW(G))  goto l848;
   yyDo(G, yy_2_ClassDecl, G->begin, G->end, "yy_2_ClassDecl");
-  goto l842;
-  l844:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;  if (!yy_FINAL_KW(G))  goto l841;
+  goto l846;
+  l848:;	  G->pos= yypos846; G->thunkpos= yythunkpos846;  if (!yy_FINAL_KW(G))  goto l845;
   yyDo(G, yy_3_ClassDecl, G->begin, G->end, "yy_3_ClassDecl");
 
   }
-  l842:;	  goto l840;
-  l841:;	  G->pos= yypos841; G->thunkpos= yythunkpos841;
-  }  if (!yy__(G))  goto l839;
-  if (!yy_CLASS_KW(G))  goto l839;
-
-  {  int yypos845= G->pos, yythunkpos845= G->thunkpos;  if (!yy_GenericArguments(G))  goto l845;
-  goto l846;
+  l846:;	  goto l844;
   l845:;	  G->pos= yypos845; G->thunkpos= yythunkpos845;
+  }  if (!yy__(G))  goto l843;
+  if (!yy_CLASS_KW(G))  goto l843;
+
+  {  int yypos849= G->pos, yythunkpos849= G->thunkpos;  if (!yy_GenericArguments(G))  goto l849;
+  goto l850;
+  l849:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;
   }
-  l846:;	
-  {  int yypos847= G->pos, yythunkpos847= G->thunkpos;  if (!yy__(G))  goto l847;
-  if (!yy_EXTENDS_KW(G))  goto l847;
-  if (!yy__(G))  goto l847;
-  if (!yy_Type(G))  goto l847;
+  l850:;	
+  {  int yypos851= G->pos, yythunkpos851= G->thunkpos;  if (!yy__(G))  goto l851;
+  if (!yy_EXTENDS_KW(G))  goto l851;
+  if (!yy__(G))  goto l851;
+  if (!yy_Type(G))  goto l851;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_4_ClassDecl, G->begin, G->end, "yy_4_ClassDecl");
-  goto l848;
-  l847:;	  G->pos= yypos847; G->thunkpos= yythunkpos847;
+  goto l852;
+  l851:;	  G->pos= yypos851; G->thunkpos= yythunkpos851;
   }
-  l848:;	
-  {  int yypos849= G->pos, yythunkpos849= G->thunkpos;  if (!yy__(G))  goto l849;
-  if (!yy_IMPLEMENTS_KW(G))  goto l849;
-  if (!yy__(G))  goto l849;
-  if (!yy_Type(G))  goto l849;
+  l852:;	
+  {  int yypos853= G->pos, yythunkpos853= G->thunkpos;  if (!yy__(G))  goto l853;
+  if (!yy_IMPLEMENTS_KW(G))  goto l853;
+  if (!yy__(G))  goto l853;
+  if (!yy_Type(G))  goto l853;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_5_ClassDecl, G->begin, G->end, "yy_5_ClassDecl");
 
-  l851:;	
-  {  int yypos852= G->pos, yythunkpos852= G->thunkpos;  if (!yy__(G))  goto l852;
-  if (!yymatchChar(G, ',')) goto l852;
-  if (!yy__(G))  goto l852;
-  if (!yy_Type(G))  goto l852;
+  l855:;	
+  {  int yypos856= G->pos, yythunkpos856= G->thunkpos;  if (!yy__(G))  goto l856;
+  if (!yymatchChar(G, ',')) goto l856;
+  if (!yy__(G))  goto l856;
+  if (!yy_Type(G))  goto l856;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_6_ClassDecl, G->begin, G->end, "yy_6_ClassDecl");
-  goto l851;
-  l852:;	  G->pos= yypos852; G->thunkpos= yythunkpos852;
-  }  goto l850;
-  l849:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;
+  goto l855;
+  l856:;	  G->pos= yypos856; G->thunkpos= yythunkpos856;
+  }  goto l854;
+  l853:;	  G->pos= yypos853; G->thunkpos= yythunkpos853;
   }
-  l850:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
-  if (!yy_WS(G))  goto l839;
-  if (!yymatchChar(G, '{')) goto l839;
-  if (!yy_WS(G))  goto l839;
-
-  l853:;	
-  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy_WS(G))  goto l854;
-
-  {  int yypos855= G->pos, yythunkpos855= G->thunkpos;  if (!yy_VariableDecl(G))  goto l856;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_8_ClassDecl, G->begin, G->end, "yy_8_ClassDecl");
-  if (!yy_Terminator(G))  goto l856;
+  l854:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
+  if (!yy_WS(G))  goto l843;
+  if (!yymatchChar(G, '{')) goto l843;
+  if (!yy_WS(G))  goto l843;
 
   l857:;	
-  {  int yypos858= G->pos, yythunkpos858= G->thunkpos;  if (!yy_Terminator(G))  goto l858;
-  goto l857;
-  l858:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;
-  }  goto l855;
-  l856:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_PropertyDecl(G))  goto l859;
+  {  int yypos858= G->pos, yythunkpos858= G->thunkpos;  if (!yy_WS(G))  goto l858;
+
+  {  int yypos859= G->pos, yythunkpos859= G->thunkpos;  if (!yy_VariableDecl(G))  goto l860;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_8_ClassDecl, G->begin, G->end, "yy_8_ClassDecl");
+  if (!yy_Terminator(G))  goto l860;
+
+  l861:;	
+  {  int yypos862= G->pos, yythunkpos862= G->thunkpos;  if (!yy_Terminator(G))  goto l862;
+  goto l861;
+  l862:;	  G->pos= yypos862; G->thunkpos= yythunkpos862;
+  }  goto l859;
+  l860:;	  G->pos= yypos859; G->thunkpos= yythunkpos859;  if (!yy_PropertyDecl(G))  goto l863;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_9_ClassDecl, G->begin, G->end, "yy_9_ClassDecl");
-  goto l855;
-  l859:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_FunctionDecl(G))  goto l860;
+  goto l859;
+  l863:;	  G->pos= yypos859; G->thunkpos= yythunkpos859;  if (!yy_FunctionDecl(G))  goto l864;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l855;
-  l860:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_OperatorDecl(G))  goto l861;
+  goto l859;
+  l864:;	  G->pos= yypos859; G->thunkpos= yythunkpos859;  if (!yy_OperatorDecl(G))  goto l865;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l855;
-  l861:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_Stmt(G))  goto l854;
+  goto l859;
+  l865:;	  G->pos= yypos859; G->thunkpos= yythunkpos859;  if (!yy_Stmt(G))  goto l858;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ClassDecl, G->begin, G->end, "yy_10_ClassDecl");
 
   }
-  l855:;	  if (!yy_WS(G))  goto l854;
-  goto l853;
-  l854:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;
-  }  if (!yy_WS(G))  goto l839;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l839; }
+  l859:;	  if (!yy_WS(G))  goto l858;
+  goto l857;
+  l858:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;
+  }  if (!yy_WS(G))  goto l843;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l843; }
   yyDo(G, yy_11_ClassDecl, G->begin, G->end, "yy_11_ClassDecl");
   yyprintf((stderr, "  ok   ClassDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l839:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
+  l843:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12460,15 +12488,15 @@ YY_RULE(int) yy_ClassDecl(GREG *G)
 YY_RULE(int) yy_IDENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IDENT"));
-  if (!yy_IDENT_CORE(G))  goto l862;
+  if (!yy_IDENT_CORE(G))  goto l866;
   yyDo(G, yySet, 0, 0, "yySet");
-  if (!yy__(G))  goto l862;
+  if (!yy__(G))  goto l866;
   yyprintf((stderr, "  ok   IDENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l862:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
+  l866:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12476,13 +12504,13 @@ YY_RULE(int) yy_IDENT(GREG *G)
 }
 YY_RULE(int) yy_INTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTO_KW"));
-  if (!yymatchString(G, "into")) goto l863;
+  if (!yymatchString(G, "into")) goto l867;
   yyprintf((stderr, "  ok   INTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l863:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
+  l867:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12490,29 +12518,29 @@ YY_RULE(int) yy_INTO_KW(GREG *G)
 }
 YY_RULE(int) yy_ImportName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l864;
-  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l868;
-  goto l867;
-  l868:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;  if (!yymatchChar(G, '-')) goto l864;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l868;
+  {  int yypos871= G->pos, yythunkpos871= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l872;
+  goto l871;
+  l872:;	  G->pos= yypos871; G->thunkpos= yythunkpos871;  if (!yymatchChar(G, '-')) goto l868;
 
   }
-  l867:;	
-  l865:;	
-  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;
-  {  int yypos869= G->pos, yythunkpos869= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l870;
-  goto l869;
-  l870:;	  G->pos= yypos869; G->thunkpos= yythunkpos869;  if (!yymatchChar(G, '-')) goto l866;
+  l871:;	
+  l869:;	
+  {  int yypos870= G->pos, yythunkpos870= G->thunkpos;
+  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l874;
+  goto l873;
+  l874:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;  if (!yymatchChar(G, '-')) goto l870;
 
   }
-  l869:;	  goto l865;
-  l866:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l864;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
+  l873:;	  goto l869;
+  l870:;	  G->pos= yypos870; G->thunkpos= yythunkpos870;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l868;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
   yyprintf((stderr, "  ok   ImportName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l864:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
+  l868:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12520,38 +12548,38 @@ YY_RULE(int) yy_ImportName(GREG *G)
 }
 YY_RULE(int) yy_ImportPath(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportPath"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l871;
-  l872:;	
-  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;
-  {  int yypos876= G->pos, yythunkpos876= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l877;
-  goto l876;
-  l877:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yymatchChar(G, '.')) goto l878;
-  goto l876;
-  l878:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yymatchChar(G, '-')) goto l873;
-
-  }
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l875;
   l876:;	
-  l874:;	
-  {  int yypos875= G->pos, yythunkpos875= G->thunkpos;
-  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l880;
-  goto l879;
-  l880:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;  if (!yymatchChar(G, '.')) goto l881;
-  goto l879;
-  l881:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;  if (!yymatchChar(G, '-')) goto l875;
+  {  int yypos877= G->pos, yythunkpos877= G->thunkpos;
+  {  int yypos880= G->pos, yythunkpos880= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l881;
+  goto l880;
+  l881:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yymatchChar(G, '.')) goto l882;
+  goto l880;
+  l882:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;  if (!yymatchChar(G, '-')) goto l877;
 
   }
-  l879:;	  goto l874;
-  l875:;	  G->pos= yypos875; G->thunkpos= yythunkpos875;
-  }  if (!yymatchChar(G, '/')) goto l873;
-  goto l872;
-  l873:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l871;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
+  l880:;	
+  l878:;	
+  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;
+  {  int yypos883= G->pos, yythunkpos883= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l884;
+  goto l883;
+  l884:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;  if (!yymatchChar(G, '.')) goto l885;
+  goto l883;
+  l885:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;  if (!yymatchChar(G, '-')) goto l879;
+
+  }
+  l883:;	  goto l878;
+  l879:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;
+  }  if (!yymatchChar(G, '/')) goto l877;
+  goto l876;
+  l877:;	  G->pos= yypos877; G->thunkpos= yythunkpos877;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l875;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
   yyprintf((stderr, "  ok   ImportPath"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l871:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
+  l875:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12560,60 +12588,60 @@ YY_RULE(int) yy_ImportPath(GREG *G)
 YY_RULE(int) yy_ImportAtom(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImportAtom"));
-  if (!yy_ImportPath(G))  goto l882;
+  if (!yy_ImportPath(G))  goto l886;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos883= G->pos, yythunkpos883= G->thunkpos;  if (!yy_ImportName(G))  goto l884;
+  {  int yypos887= G->pos, yythunkpos887= G->thunkpos;  if (!yy_ImportName(G))  goto l888;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_ImportAtom, G->begin, G->end, "yy_1_ImportAtom");
   yyDo(G, yy_2_ImportAtom, G->begin, G->end, "yy_2_ImportAtom");
-
-  {  int yypos885= G->pos, yythunkpos885= G->thunkpos;  if (!yy__(G))  goto l885;
-  if (!yy_INTO_KW(G))  goto l885;
-  if (!yy__(G))  goto l885;
-  if (!yy_IDENT(G))  goto l885;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_3_ImportAtom, G->begin, G->end, "yy_3_ImportAtom");
-  goto l886;
-  l885:;	  G->pos= yypos885; G->thunkpos= yythunkpos885;
-  }
-  l886:;	  goto l883;
-  l884:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;  if (!yymatchChar(G, '[')) goto l882;
-  yyDo(G, yy_4_ImportAtom, G->begin, G->end, "yy_4_ImportAtom");
-
-  l887:;	
-  {  int yypos888= G->pos, yythunkpos888= G->thunkpos;  if (!yy_ImportName(G))  goto l888;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_5_ImportAtom, G->begin, G->end, "yy_5_ImportAtom");
-  if (!yy__(G))  goto l888;
-  if (!yymatchChar(G, ',')) goto l888;
-  if (!yy_WS(G))  goto l888;
-  yyDo(G, yy_6_ImportAtom, G->begin, G->end, "yy_6_ImportAtom");
-  goto l887;
-  l888:;	  G->pos= yypos888; G->thunkpos= yythunkpos888;
-  }  if (!yy_ImportName(G))  goto l882;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_7_ImportAtom, G->begin, G->end, "yy_7_ImportAtom");
-  yyDo(G, yy_8_ImportAtom, G->begin, G->end, "yy_8_ImportAtom");
-  if (!yymatchChar(G, ']')) goto l882;
 
   {  int yypos889= G->pos, yythunkpos889= G->thunkpos;  if (!yy__(G))  goto l889;
   if (!yy_INTO_KW(G))  goto l889;
   if (!yy__(G))  goto l889;
   if (!yy_IDENT(G))  goto l889;
   yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_9_ImportAtom, G->begin, G->end, "yy_9_ImportAtom");
+  yyDo(G, yy_3_ImportAtom, G->begin, G->end, "yy_3_ImportAtom");
   goto l890;
   l889:;	  G->pos= yypos889; G->thunkpos= yythunkpos889;
   }
-  l890:;	
+  l890:;	  goto l887;
+  l888:;	  G->pos= yypos887; G->thunkpos= yythunkpos887;  if (!yymatchChar(G, '[')) goto l886;
+  yyDo(G, yy_4_ImportAtom, G->begin, G->end, "yy_4_ImportAtom");
+
+  l891:;	
+  {  int yypos892= G->pos, yythunkpos892= G->thunkpos;  if (!yy_ImportName(G))  goto l892;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_5_ImportAtom, G->begin, G->end, "yy_5_ImportAtom");
+  if (!yy__(G))  goto l892;
+  if (!yymatchChar(G, ',')) goto l892;
+  if (!yy_WS(G))  goto l892;
+  yyDo(G, yy_6_ImportAtom, G->begin, G->end, "yy_6_ImportAtom");
+  goto l891;
+  l892:;	  G->pos= yypos892; G->thunkpos= yythunkpos892;
+  }  if (!yy_ImportName(G))  goto l886;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_7_ImportAtom, G->begin, G->end, "yy_7_ImportAtom");
+  yyDo(G, yy_8_ImportAtom, G->begin, G->end, "yy_8_ImportAtom");
+  if (!yymatchChar(G, ']')) goto l886;
+
+  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;  if (!yy__(G))  goto l893;
+  if (!yy_INTO_KW(G))  goto l893;
+  if (!yy__(G))  goto l893;
+  if (!yy_IDENT(G))  goto l893;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_9_ImportAtom, G->begin, G->end, "yy_9_ImportAtom");
+  goto l894;
+  l893:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;
   }
-  l883:;	  yyprintf((stderr, "  ok   ImportAtom"));
+  l894:;	
+  }
+  l887:;	  yyprintf((stderr, "  ok   ImportAtom"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l882:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
+  l886:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12621,13 +12649,13 @@ YY_RULE(int) yy_ImportAtom(GREG *G)
 }
 YY_RULE(int) yy_IMPORT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPORT_KW"));
-  if (!yymatchString(G, "import")) goto l891;
+  if (!yymatchString(G, "import")) goto l895;
   yyprintf((stderr, "  ok   IMPORT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l891:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
+  l895:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12636,38 +12664,38 @@ YY_RULE(int) yy_IMPORT_KW(GREG *G)
 YY_RULE(int) yy_DefineValue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineValue"));
 
-  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;
-  {  int yypos895= G->pos, yythunkpos895= G->thunkpos;  if (!yymatchChar(G, '=')) goto l895;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l895;
-  {  int yypos899= G->pos, yythunkpos899= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l900;
-  goto l899;
-  l900:;	  G->pos= yypos899; G->thunkpos= yythunkpos899;  if (!yymatchChar(G, '-')) goto l895;
+  {  int yypos897= G->pos, yythunkpos897= G->thunkpos;
+  {  int yypos899= G->pos, yythunkpos899= G->thunkpos;  if (!yymatchChar(G, '=')) goto l899;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l899;
+  {  int yypos903= G->pos, yythunkpos903= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l904;
+  goto l903;
+  l904:;	  G->pos= yypos903; G->thunkpos= yythunkpos903;  if (!yymatchChar(G, '-')) goto l899;
 
   }
-  l899:;	
-  l897:;	
-  {  int yypos898= G->pos, yythunkpos898= G->thunkpos;
-  {  int yypos901= G->pos, yythunkpos901= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l902;
-  goto l901;
-  l902:;	  G->pos= yypos901; G->thunkpos= yythunkpos901;  if (!yymatchChar(G, '-')) goto l898;
+  l903:;	
+  l901:;	
+  {  int yypos902= G->pos, yythunkpos902= G->thunkpos;
+  {  int yypos905= G->pos, yythunkpos905= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l906;
+  goto l905;
+  l906:;	  G->pos= yypos905; G->thunkpos= yythunkpos905;  if (!yymatchChar(G, '-')) goto l902;
 
   }
-  l901:;	  goto l897;
-  l898:;	  G->pos= yypos898; G->thunkpos= yythunkpos898;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l895;  goto l896;
-  l895:;	  G->pos= yypos895; G->thunkpos= yythunkpos895;
+  l905:;	  goto l901;
+  l902:;	  G->pos= yypos902; G->thunkpos= yythunkpos902;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l899;  goto l900;
+  l899:;	  G->pos= yypos899; G->thunkpos= yythunkpos899;
   }
-  l896:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
-  goto l893;
-  l894:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
+  l900:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
+  goto l897;
+  l898:;	  G->pos= yypos897; G->thunkpos= yythunkpos897;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
 
   }
-  l893:;	  yyprintf((stderr, "  ok   DefineValue"));
+  l897:;	  yyprintf((stderr, "  ok   DefineValue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l892:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
+  l896:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12675,29 +12703,29 @@ YY_RULE(int) yy_DefineValue(GREG *G)
 }
 YY_RULE(int) yy_DefineName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l903;
-  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l907;
-  goto l906;
-  l907:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;  if (!yymatchChar(G, '-')) goto l903;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l907;
+  {  int yypos910= G->pos, yythunkpos910= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l911;
+  goto l910;
+  l911:;	  G->pos= yypos910; G->thunkpos= yythunkpos910;  if (!yymatchChar(G, '-')) goto l907;
 
   }
-  l906:;	
-  l904:;	
-  {  int yypos905= G->pos, yythunkpos905= G->thunkpos;
-  {  int yypos908= G->pos, yythunkpos908= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l909;
-  goto l908;
-  l909:;	  G->pos= yypos908; G->thunkpos= yythunkpos908;  if (!yymatchChar(G, '-')) goto l905;
+  l910:;	
+  l908:;	
+  {  int yypos909= G->pos, yythunkpos909= G->thunkpos;
+  {  int yypos912= G->pos, yythunkpos912= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l913;
+  goto l912;
+  l913:;	  G->pos= yypos912; G->thunkpos= yythunkpos912;  if (!yymatchChar(G, '-')) goto l909;
 
   }
-  l908:;	  goto l904;
-  l905:;	  G->pos= yypos905; G->thunkpos= yythunkpos905;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l903;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
+  l912:;	  goto l908;
+  l909:;	  G->pos= yypos909; G->thunkpos= yythunkpos909;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l907;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
   yyprintf((stderr, "  ok   DefineName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l903:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
+  l907:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12706,57 +12734,57 @@ YY_RULE(int) yy_DefineName(GREG *G)
 YY_RULE(int) yy_IncludeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IncludeCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l910;
-  {  int yypos913= G->pos, yythunkpos913= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l914;
-  goto l913;
-  l914:;	  G->pos= yypos913; G->thunkpos= yythunkpos913;  if (!yymatchChar(G, '-')) goto l910;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l914;
+  {  int yypos917= G->pos, yythunkpos917= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l918;
+  goto l917;
+  l918:;	  G->pos= yypos917; G->thunkpos= yythunkpos917;  if (!yymatchChar(G, '-')) goto l914;
 
   }
-  l913:;	
-  l911:;	
-  {  int yypos912= G->pos, yythunkpos912= G->thunkpos;
-  {  int yypos915= G->pos, yythunkpos915= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l916;
-  goto l915;
-  l916:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;  if (!yymatchChar(G, '-')) goto l912;
+  l917:;	
+  l915:;	
+  {  int yypos916= G->pos, yythunkpos916= G->thunkpos;
+  {  int yypos919= G->pos, yythunkpos919= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l920;
+  goto l919;
+  l920:;	  G->pos= yypos919; G->thunkpos= yythunkpos919;  if (!yymatchChar(G, '-')) goto l916;
 
   }
-  l915:;	  goto l911;
-  l912:;	  G->pos= yypos912; G->thunkpos= yythunkpos912;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l910;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
+  l919:;	  goto l915;
+  l916:;	  G->pos= yypos916; G->thunkpos= yythunkpos916;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l914;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
 
-  {  int yypos917= G->pos, yythunkpos917= G->thunkpos;  if (!yy__(G))  goto l917;
-  if (!yymatchChar(G, '|')) goto l917;
-  if (!yy__(G))  goto l917;
-  if (!yymatchChar(G, '(')) goto l917;
-  if (!yy__(G))  goto l917;
-  if (!yy_DefineName(G))  goto l917;
+  {  int yypos921= G->pos, yythunkpos921= G->thunkpos;  if (!yy__(G))  goto l921;
+  if (!yymatchChar(G, '|')) goto l921;
+  if (!yy__(G))  goto l921;
+  if (!yymatchChar(G, '(')) goto l921;
+  if (!yy__(G))  goto l921;
+  if (!yy_DefineName(G))  goto l921;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l917;
+  if (!yy_DefineValue(G))  goto l921;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_IncludeCore, G->begin, G->end, "yy_2_IncludeCore");
 
-  l919:;	
-  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;  if (!yy__(G))  goto l920;
-  if (!yymatchChar(G, ',')) goto l920;
-  if (!yy__(G))  goto l920;
-  if (!yy_DefineName(G))  goto l920;
+  l923:;	
+  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;  if (!yy__(G))  goto l924;
+  if (!yymatchChar(G, ',')) goto l924;
+  if (!yy__(G))  goto l924;
+  if (!yy_DefineName(G))  goto l924;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l920;
+  if (!yy_DefineValue(G))  goto l924;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_IncludeCore, G->begin, G->end, "yy_3_IncludeCore");
-  goto l919;
-  l920:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;
-  }  if (!yy__(G))  goto l917;
-  if (!yymatchChar(G, ')')) goto l917;
-  goto l918;
-  l917:;	  G->pos= yypos917; G->thunkpos= yythunkpos917;
+  goto l923;
+  l924:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;
+  }  if (!yy__(G))  goto l921;
+  if (!yymatchChar(G, ')')) goto l921;
+  goto l922;
+  l921:;	  G->pos= yypos921; G->thunkpos= yythunkpos921;
   }
-  l918:;	  yyprintf((stderr, "  ok   IncludeCore"));
+  l922:;	  yyprintf((stderr, "  ok   IncludeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l910:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
+  l914:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12764,13 +12792,13 @@ YY_RULE(int) yy_IncludeCore(GREG *G)
 }
 YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INCLUDE_KW"));
-  if (!yymatchString(G, "include")) goto l921;
+  if (!yymatchString(G, "include")) goto l925;
   yyprintf((stderr, "  ok   INCLUDE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l921:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
+  l925:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12778,29 +12806,29 @@ YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 }
 YY_RULE(int) yy_UseCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UseCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l922;
-  {  int yypos925= G->pos, yythunkpos925= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l926;
-  goto l925;
-  l926:;	  G->pos= yypos925; G->thunkpos= yythunkpos925;  if (!yymatchChar(G, '-')) goto l922;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l926;
+  {  int yypos929= G->pos, yythunkpos929= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l930;
+  goto l929;
+  l930:;	  G->pos= yypos929; G->thunkpos= yythunkpos929;  if (!yymatchChar(G, '-')) goto l926;
 
   }
-  l925:;	
-  l923:;	
-  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;
-  {  int yypos927= G->pos, yythunkpos927= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l928;
-  goto l927;
-  l928:;	  G->pos= yypos927; G->thunkpos= yythunkpos927;  if (!yymatchChar(G, '-')) goto l924;
+  l929:;	
+  l927:;	
+  {  int yypos928= G->pos, yythunkpos928= G->thunkpos;
+  {  int yypos931= G->pos, yythunkpos931= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l932;
+  goto l931;
+  l932:;	  G->pos= yypos931; G->thunkpos= yythunkpos931;  if (!yymatchChar(G, '-')) goto l928;
 
   }
-  l927:;	  goto l923;
-  l924:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l922;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
+  l931:;	  goto l927;
+  l928:;	  G->pos= yypos928; G->thunkpos= yythunkpos928;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l926;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
   yyprintf((stderr, "  ok   UseCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l922:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
+  l926:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12808,13 +12836,13 @@ YY_RULE(int) yy_UseCore(GREG *G)
 }
 YY_RULE(int) yy_USE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "USE_KW"));
-  if (!yymatchString(G, "use")) goto l929;
+  if (!yymatchString(G, "use")) goto l933;
   yyprintf((stderr, "  ok   USE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l929:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
+  l933:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12822,20 +12850,20 @@ YY_RULE(int) yy_USE_KW(GREG *G)
 }
 YY_RULE(int) yy_VersionName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionName"));
-  if (!yy__(G))  goto l930;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l930;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l930;
+  if (!yy__(G))  goto l934;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l934;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l934;
 
-  l931:;	
-  {  int yypos932= G->pos, yythunkpos932= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l932;
-  goto l931;
-  l932:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l930;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
+  l935:;	
+  {  int yypos936= G->pos, yythunkpos936= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l936;
+  goto l935;
+  l936:;	  G->pos= yypos936; G->thunkpos= yythunkpos936;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l934;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
   yyprintf((stderr, "  ok   VersionName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l930:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
+  l934:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12844,11 +12872,11 @@ YY_RULE(int) yy_VersionName(GREG *G)
 YY_RULE(int) yy_VersionNegation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionNegation"));
-  if (!yy__(G))  goto l933;
-  if (!yymatchChar(G, '!')) goto l933;
+  if (!yy__(G))  goto l937;
+  if (!yymatchChar(G, '!')) goto l937;
   yyDo(G, yy_1_VersionNegation, G->begin, G->end, "yy_1_VersionNegation");
-  if (!yy__(G))  goto l933;
-  if (!yy_VersionSpec(G))  goto l933;
+  if (!yy__(G))  goto l937;
+  if (!yy_VersionSpec(G))  goto l937;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionNegation, G->begin, G->end, "yy_2_VersionNegation");
   yyprintf((stderr, "  ok   VersionNegation"));
@@ -12856,7 +12884,7 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l933:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
+  l937:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12865,17 +12893,17 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
 YY_RULE(int) yy_VersionCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionCore"));
 
-  {  int yypos935= G->pos, yythunkpos935= G->thunkpos;  if (!yy_VersionNegation(G))  goto l936;
-  goto l935;
-  l936:;	  G->pos= yypos935; G->thunkpos= yythunkpos935;  if (!yy_VersionName(G))  goto l934;
+  {  int yypos939= G->pos, yythunkpos939= G->thunkpos;  if (!yy_VersionNegation(G))  goto l940;
+  goto l939;
+  l940:;	  G->pos= yypos939; G->thunkpos= yythunkpos939;  if (!yy_VersionName(G))  goto l938;
 
   }
-  l935:;	  yyprintf((stderr, "  ok   VersionCore"));
+  l939:;	  yyprintf((stderr, "  ok   VersionCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l934:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
+  l938:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12884,52 +12912,52 @@ YY_RULE(int) yy_VersionCore(GREG *G)
 YY_RULE(int) yy_OocDocCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDocCore"));
 
-  {  int yypos938= G->pos, yythunkpos938= G->thunkpos;  if (!yymatchString(G, "/**")) goto l939;
+  {  int yypos942= G->pos, yythunkpos942= G->thunkpos;  if (!yymatchString(G, "/**")) goto l943;
 
-  {  int yypos940= G->pos, yythunkpos940= G->thunkpos;  if (!yymatchChar(G, '*')) goto l940;
-  goto l939;
-  l940:;	  G->pos= yypos940; G->thunkpos= yythunkpos940;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l939;
-  l941:;	
-  {  int yypos942= G->pos, yythunkpos942= G->thunkpos;
-  {  int yypos943= G->pos, yythunkpos943= G->thunkpos;  if (!yymatchString(G, "*/")) goto l943;
-  goto l942;
-  l943:;	  G->pos= yypos943; G->thunkpos= yythunkpos943;
+  {  int yypos944= G->pos, yythunkpos944= G->thunkpos;  if (!yymatchChar(G, '*')) goto l944;
+  goto l943;
+  l944:;	  G->pos= yypos944; G->thunkpos= yythunkpos944;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l943;
+  l945:;	
+  {  int yypos946= G->pos, yythunkpos946= G->thunkpos;
+  {  int yypos947= G->pos, yythunkpos947= G->thunkpos;  if (!yymatchString(G, "*/")) goto l947;
+  goto l946;
+  l947:;	  G->pos= yypos947; G->thunkpos= yythunkpos947;
   }
-  {  int yypos944= G->pos, yythunkpos944= G->thunkpos;  if (!yy_EOL(G))  goto l945;
-  goto l944;
-  l945:;	  G->pos= yypos944; G->thunkpos= yythunkpos944;  if (!yymatchDot(G)) goto l942;
-  }
-  l944:;	  goto l941;
-  l942:;	  G->pos= yypos942; G->thunkpos= yythunkpos942;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l939;  if (!yymatchString(G, "*/")) goto l939;
-  yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
-  if (!yy_WS(G))  goto l939;
-  goto l938;
-  l939:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;  if (!yymatchString(G, "///")) goto l937;
-
-  {  int yypos946= G->pos, yythunkpos946= G->thunkpos;  if (!yymatchChar(G, '/')) goto l946;
-  goto l937;
-  l946:;	  G->pos= yypos946; G->thunkpos= yythunkpos946;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l937;
-  l947:;	
-  {  int yypos948= G->pos, yythunkpos948= G->thunkpos;
-  {  int yypos949= G->pos, yythunkpos949= G->thunkpos;  if (!yy_EOL(G))  goto l949;
+  {  int yypos948= G->pos, yythunkpos948= G->thunkpos;  if (!yy_EOL(G))  goto l949;
   goto l948;
-  l949:;	  G->pos= yypos949; G->thunkpos= yythunkpos949;
-  }  if (!yymatchDot(G)) goto l948;  goto l947;
-  l948:;	  G->pos= yypos948; G->thunkpos= yythunkpos948;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l937;  if (!yy_EOL(G))  goto l937;
+  l949:;	  G->pos= yypos948; G->thunkpos= yythunkpos948;  if (!yymatchDot(G)) goto l946;
+  }
+  l948:;	  goto l945;
+  l946:;	  G->pos= yypos946; G->thunkpos= yythunkpos946;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l943;  if (!yymatchString(G, "*/")) goto l943;
+  yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
+  if (!yy_WS(G))  goto l943;
+  goto l942;
+  l943:;	  G->pos= yypos942; G->thunkpos= yythunkpos942;  if (!yymatchString(G, "///")) goto l941;
+
+  {  int yypos950= G->pos, yythunkpos950= G->thunkpos;  if (!yymatchChar(G, '/')) goto l950;
+  goto l941;
+  l950:;	  G->pos= yypos950; G->thunkpos= yythunkpos950;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l941;
+  l951:;	
+  {  int yypos952= G->pos, yythunkpos952= G->thunkpos;
+  {  int yypos953= G->pos, yythunkpos953= G->thunkpos;  if (!yy_EOL(G))  goto l953;
+  goto l952;
+  l953:;	  G->pos= yypos953; G->thunkpos= yythunkpos953;
+  }  if (!yymatchDot(G)) goto l952;  goto l951;
+  l952:;	  G->pos= yypos952; G->thunkpos= yythunkpos952;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l941;  if (!yy_EOL(G))  goto l941;
   yyDo(G, yy_2_OocDocCore, G->begin, G->end, "yy_2_OocDocCore");
-  if (!yy_WS(G))  goto l937;
+  if (!yy_WS(G))  goto l941;
 
   }
-  l938:;	  yyprintf((stderr, "  ok   OocDocCore"));
+  l942:;	  yyprintf((stderr, "  ok   OocDocCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l937:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
+  l941:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12939,39 +12967,39 @@ YY_RULE(int) yy_Decl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Decl"));
 
-  {  int yypos951= G->pos, yythunkpos951= G->thunkpos;  if (!yy_ClassDecl(G))  goto l952;
-  goto l951;
-  l952:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_CoverDecl(G))  goto l953;
-  goto l951;
-  l953:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_ExtendDecl(G))  goto l954;
-  goto l951;
-  l954:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_EnumDecl(G))  goto l955;
-  goto l951;
-  l955:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_InterfaceDecl(G))  goto l956;
-  goto l951;
-  l956:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_OperatorDecl(G))  goto l957;
-  goto l951;
-  l957:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_FunctionDecl(G))  goto l958;
-  goto l951;
-  l958:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_PropertyDecl(G))  goto l959;
-  goto l951;
-  l959:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_VariableDecl(G))  goto l950;
+  {  int yypos955= G->pos, yythunkpos955= G->thunkpos;  if (!yy_ClassDecl(G))  goto l956;
+  goto l955;
+  l956:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_CoverDecl(G))  goto l957;
+  goto l955;
+  l957:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_ExtendDecl(G))  goto l958;
+  goto l955;
+  l958:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_EnumDecl(G))  goto l959;
+  goto l955;
+  l959:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_InterfaceDecl(G))  goto l960;
+  goto l955;
+  l960:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_OperatorDecl(G))  goto l961;
+  goto l955;
+  l961:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_FunctionDecl(G))  goto l962;
+  goto l955;
+  l962:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_PropertyDecl(G))  goto l963;
+  goto l955;
+  l963:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;  if (!yy_VariableDecl(G))  goto l954;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_Terminator(G))  goto l950;
+  if (!yy_Terminator(G))  goto l954;
 
-  l960:;	
-  {  int yypos961= G->pos, yythunkpos961= G->thunkpos;  if (!yy_Terminator(G))  goto l961;
-  goto l960;
-  l961:;	  G->pos= yypos961; G->thunkpos= yythunkpos961;
+  l964:;	
+  {  int yypos965= G->pos, yythunkpos965= G->thunkpos;  if (!yy_Terminator(G))  goto l965;
+  goto l964;
+  l965:;	  G->pos= yypos965; G->thunkpos= yythunkpos965;
   }  yyDo(G, yy_1_Decl, G->begin, G->end, "yy_1_Decl");
 
   }
-  l951:;	  yyprintf((stderr, "  ok   Decl"));
+  l955:;	  yyprintf((stderr, "  ok   Decl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l950:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
+  l954:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12979,24 +13007,24 @@ YY_RULE(int) yy_Decl(GREG *G)
 }
 YY_RULE(int) yy_Use(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Use"));
-  if (!yy_USE_KW(G))  goto l962;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l962;
-  if (!yy__(G))  goto l962;
-  if (!yy_UseCore(G))  goto l962;
+  if (!yy_USE_KW(G))  goto l966;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l966;
+  if (!yy__(G))  goto l966;
+  if (!yy_UseCore(G))  goto l966;
 
-  l963:;	
-  {  int yypos964= G->pos, yythunkpos964= G->thunkpos;  if (!yy__(G))  goto l964;
-  if (!yymatchChar(G, ',')) goto l964;
-  if (!yy__(G))  goto l964;
-  if (!yy_UseCore(G))  goto l964;
-  goto l963;
-  l964:;	  G->pos= yypos964; G->thunkpos= yythunkpos964;
+  l967:;	
+  {  int yypos968= G->pos, yythunkpos968= G->thunkpos;  if (!yy__(G))  goto l968;
+  if (!yymatchChar(G, ',')) goto l968;
+  if (!yy__(G))  goto l968;
+  if (!yy_UseCore(G))  goto l968;
+  goto l967;
+  l968:;	  G->pos= yypos968; G->thunkpos= yythunkpos968;
   }  yyprintf((stderr, "  ok   Use"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l962:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
+  l966:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13004,24 +13032,24 @@ YY_RULE(int) yy_Use(GREG *G)
 }
 YY_RULE(int) yy_Import(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Import"));
-  if (!yy_IMPORT_KW(G))  goto l965;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l965;
-  if (!yy__(G))  goto l965;
-  if (!yy_ImportAtom(G))  goto l965;
+  if (!yy_IMPORT_KW(G))  goto l969;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l969;
+  if (!yy__(G))  goto l969;
+  if (!yy_ImportAtom(G))  goto l969;
 
-  l966:;	
-  {  int yypos967= G->pos, yythunkpos967= G->thunkpos;  if (!yymatchChar(G, ',')) goto l967;
-  if (!yy_WS(G))  goto l967;
-  if (!yy__(G))  goto l967;
-  if (!yy_ImportAtom(G))  goto l967;
-  goto l966;
-  l967:;	  G->pos= yypos967; G->thunkpos= yythunkpos967;
+  l970:;	
+  {  int yypos971= G->pos, yythunkpos971= G->thunkpos;  if (!yymatchChar(G, ',')) goto l971;
+  if (!yy_WS(G))  goto l971;
+  if (!yy__(G))  goto l971;
+  if (!yy_ImportAtom(G))  goto l971;
+  goto l970;
+  l971:;	  G->pos= yypos971; G->thunkpos= yythunkpos971;
   }  yyprintf((stderr, "  ok   Import"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l965:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
+  l969:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13029,24 +13057,24 @@ YY_RULE(int) yy_Import(GREG *G)
 }
 YY_RULE(int) yy_Include(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Include"));
-  if (!yy_INCLUDE_KW(G))  goto l968;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l968;
-  if (!yy__(G))  goto l968;
-  if (!yy_IncludeCore(G))  goto l968;
+  if (!yy_INCLUDE_KW(G))  goto l972;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l972;
+  if (!yy__(G))  goto l972;
+  if (!yy_IncludeCore(G))  goto l972;
 
-  l969:;	
-  {  int yypos970= G->pos, yythunkpos970= G->thunkpos;  if (!yy__(G))  goto l970;
-  if (!yymatchChar(G, ',')) goto l970;
-  if (!yy__(G))  goto l970;
-  if (!yy_IncludeCore(G))  goto l970;
-  goto l969;
-  l970:;	  G->pos= yypos970; G->thunkpos= yythunkpos970;
+  l973:;	
+  {  int yypos974= G->pos, yythunkpos974= G->thunkpos;  if (!yy__(G))  goto l974;
+  if (!yymatchChar(G, ',')) goto l974;
+  if (!yy__(G))  goto l974;
+  if (!yy_IncludeCore(G))  goto l974;
+  goto l973;
+  l974:;	  G->pos= yypos974; G->thunkpos= yythunkpos974;
   }  yyprintf((stderr, "  ok   Include"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l968:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
+  l972:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13056,120 +13084,120 @@ YY_RULE(int) yy_Stmt(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Stmt"));
 
-  {  int yypos972= G->pos, yythunkpos972= G->thunkpos;  if (!yy_Old(G))  goto l973;
+  {  int yypos976= G->pos, yythunkpos976= G->thunkpos;  if (!yy_Old(G))  goto l977;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l973;
-  if (!yymatchString(G, "version")) goto l973;
+  if (!yy_WS(G))  goto l977;
+  if (!yymatchString(G, "version")) goto l977;
   yyDo(G, yy_1_Stmt, G->begin, G->end, "yy_1_Stmt");
-  if (!yy_WS(G))  goto l973;
-  if (!yymatchChar(G, '(')) goto l973;
-  if (!yy__(G))  goto l973;
-  if (!yy_VersionSpec(G))  goto l973;
+  if (!yy_WS(G))  goto l977;
+  if (!yymatchChar(G, '(')) goto l977;
+  if (!yy__(G))  goto l977;
+  if (!yy_VersionSpec(G))  goto l977;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_WS(G))  goto l973;
-  if (!yymatchChar(G, ')')) goto l973;
+  if (!yy_WS(G))  goto l977;
+  if (!yymatchChar(G, ')')) goto l977;
 
-  {  int yypos974= G->pos, yythunkpos974= G->thunkpos;  if (!yy__(G))  goto l975;
-  if (!yymatchChar(G, '{')) goto l975;
+  {  int yypos978= G->pos, yythunkpos978= G->thunkpos;  if (!yy__(G))  goto l979;
+  if (!yymatchChar(G, '{')) goto l979;
   yyDo(G, yy_2_Stmt, G->begin, G->end, "yy_2_Stmt");
-  if (!yy_WS(G))  goto l975;
+  if (!yy_WS(G))  goto l979;
 
-  l976:;	
-  {  int yypos977= G->pos, yythunkpos977= G->thunkpos;  if (!yy_Stmt(G))  goto l977;
+  l980:;	
+  {  int yypos981= G->pos, yythunkpos981= G->thunkpos;  if (!yy_Stmt(G))  goto l981;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_Stmt, G->begin, G->end, "yy_3_Stmt");
-  goto l976;
-  l977:;	  G->pos= yypos977; G->thunkpos= yythunkpos977;
-  }  if (!yy_WS(G))  goto l975;
-  if (!yy__(G))  goto l975;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l975; }
+  goto l980;
+  l981:;	  G->pos= yypos981; G->thunkpos= yythunkpos981;
+  }  if (!yy_WS(G))  goto l979;
+  if (!yy__(G))  goto l979;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l979; }
   yyDo(G, yy_4_Stmt, G->begin, G->end, "yy_4_Stmt");
-  goto l974;
-  l975:;	  G->pos= yypos974; G->thunkpos= yythunkpos974;  if (!yy__(G))  goto l973;
-  if (!yy_Stmt(G))  goto l973;
+  goto l978;
+  l979:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy__(G))  goto l977;
+  if (!yy_Stmt(G))  goto l977;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_5_Stmt, G->begin, G->end, "yy_5_Stmt");
 
   }
-  l974:;	
   l978:;	
-  {  int yypos979= G->pos, yythunkpos979= G->thunkpos;  if (!yy_WS(G))  goto l979;
-  if (!yymatchString(G, "else")) goto l979;
-  if (!yy__(G))  goto l979;
-  if (!yymatchString(G, "version")) goto l979;
-  yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
-  if (!yy_WS(G))  goto l979;
-  if (!yymatchChar(G, '(')) goto l979;
-  if (!yy__(G))  goto l979;
-  if (!yy_VersionSpec(G))  goto l979;
-  yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l979;
-  if (!yymatchChar(G, ')')) goto l979;
-
-  {  int yypos980= G->pos, yythunkpos980= G->thunkpos;  if (!yy__(G))  goto l981;
-  if (!yymatchChar(G, '{')) goto l981;
-  yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
-  if (!yy_WS(G))  goto l981;
-
   l982:;	
-  {  int yypos983= G->pos, yythunkpos983= G->thunkpos;  if (!yy_Stmt(G))  goto l983;
+  {  int yypos983= G->pos, yythunkpos983= G->thunkpos;  if (!yy_WS(G))  goto l983;
+  if (!yymatchString(G, "else")) goto l983;
+  if (!yy__(G))  goto l983;
+  if (!yymatchString(G, "version")) goto l983;
+  yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
+  if (!yy_WS(G))  goto l983;
+  if (!yymatchChar(G, '(')) goto l983;
+  if (!yy__(G))  goto l983;
+  if (!yy_VersionSpec(G))  goto l983;
+  yyDo(G, yySet, -1, 0, "yySet");
+  if (!yy_WS(G))  goto l983;
+  if (!yymatchChar(G, ')')) goto l983;
+
+  {  int yypos984= G->pos, yythunkpos984= G->thunkpos;  if (!yy__(G))  goto l985;
+  if (!yymatchChar(G, '{')) goto l985;
+  yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
+  if (!yy_WS(G))  goto l985;
+
+  l986:;	
+  {  int yypos987= G->pos, yythunkpos987= G->thunkpos;  if (!yy_Stmt(G))  goto l987;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_8_Stmt, G->begin, G->end, "yy_8_Stmt");
-  goto l982;
-  l983:;	  G->pos= yypos983; G->thunkpos= yythunkpos983;
-  }  if (!yy_WS(G))  goto l981;
-  if (!yy__(G))  goto l981;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l981; }
+  goto l986;
+  l987:;	  G->pos= yypos987; G->thunkpos= yythunkpos987;
+  }  if (!yy_WS(G))  goto l985;
+  if (!yy__(G))  goto l985;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l985; }
   yyDo(G, yy_9_Stmt, G->begin, G->end, "yy_9_Stmt");
-  goto l980;
-  l981:;	  G->pos= yypos980; G->thunkpos= yythunkpos980;  if (!yy__(G))  goto l979;
-  if (!yy_Stmt(G))  goto l979;
+  goto l984;
+  l985:;	  G->pos= yypos984; G->thunkpos= yythunkpos984;  if (!yy__(G))  goto l983;
+  if (!yy_Stmt(G))  goto l983;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_10_Stmt, G->begin, G->end, "yy_10_Stmt");
 
   }
-  l980:;	  goto l978;
-  l979:;	  G->pos= yypos979; G->thunkpos= yythunkpos979;
+  l984:;	  goto l982;
+  l983:;	  G->pos= yypos983; G->thunkpos= yythunkpos983;
   }
-  {  int yypos984= G->pos, yythunkpos984= G->thunkpos;  if (!yy_WS(G))  goto l984;
-  if (!yymatchString(G, "else")) goto l984;
+  {  int yypos988= G->pos, yythunkpos988= G->thunkpos;  if (!yy_WS(G))  goto l988;
+  if (!yymatchString(G, "else")) goto l988;
   yyDo(G, yy_11_Stmt, G->begin, G->end, "yy_11_Stmt");
 
-  {  int yypos986= G->pos, yythunkpos986= G->thunkpos;  if (!yy__(G))  goto l987;
-  if (!yymatchChar(G, '{')) goto l987;
+  {  int yypos990= G->pos, yythunkpos990= G->thunkpos;  if (!yy__(G))  goto l991;
+  if (!yymatchChar(G, '{')) goto l991;
   yyDo(G, yy_12_Stmt, G->begin, G->end, "yy_12_Stmt");
-  if (!yy_WS(G))  goto l987;
+  if (!yy_WS(G))  goto l991;
 
-  l988:;	
-  {  int yypos989= G->pos, yythunkpos989= G->thunkpos;  if (!yy_Stmt(G))  goto l989;
+  l992:;	
+  {  int yypos993= G->pos, yythunkpos993= G->thunkpos;  if (!yy_Stmt(G))  goto l993;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_13_Stmt, G->begin, G->end, "yy_13_Stmt");
-  goto l988;
-  l989:;	  G->pos= yypos989; G->thunkpos= yythunkpos989;
-  }  if (!yy_WS(G))  goto l987;
-  if (!yy__(G))  goto l987;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l987; }
+  goto l992;
+  l993:;	  G->pos= yypos993; G->thunkpos= yythunkpos993;
+  }  if (!yy_WS(G))  goto l991;
+  if (!yy__(G))  goto l991;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l991; }
   yyDo(G, yy_14_Stmt, G->begin, G->end, "yy_14_Stmt");
-  goto l986;
-  l987:;	  G->pos= yypos986; G->thunkpos= yythunkpos986;  if (!yy__(G))  goto l984;
-  if (!yy_Stmt(G))  goto l984;
+  goto l990;
+  l991:;	  G->pos= yypos990; G->thunkpos= yythunkpos990;  if (!yy__(G))  goto l988;
+  if (!yy_Stmt(G))  goto l988;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_15_Stmt, G->begin, G->end, "yy_15_Stmt");
 
   }
-  l986:;	  goto l985;
-  l984:;	  G->pos= yypos984; G->thunkpos= yythunkpos984;
+  l990:;	  goto l989;
+  l988:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;
   }
-  l985:;	  goto l972;
-  l973:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_StmtCore(G))  goto l971;
+  l989:;	  goto l976;
+  l977:;	  G->pos= yypos976; G->thunkpos= yythunkpos976;  if (!yy_StmtCore(G))  goto l975;
 
   }
-  l972:;	  yyprintf((stderr, "  ok   Stmt"));
+  l976:;	  yyprintf((stderr, "  ok   Stmt"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l971:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
+  l975:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13177,13 +13205,13 @@ YY_RULE(int) yy_Stmt(GREG *G)
 }
 YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_BRACK"));
-  if (!yymatchChar(G, '}')) goto l990;
+  if (!yymatchChar(G, '}')) goto l994;
   yyprintf((stderr, "  ok   CLOS_BRACK"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l990:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
+  l994:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13191,13 +13219,13 @@ YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 }
 YY_RULE(int) yy_CLOS_PAREN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_PAREN"));
-  if (!yymatchChar(G, ')')) goto l991;
+  if (!yymatchChar(G, ')')) goto l995;
   yyprintf((stderr, "  ok   CLOS_PAREN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l991:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
+  l995:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13207,46 +13235,46 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionSpec"));
 
-  {  int yypos993= G->pos, yythunkpos993= G->thunkpos;  if (!yy__(G))  goto l994;
-  if (!yymatchChar(G, '(')) goto l994;
-  if (!yy__(G))  goto l994;
-  if (!yy_VersionSpec(G))  goto l994;
+  {  int yypos997= G->pos, yythunkpos997= G->thunkpos;  if (!yy__(G))  goto l998;
+  if (!yymatchChar(G, '(')) goto l998;
+  if (!yy__(G))  goto l998;
+  if (!yy_VersionSpec(G))  goto l998;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l994;
-  if (!yymatchChar(G, ')')) goto l994;
-  goto l993;
-  l994:;	  G->pos= yypos993; G->thunkpos= yythunkpos993;  if (!yy_VersionCore(G))  goto l992;
+  if (!yy__(G))  goto l998;
+  if (!yymatchChar(G, ')')) goto l998;
+  goto l997;
+  l998:;	  G->pos= yypos997; G->thunkpos= yythunkpos997;  if (!yy_VersionCore(G))  goto l996;
   yyDo(G, yySet, -2, 0, "yySet");
 
   }
-  l993:;	
-  l995:;	
-  {  int yypos996= G->pos, yythunkpos996= G->thunkpos;
-  {  int yypos997= G->pos, yythunkpos997= G->thunkpos;  if (!yy__(G))  goto l998;
-  if (!yymatchString(G, "&&")) goto l998;
+  l997:;	
+  l999:;	
+  {  int yypos1000= G->pos, yythunkpos1000= G->thunkpos;
+  {  int yypos1001= G->pos, yythunkpos1001= G->thunkpos;  if (!yy__(G))  goto l1002;
+  if (!yymatchString(G, "&&")) goto l1002;
   yyDo(G, yy_1_VersionSpec, G->begin, G->end, "yy_1_VersionSpec");
-  if (!yy__(G))  goto l998;
-  if (!yy_VersionSpec(G))  goto l998;
+  if (!yy__(G))  goto l1002;
+  if (!yy_VersionSpec(G))  goto l1002;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionSpec, G->begin, G->end, "yy_2_VersionSpec");
-  goto l997;
-  l998:;	  G->pos= yypos997; G->thunkpos= yythunkpos997;  if (!yy__(G))  goto l996;
-  if (!yymatchString(G, "||")) goto l996;
+  goto l1001;
+  l1002:;	  G->pos= yypos1001; G->thunkpos= yythunkpos1001;  if (!yy__(G))  goto l1000;
+  if (!yymatchString(G, "||")) goto l1000;
   yyDo(G, yy_3_VersionSpec, G->begin, G->end, "yy_3_VersionSpec");
-  if (!yy__(G))  goto l996;
-  if (!yy_VersionSpec(G))  goto l996;
+  if (!yy__(G))  goto l1000;
+  if (!yy_VersionSpec(G))  goto l1000;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_VersionSpec, G->begin, G->end, "yy_4_VersionSpec");
 
   }
-  l997:;	  goto l995;
-  l996:;	  G->pos= yypos996; G->thunkpos= yythunkpos996;
+  l1001:;	  goto l999;
+  l1000:;	  G->pos= yypos1000; G->thunkpos= yythunkpos1000;
   }  yyprintf((stderr, "  ok   VersionSpec"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l992:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
+  l996:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13255,15 +13283,15 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 YY_RULE(int) yy__(GREG *G)
 {  yyprintfv((stderr, "%s\n", "_"));
 
-  l1000:;	
-  {  int yypos1001= G->pos, yythunkpos1001= G->thunkpos;
-  {  int yypos1002= G->pos, yythunkpos1002= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1003;
-  goto l1002;
-  l1003:;	  G->pos= yypos1002; G->thunkpos= yythunkpos1002;  if (!yy_CommentMultiLine(G))  goto l1001;
+  l1004:;	
+  {  int yypos1005= G->pos, yythunkpos1005= G->thunkpos;
+  {  int yypos1006= G->pos, yythunkpos1006= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1007;
+  goto l1006;
+  l1007:;	  G->pos= yypos1006; G->thunkpos= yythunkpos1006;  if (!yy_CommentMultiLine(G))  goto l1005;
 
   }
-  l1002:;	  goto l1000;
-  l1001:;	  G->pos= yypos1001; G->thunkpos= yythunkpos1001;
+  l1006:;	  goto l1004;
+  l1005:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;
   }  yyprintf((stderr, "  ok   _"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13273,20 +13301,20 @@ YY_RULE(int) yy__(GREG *G)
 YY_RULE(int) yy_EOL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EOL"));
 
-  {  int yypos1005= G->pos, yythunkpos1005= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1006;
-  goto l1005;
-  l1006:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yymatchString(G, "\r\n")) goto l1007;
-  goto l1005;
-  l1007:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yymatchChar(G, '\r')) goto l1004;
+  {  int yypos1009= G->pos, yythunkpos1009= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1010;
+  goto l1009;
+  l1010:;	  G->pos= yypos1009; G->thunkpos= yythunkpos1009;  if (!yymatchString(G, "\r\n")) goto l1011;
+  goto l1009;
+  l1011:;	  G->pos= yypos1009; G->thunkpos= yythunkpos1009;  if (!yymatchChar(G, '\r')) goto l1008;
 
   }
-  l1005:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
+  l1009:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
   yyprintf((stderr, "  ok   EOL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1004:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
+  l1008:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13295,17 +13323,17 @@ YY_RULE(int) yy_EOL(GREG *G)
 YY_RULE(int) yy_WS(GREG *G)
 {  yyprintfv((stderr, "%s\n", "WS"));
 
-  l1009:;	
-  {  int yypos1010= G->pos, yythunkpos1010= G->thunkpos;
-  {  int yypos1011= G->pos, yythunkpos1011= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1012;
-  goto l1011;
-  l1012:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy_Comment(G))  goto l1013;
-  goto l1011;
-  l1013:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy_EOL(G))  goto l1010;
+  l1013:;	
+  {  int yypos1014= G->pos, yythunkpos1014= G->thunkpos;
+  {  int yypos1015= G->pos, yythunkpos1015= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1016;
+  goto l1015;
+  l1016:;	  G->pos= yypos1015; G->thunkpos= yythunkpos1015;  if (!yy_Comment(G))  goto l1017;
+  goto l1015;
+  l1017:;	  G->pos= yypos1015; G->thunkpos= yythunkpos1015;  if (!yy_EOL(G))  goto l1014;
 
   }
-  l1011:;	  goto l1009;
-  l1010:;	  G->pos= yypos1010; G->thunkpos= yythunkpos1010;
+  l1015:;	  goto l1013;
+  l1014:;	  G->pos= yypos1014; G->thunkpos= yythunkpos1014;
   }  yyprintf((stderr, "  ok   WS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13316,140 +13344,140 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ModuleCore"));
 
-  {  int yypos1015= G->pos, yythunkpos1015= G->thunkpos;  if (!yy_WS(G))  goto l1016;
-  if (!yymatchString(G, "version")) goto l1016;
+  {  int yypos1019= G->pos, yythunkpos1019= G->thunkpos;  if (!yy_WS(G))  goto l1020;
+  if (!yymatchString(G, "version")) goto l1020;
   yyDo(G, yy_1_ModuleCore, G->begin, G->end, "yy_1_ModuleCore");
-  if (!yy_WS(G))  goto l1016;
-  if (!yymatchChar(G, '(')) goto l1016;
-  if (!yy__(G))  goto l1016;
-  if (!yy_VersionSpec(G))  goto l1016;
+  if (!yy_WS(G))  goto l1020;
+  if (!yymatchChar(G, '(')) goto l1020;
+  if (!yy__(G))  goto l1020;
+  if (!yy_VersionSpec(G))  goto l1020;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l1016;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1016; }
+  if (!yy_WS(G))  goto l1020;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1020; }
 
-  {  int yypos1017= G->pos, yythunkpos1017= G->thunkpos;  if (!yy__(G))  goto l1018;
-  if (!yymatchChar(G, '{')) goto l1018;
+  {  int yypos1021= G->pos, yythunkpos1021= G->thunkpos;  if (!yy__(G))  goto l1022;
+  if (!yymatchChar(G, '{')) goto l1022;
   yyDo(G, yy_2_ModuleCore, G->begin, G->end, "yy_2_ModuleCore");
-  if (!yy_WS(G))  goto l1018;
+  if (!yy_WS(G))  goto l1022;
 
-  l1019:;	
-  {  int yypos1020= G->pos, yythunkpos1020= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1020;
-  goto l1019;
-  l1020:;	  G->pos= yypos1020; G->thunkpos= yythunkpos1020;
-  }  if (!yy_WS(G))  goto l1018;
-  if (!yy__(G))  goto l1018;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1018; }
+  l1023:;	
+  {  int yypos1024= G->pos, yythunkpos1024= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1024;
+  goto l1023;
+  l1024:;	  G->pos= yypos1024; G->thunkpos= yythunkpos1024;
+  }  if (!yy_WS(G))  goto l1022;
+  if (!yy__(G))  goto l1022;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1022; }
   yyDo(G, yy_3_ModuleCore, G->begin, G->end, "yy_3_ModuleCore");
-  goto l1017;
-  l1018:;	  G->pos= yypos1017; G->thunkpos= yythunkpos1017;  if (!yy__(G))  goto l1016;
-  if (!yy_Stmt(G))  goto l1016;
+  goto l1021;
+  l1022:;	  G->pos= yypos1021; G->thunkpos= yythunkpos1021;  if (!yy__(G))  goto l1020;
+  if (!yy_Stmt(G))  goto l1020;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_4_ModuleCore, G->begin, G->end, "yy_4_ModuleCore");
 
   }
-  l1017:;	
   l1021:;	
-  {  int yypos1022= G->pos, yythunkpos1022= G->thunkpos;  if (!yy_WS(G))  goto l1022;
-  if (!yymatchString(G, "else")) goto l1022;
-  if (!yy__(G))  goto l1022;
-  if (!yymatchString(G, "version")) goto l1022;
-  yyDo(G, yy_5_ModuleCore, G->begin, G->end, "yy_5_ModuleCore");
-  if (!yy_WS(G))  goto l1022;
-  if (!yymatchChar(G, '(')) goto l1022;
-  if (!yy__(G))  goto l1022;
-  if (!yy_VersionSpec(G))  goto l1022;
-  yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l1022;
-  if (!yymatchChar(G, ')')) goto l1022;
-
-  {  int yypos1023= G->pos, yythunkpos1023= G->thunkpos;  if (!yy__(G))  goto l1024;
-  if (!yymatchChar(G, '{')) goto l1024;
-  yyDo(G, yy_6_ModuleCore, G->begin, G->end, "yy_6_ModuleCore");
-  if (!yy_WS(G))  goto l1024;
-
   l1025:;	
-  {  int yypos1026= G->pos, yythunkpos1026= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1026;
-  goto l1025;
-  l1026:;	  G->pos= yypos1026; G->thunkpos= yythunkpos1026;
-  }  if (!yy_WS(G))  goto l1024;
-  if (!yy__(G))  goto l1024;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1024; }
+  {  int yypos1026= G->pos, yythunkpos1026= G->thunkpos;  if (!yy_WS(G))  goto l1026;
+  if (!yymatchString(G, "else")) goto l1026;
+  if (!yy__(G))  goto l1026;
+  if (!yymatchString(G, "version")) goto l1026;
+  yyDo(G, yy_5_ModuleCore, G->begin, G->end, "yy_5_ModuleCore");
+  if (!yy_WS(G))  goto l1026;
+  if (!yymatchChar(G, '(')) goto l1026;
+  if (!yy__(G))  goto l1026;
+  if (!yy_VersionSpec(G))  goto l1026;
+  yyDo(G, yySet, -2, 0, "yySet");
+  if (!yy_WS(G))  goto l1026;
+  if (!yymatchChar(G, ')')) goto l1026;
+
+  {  int yypos1027= G->pos, yythunkpos1027= G->thunkpos;  if (!yy__(G))  goto l1028;
+  if (!yymatchChar(G, '{')) goto l1028;
+  yyDo(G, yy_6_ModuleCore, G->begin, G->end, "yy_6_ModuleCore");
+  if (!yy_WS(G))  goto l1028;
+
+  l1029:;	
+  {  int yypos1030= G->pos, yythunkpos1030= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1030;
+  goto l1029;
+  l1030:;	  G->pos= yypos1030; G->thunkpos= yythunkpos1030;
+  }  if (!yy_WS(G))  goto l1028;
+  if (!yy__(G))  goto l1028;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1028; }
   yyDo(G, yy_7_ModuleCore, G->begin, G->end, "yy_7_ModuleCore");
-  goto l1023;
-  l1024:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;  if (!yy__(G))  goto l1022;
-  if (!yy_Stmt(G))  goto l1022;
+  goto l1027;
+  l1028:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;  if (!yy__(G))  goto l1026;
+  if (!yy_Stmt(G))  goto l1026;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_8_ModuleCore, G->begin, G->end, "yy_8_ModuleCore");
 
   }
-  l1023:;	  goto l1021;
-  l1022:;	  G->pos= yypos1022; G->thunkpos= yythunkpos1022;
+  l1027:;	  goto l1025;
+  l1026:;	  G->pos= yypos1026; G->thunkpos= yythunkpos1026;
   }
-  {  int yypos1027= G->pos, yythunkpos1027= G->thunkpos;  if (!yy_WS(G))  goto l1027;
-  if (!yymatchString(G, "else")) goto l1027;
+  {  int yypos1031= G->pos, yythunkpos1031= G->thunkpos;  if (!yy_WS(G))  goto l1031;
+  if (!yymatchString(G, "else")) goto l1031;
   yyDo(G, yy_9_ModuleCore, G->begin, G->end, "yy_9_ModuleCore");
 
-  {  int yypos1029= G->pos, yythunkpos1029= G->thunkpos;  if (!yy__(G))  goto l1030;
-  if (!yymatchChar(G, '{')) goto l1030;
+  {  int yypos1033= G->pos, yythunkpos1033= G->thunkpos;  if (!yy__(G))  goto l1034;
+  if (!yymatchChar(G, '{')) goto l1034;
   yyDo(G, yy_10_ModuleCore, G->begin, G->end, "yy_10_ModuleCore");
-  if (!yy_WS(G))  goto l1030;
+  if (!yy_WS(G))  goto l1034;
 
-  l1031:;	
-  {  int yypos1032= G->pos, yythunkpos1032= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1032;
-  goto l1031;
-  l1032:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;
-  }  if (!yy_WS(G))  goto l1030;
-  if (!yy__(G))  goto l1030;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1030; }
+  l1035:;	
+  {  int yypos1036= G->pos, yythunkpos1036= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1036;
+  goto l1035;
+  l1036:;	  G->pos= yypos1036; G->thunkpos= yythunkpos1036;
+  }  if (!yy_WS(G))  goto l1034;
+  if (!yy__(G))  goto l1034;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1034; }
   yyDo(G, yy_11_ModuleCore, G->begin, G->end, "yy_11_ModuleCore");
-  goto l1029;
-  l1030:;	  G->pos= yypos1029; G->thunkpos= yythunkpos1029;  if (!yy__(G))  goto l1027;
-  if (!yy_Stmt(G))  goto l1027;
+  goto l1033;
+  l1034:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy__(G))  goto l1031;
+  if (!yy_Stmt(G))  goto l1031;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_12_ModuleCore, G->begin, G->end, "yy_12_ModuleCore");
 
   }
-  l1029:;	  goto l1028;
-  l1027:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;
+  l1033:;	  goto l1032;
+  l1031:;	  G->pos= yypos1031; G->thunkpos= yythunkpos1031;
   }
-  l1028:;	  goto l1015;
-  l1016:;	  G->pos= yypos1015; G->thunkpos= yythunkpos1015;
-  {  int yypos1033= G->pos, yythunkpos1033= G->thunkpos;  if (!yy_WS(G))  goto l1034;
-  if (!yy_Include(G))  goto l1034;
-  if (!yy_WS(G))  goto l1034;
-  goto l1033;
-  l1034:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1035;
-  if (!yy_Import(G))  goto l1035;
-  if (!yy_WS(G))  goto l1035;
-  goto l1033;
-  l1035:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1036;
-  if (!yy_Use(G))  goto l1036;
-  if (!yy_WS(G))  goto l1036;
-  goto l1033;
-  l1036:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1037;
-  if (!yy_Decl(G))  goto l1037;
-  if (!yy_WS(G))  goto l1037;
-  goto l1033;
-  l1037:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1038;
-  if (!yy_Stmt(G))  goto l1038;
-  yyDo(G, yySet, -1, 0, "yySet");
+  l1032:;	  goto l1019;
+  l1020:;	  G->pos= yypos1019; G->thunkpos= yythunkpos1019;
+  {  int yypos1037= G->pos, yythunkpos1037= G->thunkpos;  if (!yy_WS(G))  goto l1038;
+  if (!yy_Include(G))  goto l1038;
   if (!yy_WS(G))  goto l1038;
+  goto l1037;
+  l1038:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;  if (!yy_WS(G))  goto l1039;
+  if (!yy_Import(G))  goto l1039;
+  if (!yy_WS(G))  goto l1039;
+  goto l1037;
+  l1039:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;  if (!yy_WS(G))  goto l1040;
+  if (!yy_Use(G))  goto l1040;
+  if (!yy_WS(G))  goto l1040;
+  goto l1037;
+  l1040:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;  if (!yy_WS(G))  goto l1041;
+  if (!yy_Decl(G))  goto l1041;
+  if (!yy_WS(G))  goto l1041;
+  goto l1037;
+  l1041:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;  if (!yy_WS(G))  goto l1042;
+  if (!yy_Stmt(G))  goto l1042;
+  yyDo(G, yySet, -1, 0, "yySet");
+  if (!yy_WS(G))  goto l1042;
   yyDo(G, yy_13_ModuleCore, G->begin, G->end, "yy_13_ModuleCore");
-  goto l1033;
-  l1038:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1014;
+  goto l1037;
+  l1042:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;  if (!yy_WS(G))  goto l1018;
   yyDo(G, yy_14_ModuleCore, G->begin, G->end, "yy_14_ModuleCore");
-  if (!yy_OocDocCore(G))  goto l1014;
+  if (!yy_OocDocCore(G))  goto l1018;
   yyDo(G, yy_15_ModuleCore, G->begin, G->end, "yy_15_ModuleCore");
 
   }
-  l1033:;	
+  l1037:;	
   }
-  l1015:;	  yyprintf((stderr, "  ok   ModuleCore"));
+  l1019:;	  yyprintf((stderr, "  ok   ModuleCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l1014:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
+  l1018:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13458,27 +13486,27 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 YY_RULE(int) yy_Module(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Module"));
 
-  {  int yypos1040= G->pos, yythunkpos1040= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1041;
-  goto l1040;
-  l1041:;	  G->pos= yypos1040; G->thunkpos= yythunkpos1040;  if (!yy_WS(G))  goto l1039;
+  {  int yypos1044= G->pos, yythunkpos1044= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1045;
+  goto l1044;
+  l1045:;	  G->pos= yypos1044; G->thunkpos= yythunkpos1044;  if (!yy_WS(G))  goto l1043;
 
-  l1042:;	
-  {  int yypos1043= G->pos, yythunkpos1043= G->thunkpos;
-  {  int yypos1044= G->pos, yythunkpos1044= G->thunkpos;  if (!yy_EOL(G))  goto l1044;
-  goto l1043;
-  l1044:;	  G->pos= yypos1044; G->thunkpos= yythunkpos1044;
-  }  if (!yymatchDot(G)) goto l1043;  goto l1042;
-  l1043:;	  G->pos= yypos1043; G->thunkpos= yythunkpos1043;
-  }  if (!yy_EOL(G))  goto l1039;
+  l1046:;	
+  {  int yypos1047= G->pos, yythunkpos1047= G->thunkpos;
+  {  int yypos1048= G->pos, yythunkpos1048= G->thunkpos;  if (!yy_EOL(G))  goto l1048;
+  goto l1047;
+  l1048:;	  G->pos= yypos1048; G->thunkpos= yythunkpos1048;
+  }  if (!yymatchDot(G)) goto l1047;  goto l1046;
+  l1047:;	  G->pos= yypos1047; G->thunkpos= yythunkpos1047;
+  }  if (!yy_EOL(G))  goto l1043;
   yyDo(G, yy_1_Module, G->begin, G->end, "yy_1_Module");
 
   }
-  l1040:;	  yyprintf((stderr, "  ok   Module"));
+  l1044:;	  yyprintf((stderr, "  ok   Module"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1039:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
+  l1043:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 

--- a/source/rock/middle/SafeNavigation.ooc
+++ b/source/rock/middle/SafeNavigation.ooc
@@ -1,0 +1,119 @@
+import ../frontend/Token
+import [Type, Expression, VariableAccess, Comparison, Ternary, VariableDecl, CommaSequence, BinaryOp,
+        NullLiteral, Visitor, Node]
+
+import tinker/[Resolver, Response, Trail, Errors]
+import structs/ArrayList
+
+SafeNavigation: class extends Expression {
+    expr: Expression
+    idents := ArrayList<String> new()
+
+    _resolved? := false
+
+    init: func (=expr, token: Token) {
+        super(token)
+    }
+
+    // We replace ourselves, no need to return any type
+    getType: func -> Type { null }
+
+    clone: func -> This {
+        other := This new(expr clone(), token)
+        other idents = idents clone()
+        other
+    }
+
+    resolve: func (trail: Trail, res: Resolver) -> Response {
+        if (_resolved?) return Response OK
+
+        // We need to avoid multiple evaluation of the expression, so we will use a variable declaration and assign it in a comma list before this
+        vDecl := VariableDecl new(expr getType(), generateTempName("safeNavExpr"), token)
+        vAccess := VariableAccess new(vDecl, token)
+
+        if (!trail addBeforeInScope(this, vDecl)) {
+            res throwError(CouldntAddBeforeInScope new(token, this, vDecl, trail))
+            return Response OK
+        }
+
+        seq := CommaSequence new(token)
+        assignment := BinaryOp new(vAccess, expr, OpType ass, token)
+
+        seq add(assignment)
+
+        // If we have 'expr $ a $ b $ c', our list is now [expr a, expr a b, expr a b c]
+        vas := ArrayList<VariableAccess> new(idents size)
+        for ((index, ident) in idents) {
+            if (index == 0) {
+                vas add(VariableAccess new(vAccess, ident, token))
+            } else {
+                vas add(VariableAccess new(vas last(), ident, token))
+            }
+        }
+
+        localNull := NullLiteral new(token)
+
+        makeNotEquals := func(e: Expression) -> Comparison {
+            Comparison new(e, localNull, CompType notEqual, token)
+        }
+
+        makeTernary := func(cond: Comparison, e: Expression) -> Ternary {
+            Ternary new(cond, e, localNull, token)
+        }
+
+        curr : Ternary = null
+        iterator := vas backIterator()
+
+        while (iterator hasPrev?()) {
+            access := iterator prev()
+
+            curr = match curr {
+                case null => makeTernary(makeNotEquals(access), access)
+                case      => makeTernary(makeNotEquals(access), curr)
+            }
+        }
+
+        curr = makeTernary(makeNotEquals(vAccess), curr)
+
+        seq add(curr)
+
+        if (!trail peek() replace(this, seq)) {
+            res throwError(CouldntReplace new(token, this, seq, trail))
+            return Response OK
+        }
+
+        _resolved? = true
+
+        res wholeAgain(this, "replaced safe navigation access with comma sequence")
+        Response OK
+    }
+
+    toString: func -> String {
+        buff := Buffer new()
+        buff append(expr toString())
+
+        for (i in idents) {
+            buff append(" $ ") . append(i)
+        }
+
+        buff toString()
+    }
+
+    accept: func(visitor: Visitor)
+
+    replace: func(oldie: Node, kiddo: Node) -> Bool {
+        match oldie {
+            case e: Expression =>
+                if (e == expr) {
+                    expr = kiddo as Expression
+                    return true
+                }
+        }
+
+        false
+    }
+
+    isResolved: func -> Bool {
+        _resolved?
+    }
+}

--- a/source/rock/middle/SafeNavigation.ooc
+++ b/source/rock/middle/SafeNavigation.ooc
@@ -27,6 +27,19 @@ SafeNavigation: class extends Expression {
     resolve: func (trail: Trail, res: Resolver) -> Response {
         if (_resolved?) return Response OK
 
+        trail push(this)
+        resp := expr resolve(trail, res)
+        if (!resp ok()) {
+            trail pop(this)
+            return resp
+        }
+        trail pop(this)
+
+        if (!expr getType()) {
+            res wholeAgain(this, "need type of safe navigation access expression")
+            return Response OK
+        }
+
         // We need to avoid multiple evaluation of the expression, so we will use a variable declaration and assign it in a comma list before this
         vDecl := VariableDecl new(expr getType(), generateTempName("safeNavExpr"), token)
         vAccess := VariableAccess new(vDecl, token)

--- a/test/compiler/operators/safe-navigation-simple.ooc
+++ b/test/compiler/operators/safe-navigation-simple.ooc
@@ -1,0 +1,31 @@
+Foo: cover {
+    bar: Bar
+}
+
+Bar: class {
+    baz: Baz
+
+    init: func (nil? := false) {
+        if (nil?) {
+            baz = null
+        } else {
+            baz = Baz new(this)
+        }
+    }
+}
+
+Baz: class {
+    foo: Foo
+
+    init: func (bar: Bar) {
+        foo bar = bar
+    }
+}
+
+describe("safe navigation operator should navigate into classes and covers", ||
+    bar1 := Bar new()
+    bar2 := Bar new(true)
+
+    expect(bar1 $ baz $ foo bar, bar1)
+    expect(bar2 $ baz $ foo bar, null)
+)

--- a/test/compiler/operators/safe-navigation-with-nullco.ooc
+++ b/test/compiler/operators/safe-navigation-with-nullco.ooc
@@ -1,0 +1,21 @@
+Foo: class {
+    bar: Bar
+
+    init: func (=bar)
+}
+
+Bar: class {
+    str: String
+
+    init: func (=str)
+}
+
+describe("safe navigation and nullco operators should work in conjuction", ||
+    foo1 := Foo new(null)
+    foo2 := Foo new(Bar new("hi"))
+    foo3 := Foo new(Bar new(null))
+
+    expect(foo1 $ bar $ str ?? "nothing", "nothing")
+    expect(foo2 $ bar $ str ?? "nothing", "hi")
+    expect(foo3 $ bar $ str ?? "nullstr", "nullstr")
+)


### PR DESCRIPTION
See fasterthanlime/nagaqueen#28  

Tests are needed and the syntax is still not 100% ideal but I think we can agree this is a nice feature to have, especially in conjunction with the nullco `??` operator.  

Also, we should probably do some typechecking in SafeNavigation (we shouldn't allow any access to be on a non-pointer type), which involves resolving the accesses there and only adding the variable decl and comma sequence after we make sure we can resolve everything.  
