### PR TITLE
FuncTypes now correctly return TypeAccess typeArgs

### DIFF
--- a/source/rock/middle/FuncType.ooc
+++ b/source/rock/middle/FuncType.ooc
@@ -88,7 +88,13 @@ FuncType: class extends Type {
         copy
     }
 
-    getTypeArgs: func -> List<VariableDecl> { typeArgs }
+    getTypeArgs: func -> List<TypeAccess> {
+        if(typeArgs) {
+            typeArgs map(|targ| TypeAccess new(targ, targ token))
+        } else {
+            null
+        }
+    }
 
     addTypeArg: func (typeArg: VariableDecl) -> Bool {
         if(!typeArgs) typeArgs = ArrayList<VariableDecl> new()

--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -612,21 +612,14 @@ VariableAccess: class extends Expression {
 
         hasGenericTypeArgs := false
         for (typeArg in typeArgs) {
-            // TODO: Sometimes Type typeArgs get a VariableDecl instead of a TypeAccess (see #895)
-            match typeArg {
-                case vDecl: VariableDecl =>
-                    hasGenericTypeArgs = true
-                    break
-                case =>
-                    if (typeArg getRef() == null) {
-                        res wholeAgain(this, "need ref of all typeArgs of our type")
-                        return
-                    }
+            if (typeArg getRef() == null) {
+                res wholeAgain(this, "need ref of all typeArgs of our type")
+                return
+            }
 
-                    if (typeArg isGeneric()) {
-                        hasGenericTypeArgs = true
-                        break
-                    }
+            if (typeArg isGeneric()) {
+                hasGenericTypeArgs = true
+                break
             }
         }
 
@@ -713,13 +706,7 @@ VariableAccess: class extends Expression {
         replacedSome := false
 
         for ((i, typeArg) in typeArgs) {
-            // TODO: see #895
-            name := match typeArg {
-                case vDecl: VariableDecl =>
-                    vDecl name
-                case =>
-                    typeArg getName()
-            }
+            name := typeArg getName()
 
             finalScore := 0
             realType := exprType searchTypeArg(name, finalScore&)


### PR DESCRIPTION
Closes #895
Also, removes workarounds introduced in #965