### PR TITLE
Allow range expressions to be iterated through by for statements.

### DIFF
--- a/source/rock/backend/cnaughty/ControlStatementWriter.ooc
+++ b/source/rock/backend/cnaughty/ControlStatementWriter.ooc
@@ -47,7 +47,7 @@ ControlStatementWriter: abstract class extends Skeleton {
 
         range := foreach collection as RangeLiteral
         current app("for ("). app(foreach variable). app(" = "). app(range lower)
-        if(foreach indexVariable) current app(", "). app(foreach indexVariable). app(" = "). app(range lower)
+        if(foreach indexVariable) current app(", "). app(foreach indexVariable). app(" = 0")
         current app("; ").
             app(access).           app(" < "). app(range upper). app("; ").
             app(access).           app("++")

--- a/source/rock/middle/Foreach.ooc
+++ b/source/rock/middle/Foreach.ooc
@@ -129,7 +129,7 @@ Foreach: class extends ControlStatement {
                                 access = va
                             case =>
                                 // We want to avoid side effects, so we create a new declaration and get an access to it.
-                                vDecl := VariableDecl new(collection getType(), generateTempName("foreachRangeVar"), collection token)
+                                vDecl := VariableDecl new(collection getType(), generateTempName("foreachRangeVar"), collection, collection token)
                                 access = VariableAccess new(vDecl, token)
 
                                 if (!trail addBeforeInScope(this, vDecl)) {
@@ -156,8 +156,10 @@ Foreach: class extends ControlStatement {
                                 variable = VariableAccess new(vDecl name, vDecl token)
                         }
 
+                        trail toString() println()
+
                         // Let's go again!
-                        res wholeAgain(this, "replaced foreach collection to range literal")
+                        res wholeAgain(this, "replaced foreach range collection with equivalent range literal")
                         return Response OK
                     }
             }

--- a/source/rock/middle/Foreach.ooc
+++ b/source/rock/middle/Foreach.ooc
@@ -11,13 +11,10 @@ Foreach: class extends ControlStatement {
     collection: Expression
 
     replaced := false
-    _resolved? := false
 
     init: func ~_foreach (=variable, =collection, .token) {
         super(token)
     }
-
-    isResolved: func -> Bool { _resolved? }
 
     clone: func -> This {
         copy := new(variable clone(), collection clone(), token)
@@ -47,8 +44,6 @@ Foreach: class extends ControlStatement {
     }
 
     resolve: func (trail: Trail, res: Resolver) -> Response {
-        if (_resolved?) return Response OK
-
         if (!replaced) match variable {
             case vAcc: VariableAccess =>
                 _createDeclFromAccess(vAcc)
@@ -253,7 +248,6 @@ Foreach: class extends ControlStatement {
             return resp
         }
 
-        _resolved? = true
         return Response OK
 
     }

--- a/source/rock/middle/Foreach.ooc
+++ b/source/rock/middle/Foreach.ooc
@@ -145,15 +145,26 @@ Foreach: class extends ControlStatement {
                         collection = newCol
                         replaced = false
 
-                        // We need to remove the unwrapped index vDecl from our parent scope
+                        // We need to remove the unwrapped index vDecl from some parent scope
                         // because it's type is unknown and currently unresolvable.
-                        scope := trail get(trail findScope()) as Scope
+
+                        lastScope := trail findScope()
+                        scope := trail get(lastScope, Scope)
+
+                        // If we have an index variable, the variable decl will end up in another scope
+                        // TODO: Is this always true? Can the decl end up further upstream?
+                        // A more general solution would be to go up scopes until we remove the vDecl
+                        if (indexVariable != null) {
+                            lastScope = trail find(Scope, lastScope - 1)
+                            scope = trail get(lastScope, Scope)
+                        }
 
                         for (stmt in scope list) {
                             match stmt {
                                 case vDecl: VariableDecl =>
                                     if (vDecl name == variable toString() && vDecl type == null) {
                                         scope remove(vDecl)
+                                        break
                                     }
                             }
                         }

--- a/source/rock/middle/RangeLiteral.ooc
+++ b/source/rock/middle/RangeLiteral.ooc
@@ -77,4 +77,8 @@ RangeLiteral: class extends Literal {
         super() && !replaced
     }
 
+    toString: func -> String {
+        "#{lower} .. #{upper}"
+    }
+
 }

--- a/test/compiler/control/foreach-range-generated.ooc
+++ b/test/compiler/control/foreach-range-generated.ooc
@@ -9,7 +9,7 @@ f: func -> Range {
 describe("foreach should iterate through any range expression, not just literals", ||
 
     for ((j, i) in f()) {
-        expect(j, i + 10)
+        expect(j + 10, i)
     }
 
     expect(counter, 1)

--- a/test/compiler/control/foreach-range-generated.ooc
+++ b/test/compiler/control/foreach-range-generated.ooc
@@ -1,0 +1,16 @@
+counter := 0
+
+f: func -> Range {
+    counter += 1 // Side effects!
+
+    10 .. 15
+}
+
+describe("foreach should iterate through any range expression, not just literals", ||
+
+    for ((j, i) in f()) {
+        expect(j, i + 10)
+    }
+
+    expect(counter, 1)
+)


### PR DESCRIPTION
Closes #951  
Also, sneakily fix the indexing in range for loops (the backend generated wrong code)