### PR TITLE
Cache archive version bumped to 0.6, module functions are actually written, slurps are tracked

### DIFF
--- a/source/rock/frontend/drivers/Archive.ooc
+++ b/source/rock/frontend/drivers/Archive.ooc
@@ -393,6 +393,7 @@ ArchiveModule: class {
 
     types := HashMap<String, ArchiveType> new()
     functions := ArrayList<String> new()
+    slurps := HashMap<String, Long> new()
     hasMain? ::= functions contains?("main")
 
     /**
@@ -416,6 +417,11 @@ ArchiveModule: class {
         module getFunctions() each(|key, fDecl|
             functions add(fDecl getFullName())
         )
+
+        for (slurp in module slurps) {
+            slurpFile := File new(module pathElement, slurp)
+            slurps put(slurp, slurpFile lastModified())
+        }
     }
 
     /**
@@ -436,6 +442,14 @@ ArchiveModule: class {
         for(i in 0..functionsSize) {
             fName := fR readLine()
             functions add(fName)
+        }
+
+        slurpSize := fR readLine() toInt()
+        for (i in 0 .. slurpSize) {
+            path := fR readLine()
+            lastMod := fR readLine() toLong()
+
+            slurps put(path, lastMod)
         }
 
         _getModule()
@@ -511,6 +525,23 @@ ArchiveModule: class {
                 }
             }
 
+            if (module slurps size != slurps size) {
+                if (archive params debugLibcache) "Slurp counts not the same, %s not up-to-date" printfln(oocPath)
+                return false
+            }
+
+            for (slurp in module slurps) {
+                if (!slurps contains?(slurp)) {
+                    if(archive params debugLibcache) "Slurp %s wasn't there last time, %s not up-to-date" printfln(slurp, oocPath)
+                    return false
+                }
+
+                if (File new(module pathElement, slurp) lastModified() != slurps get(slurp)) {
+                    if(archive params debugLibcache) "Slurp %s was was modified since last time, %s not up-to-date" printfln(slurp, oocPath)
+                    return false
+                }
+            }
+
             return true
         }
     }
@@ -547,6 +578,13 @@ ArchiveModule: class {
         for (f in functions) {
             fW writef("%s\n", f)
         }
+
+        // write each slurp
+        fW writef("%d\n", slurps size)
+        slurps each(|slurpPath, lastMod|
+            fW writef("%s\n", slurpPath)
+            fW writef("%ld\n", lastMod)
+        )
     }
 }
 

--- a/source/rock/frontend/drivers/Archive.ooc
+++ b/source/rock/frontend/drivers/Archive.ooc
@@ -17,7 +17,7 @@ import rock/backend/cnaughty/ModuleWriter
  */
 Archive: class {
 
-    supportedVersion := static "0.5"
+    supportedVersion := static "0.6"
 
     map := static HashMap<Module, Archive> new()
     dirtyModules := ArrayList<Module> new()
@@ -545,7 +545,7 @@ ArchiveModule: class {
         // write each function
         fW writef("%d\n", functions size)
         for (f in functions) {
-            fW writef("%s\n")
+            fW writef("%s\n", f)
         }
     }
 }

--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -282,6 +282,11 @@ FunctionCall: class extends Expression {
                     if (!trail peek() replace(this, kid)) {
                         res throwError(CouldntReplace new(token, this, kid, trail))
                     }
+
+                    if (!mod slurps contains?(path)) {
+                        mod slurps add(path)
+                    }
+
                     res wholeAgain(this, "just unwrapped")
                     return Response OK
 

--- a/source/rock/middle/Module.ooc
+++ b/source/rock/middle/Module.ooc
@@ -39,6 +39,9 @@ Module: class extends Node {
     namespaces := HashMap<String, NamespaceDecl> new()
     uses       := ArrayList<Use> new()
 
+    // Files the module slurps
+    slurps     := ArrayList<String> new()
+
     funcTypesMap := HashMap<String, FuncType> new()
 
     body       := Scope new()


### PR DESCRIPTION
Closes #955  
Closes #956  

The version bump should not cause any issue, just a complete recompile the first time the compiler with the changes is used.